### PR TITLE
feat: add manforge CLI for Fortran build (build/clean/list)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,14 @@ make test-all                # Full suite including slow fitting tests
 uv run pytest tests/test_j2_elastic.py -v  # Single test file
 
 # Fortran compilation (requires gfortran)
+# Option A: CLI (recommended for Python users)
+uv run manforge build fortran/test_basic.f90 --name manforge_test_basic
+uv run manforge build fortran/abaqus_stubs.f90 fortran/j2_isotropic_3d.f90 --name j2_isotropic_3d
+uv run manforge list              # List compiled modules
+uv run manforge clean             # Remove compiled artifacts
+uv run manforge clean --dry-run   # Preview what would be removed
+
+# Option B: Makefile (lower-level)
 make fortran-build           # Compile test_basic.f90 via f2py
 make fortran-build-umat      # Compile abaqus_stubs.f90 + j2_isotropic_3d.f90 via f2py → j2_isotropic_3d module
 make fortran-test            # Run Fortran basic tests

--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ uv sync --extra dev
 # matplotlib 含む
 uv sync --extra examples
 
-# Fortran モジュールのビルド
-make fortran-build-umat
+# Fortran モジュールのビルド (gfortran 必須)
+uv sync --extra fortran           # meson/ninja のインストール
+uv run manforge build fortran/abaqus_stubs.f90 fortran/j2_isotropic_3d.f90 --name j2_isotropic_3d
 
 # Docker 内でフルビルド + テスト
 make docker-build && make docker-test
@@ -308,6 +309,11 @@ np.testing.assert_allclose(np.array(C_py), np.array(C_f), rtol=1e-12)
 ビルド:
 
 ```bash
+# CLI (推奨)
+uv sync --extra fortran
+uv run manforge build fortran/abaqus_stubs.f90 fortran/j2_isotropic_3d.f90 --name j2_isotropic_3d
+
+# Makefile
 make fortran-build-umat   # ホスト環境 (gfortran 必須)
 make docker-test          # Docker 環境でビルド + テスト
 ```

--- a/fortran/README.md
+++ b/fortran/README.md
@@ -18,6 +18,7 @@ Python `manforge` implementation.
 
 - **gfortran** ≥ 9
 - **Python** ≥ 3.10 with numpy (f2py is bundled with numpy)
+- **meson** + **ninja** — required by f2py on Python 3.12+ (`uv sync --extra fortran`)
 - **Docker** (recommended for a reproducible environment — see below)
 
 Check availability:
@@ -29,22 +30,42 @@ python -m numpy.f2py --version
 
 ---
 
-## Build with f2py
+## Build
 
-### Compile the J2 UMAT into a Python extension module
+### Option A: `manforge build` CLI (recommended)
+
+```bash
+# Install build tools (meson/ninja) if not yet done
+uv sync --extra fortran
+
+# Compile the J2 UMAT
+uv run manforge build fortran/abaqus_stubs.f90 fortran/j2_isotropic_3d.f90 --name j2_isotropic_3d
+
+# Smoke-test module only
+uv run manforge build fortran/test_basic.f90 --name manforge_test_basic
+
+# List compiled modules
+uv run manforge list
+
+# Remove compiled artifacts
+uv run manforge clean
+```
+
+### Option B: Makefile
+
+```bash
+make fortran-build-umat   # J2 UMAT
+make fortran-build        # smoke-test module
+```
+
+### Option C: f2py directly
 
 ```bash
 cd fortran/
 python -m numpy.f2py -c abaqus_stubs.f90 j2_isotropic_3d.f90 -m j2_isotropic_3d
 ```
 
-Or via the Makefile from the project root:
-
-```bash
-make fortran-build-umat
-```
-
-This produces `j2_isotropic_3d.cpython-*.so` (Linux) or `.pyd` (Windows).
+All three options produce `j2_isotropic_3d.cpython-*.so` (Linux) or `.pyd` (Windows) in the `fortran/` directory.
 
 ### Subroutine naming convention
 
@@ -165,7 +186,7 @@ subroutine j2_isotropic_3d_elastic_stiffness(E, nu, C)
 end subroutine
 ```
 
-After compiling (`make fortran-build-umat`), the call pattern is identical:
+After compiling (`manforge build` or `make fortran-build-umat`), the call pattern is identical:
 
 ```python
 # Fortran sub-component

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,9 @@ dev = ["pytest"]
 examples = ["matplotlib"]
 fortran = ["meson>=1.10.2", "ninja>=1.13.0"]
 
+[project.scripts]
+manforge = "manforge.cli:main"
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/manforge"]
 

--- a/src/manforge/cli.py
+++ b/src/manforge/cli.py
@@ -1,0 +1,321 @@
+"""manforge CLI — Fortran build toolkit for Python users.
+
+Usage:
+  manforge build <files...> --name <module_name> [--output-dir <dir>] [--verbose]
+  manforge clean [--dir <dir>] [--dry-run]
+  manforge list  [--dir <dir>]
+"""
+
+import argparse
+import glob
+import platform
+import shutil
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Utility helpers
+# ---------------------------------------------------------------------------
+
+
+def _find_project_root() -> Path:
+    """Walk up from cwd looking for pyproject.toml. Fallback to cwd."""
+    current = Path.cwd()
+    for parent in [current, *current.parents]:
+        if (parent / "pyproject.toml").exists():
+            return parent
+    return current
+
+
+def _default_output_dir() -> Path:
+    return _find_project_root() / "fortran"
+
+
+def _check_gfortran() -> None:
+    if shutil.which("gfortran") is not None:
+        return
+
+    system = platform.system()
+    if system == "Darwin":
+        hint = "  macOS:   brew install gcc"
+    elif system == "Linux":
+        hint = "  Ubuntu:  sudo apt-get install gfortran\n  Fedora:  sudo dnf install gcc-gfortran"
+    else:
+        hint = "  See https://gcc.gnu.org/wiki/GFortranBinaries"
+
+    print("Error: gfortran not found.")
+    print("Install it with:")
+    print(hint)
+    print()
+    print("Alternatively, use Docker (requires Docker installed):")
+    print("  make docker-build && make docker-test")
+    sys.exit(1)
+
+
+def _check_f2py() -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "numpy.f2py", "--version"],
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        print("Error: numpy.f2py is not available.")
+        print("Install numpy:")
+        print("  uv sync --extra fortran")
+        print("  # or: pip install numpy meson ninja")
+        sys.exit(1)
+
+
+def _check_meson() -> None:
+    if shutil.which("meson") is not None:
+        return
+    print("Error: meson not found.")
+    print("f2py requires meson as its build backend on Python 3.12+.")
+    print("Install with:")
+    print("  uv sync --extra fortran")
+    print("  # or: pip install meson ninja")
+    sys.exit(1)
+
+
+def _human_size(nbytes: int) -> str:
+    for unit in ("B", "KB", "MB"):
+        if nbytes < 1024:
+            return f"{nbytes:.0f} {unit}"
+        nbytes //= 1024
+    return f"{nbytes:.0f} GB"
+
+
+def _extract_module_name(so_path: Path) -> str:
+    """Extract the Python module name from a .so/.pyd filename.
+
+    e.g. 'j2_isotropic_3d.cpython-312-x86_64-linux-gnu.so' → 'j2_isotropic_3d'
+    """
+    return so_path.name.split(".")[0]
+
+
+# ---------------------------------------------------------------------------
+# Subcommand implementations
+# ---------------------------------------------------------------------------
+
+
+def cmd_build(args: argparse.Namespace) -> None:
+    _check_gfortran()
+    _check_f2py()
+    _check_meson()
+
+    # Validate source files
+    sources: list[Path] = []
+    for f in args.files:
+        p = Path(f).resolve()
+        if not p.exists():
+            print(f"Error: file not found: {f}")
+            sys.exit(1)
+        if p.suffix not in (".f90", ".f", ".F90", ".F"):
+            print(f"Error: not a Fortran source file: {f}")
+            print("Expected extensions: .f90, .f, .F90, .F")
+            sys.exit(1)
+        sources.append(p)
+
+    output_dir = Path(args.output_dir).resolve() if args.output_dir else _default_output_dir()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    module_name: str = args.name
+    source_names = ", ".join(s.name for s in sources)
+    print(f"Building module '{module_name}' from: {source_names}")
+    print(f"Output directory: {output_dir}")
+    print()
+
+    cmd = [sys.executable, "-m", "numpy.f2py", "-c"] + [str(s) for s in sources] + ["-m", module_name]
+
+    if args.verbose:
+        result = subprocess.run(cmd, cwd=output_dir)
+    else:
+        result = subprocess.run(cmd, cwd=output_dir, capture_output=True, text=True)
+
+    if result.returncode != 0:
+        print("Build failed.")
+        if not args.verbose:
+            print()
+            print("--- f2py output ---")
+            if result.stdout:
+                print(result.stdout)
+            if result.stderr:
+                print(result.stderr)
+            print("-------------------")
+            print()
+            print("Tip: run with --verbose for full compiler output.")
+        sys.exit(1)
+
+    # Locate the produced .so / .pyd
+    patterns = [f"{module_name}.cpython-*.so", f"{module_name}.*.pyd", f"{module_name}.so"]
+    built_files = []
+    for pat in patterns:
+        built_files.extend(output_dir.glob(pat))
+
+    print(f"Build succeeded.")
+    if built_files:
+        so = built_files[0]
+        print(f"Module file: {so}")
+
+    print()
+    print("To use in Python:")
+    print(f"  import sys")
+    print(f"  sys.path.insert(0, '{output_dir}')")
+    print(f"  import {module_name}")
+    print()
+    print("Or with FortranUMAT:")
+    print(f"  from manforge.verification import FortranUMAT")
+    print(f"  import sys; sys.path.insert(0, '{output_dir}')")
+    print(f"  umat = FortranUMAT('{module_name}')")
+
+
+def cmd_clean(args: argparse.Namespace) -> None:
+    target_dir = Path(args.dir).resolve() if args.dir else _default_output_dir()
+
+    if not target_dir.exists():
+        print(f"Nothing to clean (directory not found: {target_dir})")
+        return
+
+    patterns = ["*.so", "*.pyd", "*.mod", "*.o", "*module.c", "*-f2pywrappers*.f90"]
+    matches: list[Path] = []
+    for pat in patterns:
+        matches.extend(target_dir.glob(pat))
+
+    if not matches:
+        print("Nothing to clean.")
+        return
+
+    dry_run: bool = args.dry_run
+    if dry_run:
+        print(f"Dry run — would remove {len(matches)} file(s):")
+    else:
+        print(f"Removing {len(matches)} file(s):")
+
+    for f in sorted(matches):
+        print(f"  {f}")
+        if not dry_run:
+            f.unlink()
+
+    if not dry_run:
+        print("Done.")
+
+
+def cmd_list(args: argparse.Namespace) -> None:
+    target_dir = Path(args.dir).resolve() if args.dir else _default_output_dir()
+
+    if not target_dir.exists():
+        print(f"No compiled modules found (directory not found: {target_dir})")
+        return
+
+    so_files: list[Path] = []
+    so_files.extend(target_dir.glob("*.so"))
+    so_files.extend(target_dir.glob("*.pyd"))
+    so_files = sorted(so_files)
+
+    if not so_files:
+        print("No compiled modules found.")
+        print(f"Run 'manforge build' to compile a Fortran module.")
+        return
+
+    name_width = max(len(_extract_module_name(f)) for f in so_files)
+    name_width = max(name_width, 6)
+
+    header = f"{'Module':<{name_width}}  {'Size':>8}  {'Modified':<20}  File"
+    print(header)
+    print("-" * len(header))
+    for f in so_files:
+        stat = f.stat()
+        mtime = datetime.fromtimestamp(stat.st_mtime).strftime("%Y-%m-%d %H:%M")
+        size = _human_size(stat.st_size)
+        module = _extract_module_name(f)
+        print(f"{module:<{name_width}}  {size:>8}  {mtime:<20}  {f.name}")
+
+
+# ---------------------------------------------------------------------------
+# Argument parser
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="manforge",
+        description="manforge — Fortran UMAT build toolkit for Python users",
+    )
+    subparsers = parser.add_subparsers(dest="command", metavar="<command>")
+    subparsers.required = True
+
+    # --- build ---
+    build_parser = subparsers.add_parser(
+        "build",
+        help="Compile Fortran source files into a Python extension module",
+        description=(
+            "Compile one or more Fortran source files into a Python extension module "
+            "using f2py. The compiled .so file is placed in the fortran/ directory by default."
+        ),
+    )
+    build_parser.add_argument(
+        "files",
+        nargs="+",
+        metavar="<file.f90>",
+        help="Fortran source file(s) to compile (.f90 or .f)",
+    )
+    build_parser.add_argument(
+        "--name", "-n",
+        required=True,
+        metavar="<module_name>",
+        help="Python module name for the compiled extension",
+    )
+    build_parser.add_argument(
+        "--output-dir", "-o",
+        default=None,
+        metavar="<dir>",
+        help="Output directory for the compiled .so file (default: fortran/)",
+    )
+    build_parser.add_argument(
+        "--verbose", "-v",
+        action="store_true",
+        help="Show full f2py / compiler output",
+    )
+    build_parser.set_defaults(func=cmd_build)
+
+    # --- clean ---
+    clean_parser = subparsers.add_parser(
+        "clean",
+        help="Remove compiled Fortran artifacts",
+        description="Remove f2py build artifacts (*.so, *.mod, *.o, etc.) from the fortran/ directory.",
+    )
+    clean_parser.add_argument(
+        "--dir", "-d",
+        default=None,
+        metavar="<dir>",
+        help="Directory to clean (default: fortran/)",
+    )
+    clean_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be removed without actually deleting",
+    )
+    clean_parser.set_defaults(func=cmd_clean)
+
+    # --- list ---
+    list_parser = subparsers.add_parser(
+        "list",
+        help="List compiled Fortran extension modules",
+        description="Show compiled Python extension modules (.so files) in the fortran/ directory.",
+    )
+    list_parser.add_argument(
+        "--dir", "-d",
+        default=None,
+        metavar="<dir>",
+        help="Directory to scan (default: fortran/)",
+    )
+    list_parser.set_defaults(func=cmd_list)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- `manforge build <files...> --name <module>` — f2py をラップして Fortran ソースを Python 拡張モジュールにコンパイル
- `manforge list` — コンパイル済みモジュールの一覧表示
- `manforge clean [--dry-run]` — ビルド成果物の削除

Makefile の知識なしに、Python ユーザーが直接 Fortran UMAT をビルドできる仕組みを提供する。

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `src/manforge/cli.py` | 新規 — `argparse` ベースの CLI 本体 |
| `pyproject.toml` | `[project.scripts]` エントリポイント追加 |
| `CLAUDE.md` | CLI コマンドのドキュメント追記 |

## 使い方

```bash
uv sync --extra fortran  # meson/ninja が必要

uv run manforge build fortran/test_basic.f90 --name manforge_test_basic
uv run manforge build fortran/abaqus_stubs.f90 fortran/j2_isotropic_3d.f90 --name j2_isotropic_3d
uv run manforge list
uv run manforge clean
```

## Test plan

- [x] `manforge build` でシングル/マルチファイルのビルドが成功することを確認
- [x] `manforge list` でコンパイル済みモジュール一覧が表示されること
- [x] `manforge clean --dry-run` で削除予定ファイルのプレビューが出ること
- [x] `manforge clean` で成果物が削除されること
- [x] 存在しないファイルを指定した場合に明確なエラーメッセージが出ること
- [x] `make fortran-build` が引き続き動作すること（既存フローへの影響なし）
- [x] 全テスト (229 passed) が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)