### PR TITLE
refactor: consolidate test fixtures, add markers, standardize assertions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ fortran-test-umat:
 
 ## Run full test suite (excluding slow fitting tests)
 test:
-	uv run pytest tests/ --ignore=tests/test_fitting.py -v
+	uv run pytest tests/ -m "not slow" -v
 
 ## Run complete test suite (slow — includes fitting tests)
 test-all:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,3 +24,7 @@ packages = ["src/manforge"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+markers = [
+    "slow: marks tests as slow (fitting/optimization) -- deselect with -m 'not slow'",
+    "fortran: marks tests requiring compiled Fortran modules -- deselect with -m 'not fortran'",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,15 @@
+import sys
+import os
 import pytest
+
+import manforge  # noqa: F401 — enables JAX float64 for the entire test session
+
+from manforge.models.j2_isotropic import J2Isotropic3D
+
+# Add fortran/ to sys.path so compiled modules are importable session-wide.
+# Harmless if the directory contains no compiled modules.
+_FORTRAN_DIR = os.path.join(os.path.dirname(__file__), "..", "fortran")
+sys.path.insert(0, os.path.abspath(_FORTRAN_DIR))
 
 
 @pytest.fixture
@@ -10,3 +21,24 @@ def steel_params():
         "sigma_y0": 250.0,
         "H": 1000.0,
     }
+
+
+@pytest.fixture
+def model():
+    """Default J2Isotropic3D model instance (SOLID_3D)."""
+    return J2Isotropic3D()
+
+
+@pytest.fixture
+def initial_state(model):
+    """Initial (virgin) state for the default model."""
+    return model.initial_state()
+
+
+@pytest.fixture
+def lame_constants(steel_params):
+    """Lame constants (lambda, mu) derived from steel_params."""
+    E, nu = steel_params["E"], steel_params["nu"]
+    mu = E / (2.0 * (1.0 + nu))
+    lam = E * nu / ((1.0 + nu) * (1.0 - 2.0 * nu))
+    return lam, mu

--- a/tests/test_analytical_j2.py
+++ b/tests/test_analytical_j2.py
@@ -8,19 +8,13 @@ Covers:
 - method="analytical" raises NotImplementedError on a model without hooks
 """
 
+import numpy as np
 import jax.numpy as jnp
 import pytest
 
-import manforge  # noqa: F401
 from manforge.core.return_mapping import return_mapping
 from manforge.core.material import MaterialModel3D
-from manforge.models.j2_isotropic import J2Isotropic3D
 from manforge.verification.fd_check import check_tangent
-
-
-@pytest.fixture
-def model():
-    return J2Isotropic3D()
 
 
 # ---------------------------------------------------------------------------
@@ -42,17 +36,12 @@ def test_plastic_corrector_elastic_path_not_called(model, steel_params):
         model, strain_inc, stress_n, state_n, steel_params, method="analytical"
     )
     C = model.elastic_stiffness(steel_params)
-    assert jnp.allclose(stress_new, C @ strain_inc, rtol=1e-10)
-    assert jnp.allclose(ddsdde, C, rtol=1e-10)
+    np.testing.assert_allclose(np.asarray(stress_new), np.asarray(C @ strain_inc), rtol=1e-10)
+    np.testing.assert_allclose(np.asarray(ddsdde), np.asarray(C), rtol=1e-10)
 
 
 def test_plastic_corrector_standalone_plastic(model, steel_params):
     """plastic_corrector returns correct (stress, state, dlambda) for a plastic step."""
-    E, nu = steel_params["E"], steel_params["nu"]
-    mu = E / (2.0 * (1.0 + nu))
-    H = steel_params["H"]
-    sigma_y0 = steel_params["sigma_y0"]
-
     C = model.elastic_stiffness(steel_params)
     deps11 = 2e-3
     strain_inc = jnp.array([deps11, 0.0, 0.0, 0.0, 0.0, 0.0])
@@ -103,8 +92,10 @@ def test_analytical_stress_matches_autodiff(model, steel_params, strain_inc_vec)
     s_ad, st_ad, _ = return_mapping(model, strain_inc, stress_n, state_n, steel_params, method="autodiff")
     s_an, st_an, _ = return_mapping(model, strain_inc, stress_n, state_n, steel_params, method="analytical")
 
-    assert jnp.allclose(s_an, s_ad, atol=1e-6), \
-        f"max stress diff = {float(jnp.max(jnp.abs(s_an - s_ad))):.3e}"
+    np.testing.assert_allclose(
+        np.asarray(s_an), np.asarray(s_ad), atol=1e-6,
+        err_msg=f"max stress diff = {float(jnp.max(jnp.abs(s_an - s_ad))):.3e}",
+    )
     assert abs(float(st_an["ep"]) - float(st_ad["ep"])) < 1e-10
 
 
@@ -119,7 +110,7 @@ def test_analytical_stress_matches_autodiff_nonzero_initial_stress(model, steel_
     s_ad, _, _ = return_mapping(model, strain_inc2, s1, st1, steel_params, method="autodiff")
     s_an, _, _ = return_mapping(model, strain_inc2, s1, st1, steel_params, method="analytical")
 
-    assert jnp.allclose(s_an, s_ad, atol=1e-6)
+    np.testing.assert_allclose(np.asarray(s_an), np.asarray(s_ad), atol=1e-6)
 
 
 # ---------------------------------------------------------------------------
@@ -158,8 +149,10 @@ def test_method_auto_uses_analytical(model, steel_params):
     s_auto, _, D_auto = return_mapping(model, strain_inc, stress_n, state_n, steel_params, method="auto")
     s_an,   _, D_an   = return_mapping(model, strain_inc, stress_n, state_n, steel_params, method="analytical")
 
-    assert jnp.allclose(s_auto, s_an, atol=1e-12), "auto should match analytical path"
-    assert jnp.allclose(D_auto, D_an, atol=1e-12), "auto should match analytical tangent"
+    np.testing.assert_allclose(np.asarray(s_auto), np.asarray(s_an), atol=1e-12,
+                               err_msg="auto should match analytical path")
+    np.testing.assert_allclose(np.asarray(D_auto), np.asarray(D_an), atol=1e-12,
+                               err_msg="auto should match analytical tangent")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_compare_solvers.py
+++ b/tests/test_compare_solvers.py
@@ -11,15 +11,8 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-import manforge  # noqa: F401
 from manforge.core.return_mapping import return_mapping
-from manforge.models.j2_isotropic import J2Isotropic3D
 from manforge.verification.compare import compare_solvers, SolverComparisonResult
-
-
-@pytest.fixture
-def model():
-    return J2Isotropic3D()
 
 
 def _make_solver(model, method):

--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -12,11 +12,11 @@ Strategy
 import numpy as np
 import pytest
 
-import manforge  # noqa: F401 — enables float64
-from manforge.models.j2_isotropic import J2Isotropic3D
 from manforge.simulation.driver import StrainDriver
 from manforge.simulation.types import FieldHistory, FieldType
 from manforge.fitting.optimizer import fit_params, FitResult
+
+pytestmark = pytest.mark.slow
 
 
 # ---------------------------------------------------------------------------
@@ -24,26 +24,16 @@ from manforge.fitting.optimizer import fit_params, FitResult
 # ---------------------------------------------------------------------------
 
 @pytest.fixture
-def model():
-    return J2Isotropic3D()
-
-
-@pytest.fixture
 def driver():
     return StrainDriver()
 
 
 @pytest.fixture
-def true_params():
-    return {"E": 210000.0, "nu": 0.3, "sigma_y0": 250.0, "H": 1000.0}
-
-
-@pytest.fixture
-def synthetic_data(model, driver, true_params):
+def synthetic_data(model, driver, steel_params):
     """Uniaxial strain history and synthetic stress response (σ11 only)."""
     strain = np.linspace(0.0, 5e-3, 40)
     load = FieldHistory(FieldType.STRAIN, "Strain", strain)
-    result = driver.run(model, load, true_params)
+    result = driver.run(model, load, steel_params)
     return {"strain": strain, "stress": result.stress[:, 0]}
 
 
@@ -51,13 +41,13 @@ def synthetic_data(model, driver, true_params):
 # Structure test
 # ---------------------------------------------------------------------------
 
-def test_fit_result_structure(model, driver, synthetic_data, true_params):
+def test_fit_result_structure(model, driver, synthetic_data, steel_params):
     """FitResult has all required fields with correct types."""
     fit_config = {
         "sigma_y0": (220.0, (50.0, 600.0)),
         "H":        (800.0, (0.0, 5000.0)),
     }
-    fixed = {"E": true_params["E"], "nu": true_params["nu"]}
+    fixed = {"E": steel_params["E"], "nu": steel_params["nu"]}
 
     result = fit_params(model, driver, synthetic_data, fit_config,
                         fixed_params=fixed, method="L-BFGS-B")
@@ -78,52 +68,52 @@ def test_fit_result_structure(model, driver, synthetic_data, true_params):
 # Convergence test — L-BFGS-B
 # ---------------------------------------------------------------------------
 
-def test_fit_uniaxial_synthetic(model, driver, synthetic_data, true_params):
+def test_fit_uniaxial_synthetic(model, driver, synthetic_data, steel_params):
     """L-BFGS-B recovers sigma_y0 and H within 10% of true values."""
     fit_config = {
         "sigma_y0": (220.0, (50.0, 600.0)),
         "H":        (800.0, (0.0, 5000.0)),
     }
-    fixed = {"E": true_params["E"], "nu": true_params["nu"]}
+    fixed = {"E": steel_params["E"], "nu": steel_params["nu"]}
 
     result = fit_params(model, driver, synthetic_data, fit_config,
                         fixed_params=fixed, method="L-BFGS-B")
 
     assert result.residual < 1.0, f"Residual too large: {result.residual:.3e}"
-    assert abs(result.params["sigma_y0"] - true_params["sigma_y0"]) / true_params["sigma_y0"] < 0.1
-    assert abs(result.params["H"] - true_params["H"]) / true_params["H"] < 0.1
+    assert abs(result.params["sigma_y0"] - steel_params["sigma_y0"]) / steel_params["sigma_y0"] < 0.1
+    assert abs(result.params["H"] - steel_params["H"]) / steel_params["H"] < 0.1
 
 
 # ---------------------------------------------------------------------------
 # Convergence test — Nelder-Mead
 # ---------------------------------------------------------------------------
 
-def test_fit_nelder_mead(model, driver, synthetic_data, true_params):
+def test_fit_nelder_mead(model, driver, synthetic_data, steel_params):
     """Nelder-Mead also converges to true parameters."""
     fit_config = {
         "sigma_y0": (220.0, (None, None)),
         "H":        (800.0, (None, None)),
     }
-    fixed = {"E": true_params["E"], "nu": true_params["nu"]}
+    fixed = {"E": steel_params["E"], "nu": steel_params["nu"]}
 
     result = fit_params(model, driver, synthetic_data, fit_config,
                         fixed_params=fixed, method="Nelder-Mead")
 
     assert result.residual < 1.0
-    assert abs(result.params["sigma_y0"] - true_params["sigma_y0"]) / true_params["sigma_y0"] < 0.1
+    assert abs(result.params["sigma_y0"] - steel_params["sigma_y0"]) / steel_params["sigma_y0"] < 0.1
 
 
 # ---------------------------------------------------------------------------
 # History populated for gradient-based methods
 # ---------------------------------------------------------------------------
 
-def test_fit_history_populated(model, driver, synthetic_data, true_params):
+def test_fit_history_populated(model, driver, synthetic_data, steel_params):
     """History list is non-empty after L-BFGS-B run."""
     fit_config = {
         "sigma_y0": (220.0, (50.0, 600.0)),
         "H":        (800.0, (0.0, 5000.0)),
     }
-    fixed = {"E": true_params["E"], "nu": true_params["nu"]}
+    fixed = {"E": steel_params["E"], "nu": steel_params["nu"]}
 
     result = fit_params(model, driver, synthetic_data, fit_config,
                         fixed_params=fixed, method="L-BFGS-B")
@@ -137,15 +127,15 @@ def test_fit_history_populated(model, driver, synthetic_data, true_params):
 # GeneralDriver smoke test
 # ---------------------------------------------------------------------------
 
-def test_general_driver_runs(model, true_params):
+def test_general_driver_runs(model, steel_params):
     """StrainDriver (general) produces (N, 6) stress output without errors."""
     N = 20
     strain6 = np.zeros((N, 6))
     strain6[:, 0] = np.linspace(0.0, 5e-3, N)  # uniaxial ε11
     load = FieldHistory(FieldType.STRAIN, "Strain", strain6)
 
-    result = StrainDriver().run(model, load, true_params)
+    result = StrainDriver().run(model, load, steel_params)
 
     assert result.stress.shape == (N, 6)
     # σ11 should be non-trivial (plastic hardening)
-    assert result.stress[-1, 0] > true_params["sigma_y0"]
+    assert result.stress[-1, 0] > steel_params["sigma_y0"]

--- a/tests/test_fortran_basic.py
+++ b/tests/test_fortran_basic.py
@@ -12,15 +12,8 @@ The compiled module ``manforge_test_basic`` must be built before running:
 If the module is not available, all tests in this file are skipped.
 """
 
-import sys
-import os
-
 import numpy as np
 import pytest
-
-# Add fortran/ to path so the compiled .so is importable
-_FORTRAN_DIR = os.path.join(os.path.dirname(__file__), "..", "fortran")
-sys.path.insert(0, os.path.abspath(_FORTRAN_DIR))
 
 mod = pytest.importorskip(
     "manforge_test_basic",
@@ -28,18 +21,7 @@ mod = pytest.importorskip(
            "cd fortran && python -m numpy.f2py -c test_basic.f90 -m manforge_test_basic",
 )
 
-import manforge  # noqa: F401 — enables JAX float64
-from manforge.models.j2_isotropic import J2Isotropic3D
-
-
-@pytest.fixture
-def params():
-    return {"E": 210_000.0, "nu": 0.3, "sigma_y0": 250.0, "H": 1_000.0}
-
-
-@pytest.fixture
-def model():
-    return J2Isotropic3D()
+pytestmark = pytest.mark.fortran
 
 
 def _py_stress(model, params, dstran):
@@ -53,12 +35,12 @@ def _py_stress(model, params, dstran):
 # elastic_stress — uniaxial strain increment
 # ---------------------------------------------------------------------------
 
-def test_elastic_stress_uniaxial(model, params):
+def test_elastic_stress_uniaxial(model, steel_params):
     """Fortran elastic_stress matches Python C @ dstran (uniaxial)."""
     dstran = np.array([2e-3, 0.0, 0.0, 0.0, 0.0, 0.0])
 
-    stress_f90 = mod.elastic_stress(params["E"], params["nu"], dstran)
-    stress_py  = _py_stress(model, params, dstran)
+    stress_f90 = mod.elastic_stress(steel_params["E"], steel_params["nu"], dstran)
+    stress_py  = _py_stress(model, steel_params, dstran)
 
     np.testing.assert_allclose(stress_f90, stress_py, rtol=1e-12,
                                err_msg="Uniaxial: Fortran vs Python mismatch")
@@ -68,12 +50,12 @@ def test_elastic_stress_uniaxial(model, params):
 # elastic_stress — multiaxial strain increment
 # ---------------------------------------------------------------------------
 
-def test_elastic_stress_multiaxial(model, params):
+def test_elastic_stress_multiaxial(model, steel_params):
     """Fortran elastic_stress matches Python C @ dstran (multiaxial)."""
     dstran = np.array([1.5e-3, -0.5e-3, -0.5e-3, 0.5e-3, 0.0, 0.0])
 
-    stress_f90 = mod.elastic_stress(params["E"], params["nu"], dstran)
-    stress_py  = _py_stress(model, params, dstran)
+    stress_f90 = mod.elastic_stress(steel_params["E"], steel_params["nu"], dstran)
+    stress_py  = _py_stress(model, steel_params, dstran)
 
     np.testing.assert_allclose(stress_f90, stress_py, rtol=1e-12,
                                err_msg="Multiaxial: Fortran vs Python mismatch")
@@ -83,9 +65,9 @@ def test_elastic_stress_multiaxial(model, params):
 # elastic_stiffness — diagonal entries
 # ---------------------------------------------------------------------------
 
-def test_elastic_stiffness_diagonal(params):
+def test_elastic_stiffness_diagonal(steel_params):
     """Fortran stiffness diagonal: normal entries = lam+2mu, shear = mu."""
-    E, nu = params["E"], params["nu"]
+    E, nu = steel_params["E"], steel_params["nu"]
     mu  = E / (2.0 * (1.0 + nu))
     lam = E * nu / ((1.0 + nu) * (1.0 - 2.0 * nu))
 
@@ -106,8 +88,8 @@ def test_elastic_stiffness_diagonal(params):
 # elastic_stiffness — symmetry
 # ---------------------------------------------------------------------------
 
-def test_elastic_stiffness_symmetric(params):
+def test_elastic_stiffness_symmetric(steel_params):
     """Fortran stiffness matrix is symmetric."""
-    C_f90 = mod.elastic_stiffness(params["E"], params["nu"], 6)
+    C_f90 = mod.elastic_stiffness(steel_params["E"], steel_params["nu"], 6)
     np.testing.assert_allclose(C_f90, C_f90.T, atol=1e-12,
                                err_msg="Stiffness matrix not symmetric")

--- a/tests/test_fortran_umat.py
+++ b/tests/test_fortran_umat.py
@@ -10,24 +10,17 @@ The compiled module must be built before running:
 If the module is not available, all tests in this file are skipped.
 """
 
-import sys
-import os
-
 import numpy as np
 import jax.numpy as jnp
 import pytest
-
-# Add fortran/ to path so the compiled .so is importable
-_FORTRAN_DIR = os.path.join(os.path.dirname(__file__), "..", "fortran")
-sys.path.insert(0, os.path.abspath(_FORTRAN_DIR))
 
 pytest.importorskip(
     "j2_isotropic_3d",
     reason="j2_isotropic_3d not compiled -- run: make fortran-build-umat",
 )
 
-import manforge  # noqa: F401 -- enables JAX float64
-from manforge.models.j2_isotropic import J2Isotropic3D
+pytestmark = pytest.mark.fortran
+
 from manforge.core.return_mapping import return_mapping
 from manforge.verification import FortranUMAT
 
@@ -35,16 +28,6 @@ from manforge.verification import FortranUMAT
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
-
-@pytest.fixture
-def model():
-    return J2Isotropic3D()
-
-
-@pytest.fixture
-def params():
-    return {"E": 210_000.0, "nu": 0.3, "sigma_y0": 250.0, "H": 1_000.0}
-
 
 @pytest.fixture
 def fortran():
@@ -55,12 +38,12 @@ def fortran():
 # Shape / smoke tests
 # ---------------------------------------------------------------------------
 
-def test_call_j2_isotropic_3d(fortran, params):
+def test_call_j2_isotropic_3d(fortran, steel_params):
     """j2_isotropic_3d subroutine returns stress (6,) and ddsdde (6,6)."""
     dstran = np.array([1e-4, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float64)
     stress_f, ep_f, ddsdde_f = fortran.call(
         "j2_isotropic_3d",
-        params["E"], params["nu"], params["sigma_y0"], params["H"],
+        steel_params["E"], steel_params["nu"], steel_params["sigma_y0"], steel_params["H"],
         np.zeros(6), 0.0, dstran,
     )
     assert np.asarray(stress_f).shape == (6,)
@@ -77,34 +60,34 @@ def test_call_elastic_stiffness(fortran):
 # Fortran vs Python comparison
 # ---------------------------------------------------------------------------
 
-def test_fortran_vs_python_elastic(fortran, model, params):
+def test_fortran_vs_python_elastic(fortran, model, steel_params):
     """Elastic step: Fortran stress and tangent match Python reference."""
     dstran = np.array([1e-4, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float64)
 
     stress_f, ep_f, ddsdde_f = fortran.call(
         "j2_isotropic_3d",
-        params["E"], params["nu"], params["sigma_y0"], params["H"],
+        steel_params["E"], steel_params["nu"], steel_params["sigma_y0"], steel_params["H"],
         np.zeros(6), 0.0, dstran,
     )
     stress_py, _, ddsdde_py = return_mapping(
-        model, jnp.array(dstran), jnp.zeros(6), model.initial_state(), params,
+        model, jnp.array(dstran), jnp.zeros(6), model.initial_state(), steel_params,
     )
 
     np.testing.assert_allclose(np.array(stress_py), stress_f, rtol=1e-6)
     np.testing.assert_allclose(np.array(ddsdde_py), np.array(ddsdde_f), rtol=1e-5)
 
 
-def test_fortran_vs_python_plastic_uniaxial(fortran, model, params):
+def test_fortran_vs_python_plastic_uniaxial(fortran, model, steel_params):
     """Plastic uniaxial step: Fortran stress and tangent match Python reference."""
     dstran = np.array([2e-3, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float64)
 
     stress_f, ep_f, ddsdde_f = fortran.call(
         "j2_isotropic_3d",
-        params["E"], params["nu"], params["sigma_y0"], params["H"],
+        steel_params["E"], steel_params["nu"], steel_params["sigma_y0"], steel_params["H"],
         np.zeros(6), 0.0, dstran,
     )
     stress_py, state_py, ddsdde_py = return_mapping(
-        model, jnp.array(dstran), jnp.zeros(6), model.initial_state(), params,
+        model, jnp.array(dstran), jnp.zeros(6), model.initial_state(), steel_params,
     )
 
     np.testing.assert_allclose(np.array(stress_py), stress_f, rtol=1e-6)
@@ -112,27 +95,27 @@ def test_fortran_vs_python_plastic_uniaxial(fortran, model, params):
     assert abs(float(state_py["ep"]) - float(ep_f)) / (abs(float(state_py["ep"])) + 1e-14) < 1e-6
 
 
-def test_fortran_vs_python_plastic_multiaxial(fortran, model, params):
+def test_fortran_vs_python_plastic_multiaxial(fortran, model, steel_params):
     """Plastic multiaxial step: Fortran matches Python."""
     dstran = np.array([1.5e-3, -0.5e-3, -0.5e-3, 0.5e-3, 0.0, 0.0], dtype=np.float64)
 
     stress_f, ep_f, ddsdde_f = fortran.call(
         "j2_isotropic_3d",
-        params["E"], params["nu"], params["sigma_y0"], params["H"],
+        steel_params["E"], steel_params["nu"], steel_params["sigma_y0"], steel_params["H"],
         np.zeros(6), 0.0, dstran,
     )
     stress_py, _, ddsdde_py = return_mapping(
-        model, jnp.array(dstran), jnp.zeros(6), model.initial_state(), params,
+        model, jnp.array(dstran), jnp.zeros(6), model.initial_state(), steel_params,
     )
 
     np.testing.assert_allclose(np.array(stress_py), stress_f, rtol=1e-6)
     np.testing.assert_allclose(np.array(ddsdde_py), np.array(ddsdde_f), rtol=1e-5)
 
 
-def test_elastic_stiffness_vs_python(fortran, model, params):
+def test_elastic_stiffness_vs_python(fortran, model, steel_params):
     """Elastic stiffness sub-component: Fortran matches Python to near machine precision."""
-    C_f = fortran.call("j2_isotropic_3d_elastic_stiffness", params["E"], params["nu"])
-    C_py = model.elastic_stiffness(params)
+    C_f = fortran.call("j2_isotropic_3d_elastic_stiffness", steel_params["E"], steel_params["nu"])
+    C_py = model.elastic_stiffness(steel_params)
 
     np.testing.assert_allclose(np.array(C_py), np.array(C_f), rtol=1e-12)
 
@@ -141,9 +124,9 @@ def test_elastic_stiffness_vs_python(fortran, model, params):
 # Multi-step: independent state propagation
 # ---------------------------------------------------------------------------
 
-def test_multi_step_tension_unload_compression(fortran, model, params):
+def test_multi_step_tension_unload_compression(fortran, model, steel_params):
     """Multi-step tension-unload-compression: accumulated error stays small."""
-    eps_y = params["sigma_y0"] / params["E"]
+    eps_y = steel_params["sigma_y0"] / steel_params["E"]
     n = 35
     tension = np.linspace(0.0, 3.0 * eps_y, n // 2 + 1)
     compression = np.linspace(tension[-1], -3.0 * eps_y, n - len(tension) + 2)[1:]
@@ -167,11 +150,11 @@ def test_multi_step_tension_unload_compression(fortran, model, params):
         eps_prev = history[i].copy()
 
         stress_py, state_py, _ = return_mapping(
-            model, jnp.array(dstran), stress_py, state_py, params
+            model, jnp.array(dstran), stress_py, state_py, steel_params
         )
         stress_f, ep_f, _ = fortran.call(
             "j2_isotropic_3d",
-            params["E"], params["nu"], params["sigma_y0"], params["H"],
+            steel_params["E"], steel_params["nu"], steel_params["sigma_y0"], steel_params["H"],
             stress_f, ep_f, dstran,
         )
 

--- a/tests/test_j2_elastic.py
+++ b/tests/test_j2_elastic.py
@@ -1,21 +1,9 @@
 """Test return mapping in the elastic domain for J2Isotropic3D."""
 
+import numpy as np
 import jax.numpy as jnp
-import pytest
 
-import manforge  # noqa: F401
 from manforge.core.return_mapping import return_mapping
-from manforge.models.j2_isotropic import J2Isotropic3D
-
-
-@pytest.fixture
-def model():
-    return J2Isotropic3D()
-
-
-@pytest.fixture
-def initial_state(model):
-    return model.initial_state()
 
 
 # ---------------------------------------------------------------------------
@@ -32,7 +20,7 @@ def test_elastic_stress_update(model, steel_params, initial_state):
     )
 
     expected_stress = C @ strain_inc
-    assert jnp.allclose(stress_new, expected_stress, rtol=1e-10)
+    np.testing.assert_allclose(np.asarray(stress_new), np.asarray(expected_stress), rtol=1e-10)
 
 
 def test_elastic_tangent_equals_C(model, steel_params, initial_state):
@@ -44,7 +32,7 @@ def test_elastic_tangent_equals_C(model, steel_params, initial_state):
         model, strain_inc, jnp.zeros(6), initial_state, steel_params
     )
 
-    assert jnp.allclose(ddsdde, C, rtol=1e-10)
+    np.testing.assert_allclose(np.asarray(ddsdde), np.asarray(C), rtol=1e-10)
 
 
 def test_elastic_state_unchanged(model, steel_params, initial_state):
@@ -55,7 +43,7 @@ def test_elastic_state_unchanged(model, steel_params, initial_state):
         model, strain_inc, jnp.zeros(6), initial_state, steel_params
     )
 
-    assert jnp.allclose(state_new["ep"], initial_state["ep"])
+    np.testing.assert_allclose(np.asarray(state_new["ep"]), np.asarray(initial_state["ep"]))
 
 
 def test_elastic_multiaxial(model, steel_params, initial_state):
@@ -67,8 +55,8 @@ def test_elastic_multiaxial(model, steel_params, initial_state):
         model, strain_inc, jnp.zeros(6), initial_state, steel_params
     )
 
-    assert jnp.allclose(stress_new, C @ strain_inc, rtol=1e-10)
-    assert jnp.allclose(ddsdde, C, rtol=1e-10)
+    np.testing.assert_allclose(np.asarray(stress_new), np.asarray(C @ strain_inc), rtol=1e-10)
+    np.testing.assert_allclose(np.asarray(ddsdde), np.asarray(C), rtol=1e-10)
 
 
 def test_elastic_from_prestress(model, steel_params):
@@ -84,5 +72,5 @@ def test_elastic_from_prestress(model, steel_params):
         model, strain_inc, stress_n, state_n, steel_params
     )
 
-    assert jnp.allclose(stress_new, stress_n + C @ strain_inc, rtol=1e-10)
-    assert jnp.allclose(ddsdde, C, rtol=1e-10)
+    np.testing.assert_allclose(np.asarray(stress_new), np.asarray(stress_n + C @ strain_inc), rtol=1e-10)
+    np.testing.assert_allclose(np.asarray(ddsdde), np.asarray(C), rtol=1e-10)

--- a/tests/test_j2_plastic.py
+++ b/tests/test_j2_plastic.py
@@ -9,31 +9,18 @@ Analytical solution for uniaxial tension with linear isotropic hardening:
 where σ_y = σ_y0 + H ep_n.
 """
 
+import numpy as np
 import jax.numpy as jnp
 import pytest
 
-import manforge  # noqa: F401
 from manforge.core.return_mapping import return_mapping
-from manforge.models.j2_isotropic import J2Isotropic3D
-
-
-@pytest.fixture
-def model():
-    return J2Isotropic3D()
-
-
-def _lame(params):
-    E, nu = params["E"], params["nu"]
-    mu = E / (2.0 * (1.0 + nu))
-    lam = E * nu / ((1.0 + nu) * (1.0 - 2.0 * nu))
-    return lam, mu
 
 
 # ---------------------------------------------------------------------------
 # Uniaxial plastic step from virgin state
 # ---------------------------------------------------------------------------
 
-def test_plastic_stress_uniaxial(model, steel_params):
+def test_plastic_stress_uniaxial(model, steel_params, lame_constants):
     """Plastic uniaxial strain step: σ11_new matches analytic correction.
 
     Note: strain_inc = [deps11, 0, 0, ...] is a *uniaxial strain* increment,
@@ -44,7 +31,7 @@ def test_plastic_stress_uniaxial(model, steel_params):
     The analytic σ11 after return mapping is:
         σ11_new = (λ+2μ)deps11 - 2μ·Δλ
     """
-    lam, mu = _lame(steel_params)
+    lam, mu = lame_constants
     sigma_y0 = steel_params["sigma_y0"]
     H = steel_params["H"]
 
@@ -67,9 +54,10 @@ def test_plastic_stress_uniaxial(model, steel_params):
     sigma11_analytic = float((lam + 2.0 * mu) * deps11 - 2.0 * mu * dlambda_analytic)
 
     assert dlambda_analytic > 0, "should be in plastic domain"
-    assert jnp.allclose(
-        float(stress_new[0]), sigma11_analytic, rtol=1e-6
-    ), f"Expected σ11 ≈ {sigma11_analytic:.4f}, got {float(stress_new[0]):.4f}"
+    np.testing.assert_allclose(
+        float(stress_new[0]), sigma11_analytic, rtol=1e-6,
+        err_msg=f"Expected σ11 ≈ {sigma11_analytic:.4f}, got {float(stress_new[0]):.4f}",
+    )
 
 
 def test_plastic_ep_updated(model, steel_params):
@@ -85,13 +73,13 @@ def test_plastic_ep_updated(model, steel_params):
     assert float(state_new["ep"]) > 0.0
 
 
-def test_plastic_ep_matches_dlambda(model, steel_params):
+def test_plastic_ep_matches_dlambda(model, steel_params, lame_constants):
     """ep_new = Δλ for J2 (Δep = Δλ from consistency condition).
 
     σ_vm_trial must be computed via vonmises(σ_trial), not σ_trial[0],
     because a uniaxial strain increment produces a triaxial stress state.
     """
-    lam, mu = _lame(steel_params)
+    lam, mu = lame_constants
     sigma_y0 = steel_params["sigma_y0"]
     H = steel_params["H"]
 
@@ -107,7 +95,7 @@ def test_plastic_ep_matches_dlambda(model, steel_params):
         model, strain_inc, jnp.zeros(6), state_n, steel_params
     )
 
-    assert jnp.allclose(float(state_new["ep"]), dlambda_analytic, rtol=1e-6)
+    np.testing.assert_allclose(float(state_new["ep"]), dlambda_analytic, rtol=1e-6)
 
 
 def test_plastic_yield_consistency(model, steel_params):
@@ -134,5 +122,5 @@ def test_plastic_ddsdde_differs_from_C(model, steel_params):
         model, strain_inc, jnp.zeros(6), model.initial_state(), steel_params
     )
 
-    assert not jnp.allclose(ddsdde, C, atol=1.0), \
+    assert not np.allclose(np.asarray(ddsdde), np.asarray(C), atol=1.0), \
         "Plastic tangent should differ from elastic stiffness"

--- a/tests/test_material_bases.py
+++ b/tests/test_material_bases.py
@@ -11,7 +11,6 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-import manforge  # noqa: F401
 from manforge.core.material import MaterialModel3D, MaterialModelPS, MaterialModel1D
 from manforge.core.stress_state import SOLID_3D, PLANE_STRAIN, PLANE_STRESS, UNIAXIAL_1D
 
@@ -71,7 +70,7 @@ def test_hydrostatic_isotropic(ss):
     m = _Stub3D(ss)
     p = 150.0
     stress = jnp.array([p, p, p] + [0.0] * (ss.ntens - 3))
-    assert jnp.allclose(m._hydrostatic(stress), p)
+    np.testing.assert_allclose(float(m._hydrostatic(stress)), p)
 
 
 @pytest.mark.parametrize("ss", [SOLID_3D, PLANE_STRAIN])
@@ -80,14 +79,14 @@ def test_hydrostatic_uniaxial(ss):
     m = _Stub3D(ss)
     sigma = 300.0
     stress = jnp.zeros(ss.ntens).at[0].set(sigma)
-    assert jnp.allclose(m._hydrostatic(stress), sigma / 3.0)
+    np.testing.assert_allclose(float(m._hydrostatic(stress)), sigma / 3.0)
 
 
 def test_hydrostatic_shear_only():
     """Pure shear contributes nothing to hydrostatic pressure."""
     m = _Stub3D(SOLID_3D)
     stress = jnp.array([0.0, 0.0, 0.0, 100.0, 50.0, 25.0])
-    assert jnp.allclose(m._hydrostatic(stress), 0.0)
+    np.testing.assert_allclose(float(m._hydrostatic(stress)), 0.0)
 
 
 # ---------------------------------------------------------------------------
@@ -101,7 +100,7 @@ def test_dev_trace_zero(ss):
     stress = jnp.array([100.0, -50.0, 30.0] + [20.0] * (ss.ntens - 3))
     s = m._dev(stress)
     # Trace = sum of direct components
-    assert jnp.allclose(jnp.sum(s[:3]), 0.0, atol=1e-12)
+    np.testing.assert_allclose(float(jnp.sum(s[:3])), 0.0, atol=1e-12)
 
 
 @pytest.mark.parametrize("ss", [SOLID_3D, PLANE_STRAIN])
@@ -117,7 +116,7 @@ def test_dev_isotropic_stress_is_zero():
     m = _Stub3D(SOLID_3D)
     p = 200.0
     stress = jnp.array([p, p, p, 0.0, 0.0, 0.0])
-    assert jnp.allclose(m._dev(stress), 0.0)
+    np.testing.assert_allclose(np.asarray(m._dev(stress)), 0.0, atol=1e-12)
 
 
 # ---------------------------------------------------------------------------
@@ -129,7 +128,7 @@ def test_vonmises_uniaxial_solid_3d(steel_params):
     m = _Stub3D(SOLID_3D)
     sigma = 300.0
     stress = jnp.array([sigma, 0.0, 0.0, 0.0, 0.0, 0.0])
-    assert jnp.allclose(m._vonmises(stress), sigma, rtol=1e-6)
+    np.testing.assert_allclose(float(m._vonmises(stress)), sigma, rtol=1e-6)
 
 
 def test_vonmises_pure_shear_solid_3d():
@@ -137,8 +136,8 @@ def test_vonmises_pure_shear_solid_3d():
     m = _Stub3D(SOLID_3D)
     tau = 100.0
     stress = jnp.array([0.0, 0.0, 0.0, tau, 0.0, 0.0])
-    expected = jnp.sqrt(3.0) * tau
-    assert jnp.allclose(m._vonmises(stress), expected, rtol=1e-6)
+    expected = float(jnp.sqrt(3.0) * tau)
+    np.testing.assert_allclose(float(m._vonmises(stress)), expected, rtol=1e-6)
 
 
 def test_vonmises_plane_strain_uniaxial():
@@ -146,7 +145,7 @@ def test_vonmises_plane_strain_uniaxial():
     m = _Stub3D(PLANE_STRAIN)
     sigma = 300.0
     stress = jnp.array([sigma, 0.0, 0.0, 0.0])
-    assert jnp.allclose(m._vonmises(stress), sigma, rtol=1e-6)
+    np.testing.assert_allclose(float(m._vonmises(stress)), sigma, rtol=1e-6)
 
 
 @pytest.mark.parametrize("ss", [SOLID_3D, PLANE_STRAIN])
@@ -178,7 +177,7 @@ def test_isotropic_C_symmetry(ss):
     """Stiffness tensor must be symmetric."""
     m = _Stub3D(ss)
     C = m.isotropic_C(lam=121153.8, mu=80769.2)
-    assert jnp.allclose(C, C.T, atol=1e-10)
+    np.testing.assert_allclose(np.asarray(C), np.asarray(C.T), atol=1e-10)
 
 
 def test_isotropic_C_solid_3d_diagonal(steel_params):
@@ -188,9 +187,9 @@ def test_isotropic_C_solid_3d_diagonal(steel_params):
     mu = E / (2 * (1 + nu))
     m = _Stub3D(SOLID_3D)
     C = m.isotropic_C(lam, mu)
-    assert jnp.allclose(C[0, 0], lam + 2 * mu, rtol=1e-8)
-    assert jnp.allclose(C[0, 1], lam, rtol=1e-8)
-    assert jnp.allclose(C[3, 3], mu, rtol=1e-8)
+    np.testing.assert_allclose(float(C[0, 0]), lam + 2 * mu, rtol=1e-8)
+    np.testing.assert_allclose(float(C[0, 1]), lam, rtol=1e-8)
+    np.testing.assert_allclose(float(C[3, 3]), mu, rtol=1e-8)
 
 
 def test_isotropic_C_plane_strain_is_submatrix(steel_params):
@@ -200,7 +199,7 @@ def test_isotropic_C_plane_strain_is_submatrix(steel_params):
     mu = E / (2 * (1 + nu))
     C3d = _Stub3D(SOLID_3D).isotropic_C(lam, mu)
     Cpe = _Stub3D(PLANE_STRAIN).isotropic_C(lam, mu)
-    assert jnp.allclose(Cpe, C3d[:4, :4], atol=1e-10)
+    np.testing.assert_allclose(np.asarray(Cpe), np.asarray(C3d[:4, :4]), atol=1e-10)
 
 
 # ---------------------------------------------------------------------------
@@ -211,8 +210,7 @@ def test_isotropic_C_plane_strain_is_submatrix(steel_params):
 def test_I_vol_plus_I_dev_equals_identity(ss):
     """P_vol + P_dev must equal the ntens×ntens identity."""
     m = _Stub3D(ss)
-    I = jnp.eye(ss.ntens)
-    assert jnp.allclose(m._I_vol() + m._I_dev(), I, atol=1e-12)
+    np.testing.assert_allclose(np.asarray(m._I_vol() + m._I_dev()), np.eye(ss.ntens), atol=1e-12)
 
 
 @pytest.mark.parametrize("ss", [SOLID_3D, PLANE_STRAIN])
@@ -223,7 +221,7 @@ def test_I_vol_projects_to_hydrostatic(ss):
     p = m._hydrostatic(stress)
     vol_part = m._I_vol() @ stress
     expected = p * ss.identity_jnp
-    assert jnp.allclose(vol_part, expected, atol=1e-10)
+    np.testing.assert_allclose(np.asarray(vol_part), np.asarray(expected), atol=1e-10)
 
 
 @pytest.mark.parametrize("ss", [SOLID_3D, PLANE_STRAIN])
@@ -231,7 +229,7 @@ def test_I_dev_projects_to_deviatoric(ss):
     """P_dev @ σ must equal _dev(σ)."""
     m = _Stub3D(ss)
     stress = jnp.array([100.0, -50.0, 30.0] + [20.0] * (ss.ntens - 3))
-    assert jnp.allclose(m._I_dev() @ stress, m._dev(stress), atol=1e-10)
+    np.testing.assert_allclose(np.asarray(m._I_dev() @ stress), np.asarray(m._dev(stress)), atol=1e-10)
 
 
 # ===========================================================================
@@ -287,7 +285,7 @@ def test_ps_hydrostatic_uniaxial():
     m = _StubPS()
     sigma = 300.0
     stress = jnp.array([sigma, 0.0, 0.0])
-    assert jnp.allclose(m._hydrostatic(stress), sigma / 3.0)
+    np.testing.assert_allclose(float(m._hydrostatic(stress)), sigma / 3.0)
 
 
 def test_ps_hydrostatic_equal_biaxial():
@@ -295,14 +293,14 @@ def test_ps_hydrostatic_equal_biaxial():
     m = _StubPS()
     sigma = 200.0
     stress = jnp.array([sigma, sigma, 0.0])
-    assert jnp.allclose(m._hydrostatic(stress), 2.0 * sigma / 3.0)
+    np.testing.assert_allclose(float(m._hydrostatic(stress)), 2.0 * sigma / 3.0)
 
 
 def test_ps_hydrostatic_shear_only():
     """Pure shear contributes nothing to hydrostatic pressure."""
     m = _StubPS()
     stress = jnp.array([0.0, 0.0, 100.0])
-    assert jnp.allclose(m._hydrostatic(stress), 0.0)
+    np.testing.assert_allclose(float(m._hydrostatic(stress)), 0.0)
 
 
 # ---------------------------------------------------------------------------
@@ -318,7 +316,7 @@ def test_ps_dev_trace_zero():
     # σ11 + σ22 - 2p = σ11 + σ22 - 2(σ11+σ22)/3 = (σ11+σ22)/3
     # The full 3D trace s11+s22+s33 = 0; here we verify s11+s22 = -s33 = p
     p = m._hydrostatic(stress)
-    assert jnp.allclose(s[0] + s[1], p, atol=1e-12)
+    np.testing.assert_allclose(float(s[0] + s[1]), float(p), atol=1e-12)
 
 
 def test_ps_dev_shape():
@@ -336,7 +334,7 @@ def test_ps_vonmises_uniaxial():
     m = _StubPS()
     sigma = 300.0
     stress = jnp.array([sigma, 0.0, 0.0])
-    assert jnp.allclose(m._vonmises(stress), sigma, rtol=1e-6)
+    np.testing.assert_allclose(float(m._vonmises(stress)), sigma, rtol=1e-6)
 
 
 def test_ps_vonmises_equal_biaxial():
@@ -344,7 +342,7 @@ def test_ps_vonmises_equal_biaxial():
     m = _StubPS()
     sigma = 200.0
     stress = jnp.array([sigma, sigma, 0.0])
-    assert jnp.allclose(m._vonmises(stress), sigma, rtol=1e-6)
+    np.testing.assert_allclose(float(m._vonmises(stress)), sigma, rtol=1e-6)
 
 
 def test_ps_vonmises_pure_shear():
@@ -352,7 +350,7 @@ def test_ps_vonmises_pure_shear():
     m = _StubPS()
     tau = 100.0
     stress = jnp.array([0.0, 0.0, tau])
-    assert jnp.allclose(m._vonmises(stress), jnp.sqrt(3.0) * tau, rtol=1e-6)
+    np.testing.assert_allclose(float(m._vonmises(stress)), float(jnp.sqrt(3.0) * tau), rtol=1e-6)
 
 
 def test_ps_vonmises_matches_3d_reference():
@@ -362,7 +360,7 @@ def test_ps_vonmises_matches_3d_reference():
     # A stress that is valid in both: [σ11, σ22, σ12] plane-stress = [σ11, σ22, 0, σ12, 0, 0]
     sigma = jnp.array([200.0, -100.0, 50.0])
     sigma_3d = jnp.array([200.0, -100.0, 0.0, 50.0, 0.0, 0.0])
-    assert jnp.allclose(m_ps._vonmises(sigma), m_3d._vonmises(sigma_3d), rtol=1e-6)
+    np.testing.assert_allclose(float(m_ps._vonmises(sigma)), float(m_3d._vonmises(sigma_3d)), rtol=1e-6)
 
 
 # ---------------------------------------------------------------------------
@@ -378,7 +376,7 @@ def test_ps_isotropic_C_shape():
 def test_ps_isotropic_C_symmetry():
     m = _StubPS()
     C = m.isotropic_C(lam=121153.8, mu=80769.2)
-    assert jnp.allclose(C, C.T, atol=1e-10)
+    np.testing.assert_allclose(np.asarray(C), np.asarray(C.T), atol=1e-10)
 
 
 def test_ps_isotropic_C_known_values(steel_params):
@@ -390,8 +388,8 @@ def test_ps_isotropic_C_known_values(steel_params):
     C = m.isotropic_C(lam, mu)
     expected_00 = E / (1 - nu ** 2)
     expected_01 = E * nu / (1 - nu ** 2)
-    assert jnp.allclose(C[0, 0], expected_00, rtol=1e-6)
-    assert jnp.allclose(C[0, 1], expected_01, rtol=1e-6)
+    np.testing.assert_allclose(float(C[0, 0]), expected_00, rtol=1e-6)
+    np.testing.assert_allclose(float(C[0, 1]), expected_01, rtol=1e-6)
 
 
 # ---------------------------------------------------------------------------
@@ -400,14 +398,14 @@ def test_ps_isotropic_C_known_values(steel_params):
 
 def test_ps_I_vol_plus_I_dev_equals_identity():
     m = _StubPS()
-    assert jnp.allclose(m._I_vol() + m._I_dev(), jnp.eye(3), atol=1e-12)
+    np.testing.assert_allclose(np.asarray(m._I_vol() + m._I_dev()), np.eye(3), atol=1e-12)
 
 
 def test_ps_I_dev_projects_to_deviatoric():
     """P_dev @ σ must equal _dev(σ) for plane stress."""
     m = _StubPS()
     stress = jnp.array([100.0, -50.0, 20.0])
-    assert jnp.allclose(m._I_dev() @ stress, m._dev(stress), atol=1e-10)
+    np.testing.assert_allclose(np.asarray(m._I_dev() @ stress), np.asarray(m._dev(stress)), atol=1e-10)
 
 
 # ===========================================================================
@@ -463,7 +461,7 @@ def test_1d_hydrostatic_uniaxial():
     m = _Stub1D()
     sigma = 300.0
     stress = jnp.array([sigma])
-    assert jnp.allclose(m._hydrostatic(stress), sigma / 3.0)
+    np.testing.assert_allclose(float(m._hydrostatic(stress)), sigma / 3.0)
 
 
 def test_1d_hydrostatic_compressive():
@@ -471,7 +469,7 @@ def test_1d_hydrostatic_compressive():
     m = _Stub1D()
     sigma = -200.0
     stress = jnp.array([sigma])
-    assert jnp.allclose(m._hydrostatic(stress), sigma / 3.0)
+    np.testing.assert_allclose(float(m._hydrostatic(stress)), sigma / 3.0)
 
 
 # ---------------------------------------------------------------------------
@@ -484,7 +482,7 @@ def test_1d_dev_value():
     sigma = 300.0
     stress = jnp.array([sigma])
     s = m._dev(stress)
-    assert jnp.allclose(s[0], 2.0 * sigma / 3.0, rtol=1e-8)
+    np.testing.assert_allclose(float(s[0]), 2.0 * sigma / 3.0, rtol=1e-8)
 
 
 def test_1d_dev_shape():
@@ -501,7 +499,7 @@ def test_1d_vonmises_equals_abs_stress():
     m = _Stub1D()
     for sigma in [300.0, -200.0, 0.0]:
         stress = jnp.array([sigma])
-        assert jnp.allclose(m._vonmises(stress), jnp.abs(sigma), atol=1e-8)
+        np.testing.assert_allclose(float(m._vonmises(stress)), abs(sigma), atol=1e-8)
 
 
 def test_1d_vonmises_matches_3d_reference():
@@ -511,7 +509,7 @@ def test_1d_vonmises_matches_3d_reference():
     sigma = 350.0
     stress_1d = jnp.array([sigma])
     stress_3d = jnp.array([sigma, 0.0, 0.0, 0.0, 0.0, 0.0])
-    assert jnp.allclose(m_1d._vonmises(stress_1d), m_3d._vonmises(stress_3d), rtol=1e-6)
+    np.testing.assert_allclose(float(m_1d._vonmises(stress_1d)), float(m_3d._vonmises(stress_3d)), rtol=1e-6)
 
 
 # ---------------------------------------------------------------------------
@@ -531,7 +529,7 @@ def test_1d_isotropic_C_equals_E(steel_params):
     mu = E / (2 * (1 + nu))
     m = _Stub1D()
     C = m.isotropic_C(lam, mu)
-    assert jnp.allclose(C[0, 0], E, rtol=1e-6)
+    np.testing.assert_allclose(float(C[0, 0]), E, rtol=1e-6)
 
 
 # ---------------------------------------------------------------------------
@@ -540,17 +538,17 @@ def test_1d_isotropic_C_equals_E(steel_params):
 
 def test_1d_I_vol_plus_I_dev_equals_identity():
     m = _Stub1D()
-    assert jnp.allclose(m._I_vol() + m._I_dev(), jnp.eye(1), atol=1e-12)
+    np.testing.assert_allclose(np.asarray(m._I_vol() + m._I_dev()), np.eye(1), atol=1e-12)
 
 
 def test_1d_I_vol_value():
     """P_vol must equal [[1/3]] for 1D."""
     m = _Stub1D()
-    assert jnp.allclose(m._I_vol(), jnp.array([[1.0 / 3.0]]), atol=1e-12)
+    np.testing.assert_allclose(np.asarray(m._I_vol()), np.array([[1.0 / 3.0]]), atol=1e-12)
 
 
 def test_1d_I_dev_projects_to_deviatoric():
     """P_dev @ σ must equal _dev(σ) for 1D."""
     m = _Stub1D()
     stress = jnp.array([300.0])
-    assert jnp.allclose(m._I_dev() @ stress, m._dev(stress), atol=1e-10)
+    np.testing.assert_allclose(np.asarray(m._I_dev() @ stress), np.asarray(m._dev(stress)), atol=1e-10)

--- a/tests/test_multidim_return_mapping.py
+++ b/tests/test_multidim_return_mapping.py
@@ -16,7 +16,6 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-import manforge  # noqa: F401
 from manforge.core.return_mapping import return_mapping
 from manforge.core.stress_state import SOLID_3D, PLANE_STRAIN, PLANE_STRESS, UNIAXIAL_1D
 from manforge.models.j2_isotropic import J2Isotropic3D, J2IsotropicPS
@@ -86,7 +85,7 @@ def test_elastic_step_stress_equals_C_deps(pe_model, pe_state, steel_params):
     stress, _, _ = return_mapping(
         pe_model, deps, jnp.zeros(4), pe_state, steel_params
     )
-    assert jnp.allclose(stress, C @ deps, rtol=1e-10)
+    np.testing.assert_allclose(np.asarray(stress), np.asarray(C @ deps), rtol=1e-10)
 
 
 def test_elastic_step_tangent_equals_C(pe_model, pe_state, steel_params):
@@ -96,7 +95,7 @@ def test_elastic_step_tangent_equals_C(pe_model, pe_state, steel_params):
     _, _, ddsdde = return_mapping(
         pe_model, deps, jnp.zeros(4), pe_state, steel_params
     )
-    assert jnp.allclose(ddsdde, C, rtol=1e-10)
+    np.testing.assert_allclose(np.asarray(ddsdde), np.asarray(C), rtol=1e-10)
 
 
 # ---------------------------------------------------------------------------
@@ -176,8 +175,10 @@ def test_analytical_stress_matches_autodiff(pe_model, pe_state, steel_params, st
     s_an, _, _ = return_mapping(
         pe_model, deps, jnp.zeros(4), pe_state, steel_params, method="analytical"
     )
-    assert jnp.allclose(s_an, s_ad, atol=1e-6), \
-        f"max stress diff = {float(jnp.max(jnp.abs(s_an - s_ad))):.3e}"
+    np.testing.assert_allclose(
+        np.asarray(s_an), np.asarray(s_ad), atol=1e-6,
+        err_msg=f"max stress diff = {float(jnp.max(jnp.abs(s_an - s_ad))):.3e}",
+    )
 
 
 @pytest.mark.parametrize("strain_inc_vec", [

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -1,9 +1,8 @@
 """Unit tests for autodiff.operators and utils.voigt."""
 
+import numpy as np
 import jax.numpy as jnp
-import pytest
 
-import manforge  # noqa: F401  ensures jax_enable_x64 is set
 from manforge.autodiff.operators import (
     I_dev_voigt,
     I_vol_voigt,
@@ -22,7 +21,7 @@ from manforge.utils.voigt import from_mandel, from_voigt, to_mandel, to_voigt
 
 def test_identity_voigt():
     expected = jnp.array([1.0, 1.0, 1.0, 0.0, 0.0, 0.0])
-    assert jnp.allclose(identity_voigt(), expected)
+    np.testing.assert_allclose(np.asarray(identity_voigt()), np.asarray(expected))
 
 
 # ---------------------------------------------------------------------------
@@ -31,12 +30,12 @@ def test_identity_voigt():
 
 def test_hydrostatic_known():
     s = jnp.array([100.0, 200.0, 300.0, 0.0, 0.0, 0.0])
-    assert jnp.allclose(hydrostatic(s), 200.0)
+    np.testing.assert_allclose(float(hydrostatic(s)), 200.0)
 
 
 def test_hydrostatic_pure_shear():
     s = jnp.array([0.0, 0.0, 0.0, 50.0, 30.0, 10.0])
-    assert jnp.allclose(hydrostatic(s), 0.0)
+    np.testing.assert_allclose(float(hydrostatic(s)), 0.0)
 
 
 # ---------------------------------------------------------------------------
@@ -46,20 +45,20 @@ def test_hydrostatic_pure_shear():
 def test_dev_trace_zero():
     s = jnp.array([100.0, 200.0, 300.0, 10.0, 20.0, 30.0])
     d = dev(s)
-    assert jnp.allclose(d[0] + d[1] + d[2], 0.0, atol=1e-12)
+    np.testing.assert_allclose(float(d[0] + d[1] + d[2]), 0.0, atol=1e-12)
 
 
 def test_dev_known_uniaxial():
     # Uniaxial σ11 = 300, all others zero
     s = jnp.array([300.0, 0.0, 0.0, 0.0, 0.0, 0.0])
     expected = jnp.array([200.0, -100.0, -100.0, 0.0, 0.0, 0.0])
-    assert jnp.allclose(dev(s), expected)
+    np.testing.assert_allclose(np.asarray(dev(s)), np.asarray(expected))
 
 
 def test_dev_preserves_shear():
     s = jnp.array([0.0, 0.0, 0.0, 50.0, 30.0, 10.0])
     d = dev(s)
-    assert jnp.allclose(d[3:], s[3:])
+    np.testing.assert_allclose(np.asarray(d[3:]), np.asarray(s[3:]))
 
 
 # ---------------------------------------------------------------------------
@@ -70,19 +69,19 @@ def test_vonmises_uniaxial():
     # Under uniaxial tension σ11 = σ, σ_vm should equal σ
     sigma = 250.0
     s = jnp.array([sigma, 0.0, 0.0, 0.0, 0.0, 0.0])
-    assert jnp.allclose(vonmises(s), sigma, rtol=1e-6)
+    np.testing.assert_allclose(float(vonmises(s)), sigma, rtol=1e-6)
 
 
 def test_vonmises_pure_shear():
     # Under pure shear τ_12 = τ, σ_vm = √3 · τ
     tau = 100.0
     s = jnp.array([0.0, 0.0, 0.0, tau, 0.0, 0.0])
-    assert jnp.allclose(vonmises(s), jnp.sqrt(3.0) * tau, rtol=1e-6)
+    np.testing.assert_allclose(float(vonmises(s)), float(jnp.sqrt(3.0) * tau), rtol=1e-6)
 
 
 def test_vonmises_zero():
     s = jnp.zeros(6)
-    assert jnp.allclose(vonmises(s), 0.0)
+    np.testing.assert_allclose(float(vonmises(s)), 0.0)
 
 
 # ---------------------------------------------------------------------------
@@ -93,13 +92,13 @@ def test_norm_mandel_known():
     # v = [1, 0, 0, 1, 0, 0]  → mandel = [1, 0, 0, √2, 0, 0]
     # norm = √(1 + 2) = √3
     v = jnp.array([1.0, 0.0, 0.0, 1.0, 0.0, 0.0])
-    assert jnp.allclose(norm_mandel(v), jnp.sqrt(3.0), rtol=1e-6)
+    np.testing.assert_allclose(float(norm_mandel(v)), float(jnp.sqrt(3.0)), rtol=1e-6)
 
 
 def test_norm_mandel_normal_only():
     # Normal-only vector: Mandel = Voigt, so norm is just L2 norm
     v = jnp.array([3.0, 4.0, 0.0, 0.0, 0.0, 0.0])
-    assert jnp.allclose(norm_mandel(v), 5.0, rtol=1e-6)
+    np.testing.assert_allclose(float(norm_mandel(v)), 5.0, rtol=1e-6)
 
 
 # ---------------------------------------------------------------------------
@@ -109,19 +108,19 @@ def test_norm_mandel_normal_only():
 def test_I_dev_plus_I_vol_equals_identity():
     I_dev = I_dev_voigt()
     I_vol = I_vol_voigt()
-    assert jnp.allclose(I_dev + I_vol, jnp.eye(6), atol=1e-12)
+    np.testing.assert_allclose(np.asarray(I_dev + I_vol), np.eye(6), atol=1e-12)
 
 
 def test_dev_via_projection():
     s = jnp.array([100.0, 200.0, 300.0, 10.0, 20.0, 30.0])
-    assert jnp.allclose(I_dev_voigt() @ s, dev(s), atol=1e-10)
+    np.testing.assert_allclose(np.asarray(I_dev_voigt() @ s), np.asarray(dev(s)), atol=1e-10)
 
 
 def test_I_vol_projects_to_hydrostatic():
     s = jnp.array([100.0, 200.0, 300.0, 10.0, 20.0, 30.0])
     p = hydrostatic(s)
     expected = p * identity_voigt()
-    assert jnp.allclose(I_vol_voigt() @ s, expected, atol=1e-10)
+    np.testing.assert_allclose(np.asarray(I_vol_voigt() @ s), np.asarray(expected), atol=1e-10)
 
 
 # ---------------------------------------------------------------------------
@@ -132,12 +131,12 @@ def test_voigt_roundtrip():
     T = jnp.array([[1.0, 2.0, 3.0],
                    [2.0, 4.0, 5.0],
                    [3.0, 5.0, 6.0]])
-    assert jnp.allclose(from_voigt(to_voigt(T)), T)
+    np.testing.assert_allclose(np.asarray(from_voigt(to_voigt(T))), np.asarray(T))
 
 
 def test_mandel_roundtrip():
     v = jnp.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
-    assert jnp.allclose(from_mandel(to_mandel(v)), v, atol=1e-12)
+    np.testing.assert_allclose(np.asarray(from_mandel(to_mandel(v))), np.asarray(v), atol=1e-12)
 
 
 def test_mandel_inner_product_equals_double_contraction():
@@ -146,4 +145,4 @@ def test_mandel_inner_product_equals_double_contraction():
     a = jnp.array([1.0, 2.0, 3.0, 0.0, 0.0, 0.0])
     b = jnp.array([4.0, 5.0, 6.0, 0.0, 0.0, 0.0])
     # A:B = 1*4 + 2*5 + 3*6 = 32
-    assert jnp.allclose(jnp.dot(to_mandel(a), to_mandel(b)), 32.0)
+    np.testing.assert_allclose(float(jnp.dot(to_mandel(a), to_mandel(b))), 32.0)

--- a/tests/test_stress_driver.py
+++ b/tests/test_stress_driver.py
@@ -3,7 +3,6 @@
 import numpy as np
 import pytest
 
-import manforge  # noqa: F401 — enables float64
 from manforge.core.stress_state import SOLID_3D, UNIAXIAL_1D
 from manforge.models.j2_isotropic import J2Isotropic3D, J2Isotropic1D
 from manforge.simulation.driver import StressDriver, StrainDriver

--- a/tests/test_tangent_fd.py
+++ b/tests/test_tangent_fd.py
@@ -8,17 +8,10 @@ For each test case, DDSDDE is computed two ways:
 The two must agree to rtol = 1e-5.
 """
 
+import numpy as np
 import jax.numpy as jnp
-import pytest
 
-import manforge  # noqa: F401
 from manforge.core.return_mapping import return_mapping
-from manforge.models.j2_isotropic import J2Isotropic3D
-
-
-@pytest.fixture
-def model():
-    return J2Isotropic3D()
 
 
 def _fd_tangent(model, strain_inc, stress_n, state_n, params, h=1e-7):
@@ -56,8 +49,9 @@ def test_tangent_fd_elastic(model, steel_params):
     )
     ddsdde_fd = _fd_tangent(model, strain_inc, stress_n, state_n, steel_params)
 
-    assert jnp.allclose(ddsdde_ad, ddsdde_fd, rtol=1e-5, atol=1e-3), (
-        f"Max rel err: {float(jnp.max(jnp.abs(ddsdde_ad - ddsdde_fd) / (jnp.abs(ddsdde_fd) + 1e-12))):.3e}"
+    np.testing.assert_allclose(
+        np.asarray(ddsdde_ad), np.asarray(ddsdde_fd), rtol=1e-5, atol=1e-3,
+        err_msg=f"Max rel err: {float(jnp.max(jnp.abs(ddsdde_ad - ddsdde_fd) / (jnp.abs(ddsdde_fd) + 1e-12))):.3e}",
     )
 
 

--- a/tests/test_umat_verifier.py
+++ b/tests/test_umat_verifier.py
@@ -7,10 +7,7 @@ using the Python J2 model only.
 
 import numpy as np
 import pytest
-import jax.numpy as jnp
 
-import manforge  # noqa: F401 -- enables JAX float64
-from manforge.models.j2_isotropic import J2Isotropic3D
 from manforge.verification.test_cases import (
     estimate_yield_strain,
     generate_single_step_cases,
@@ -19,52 +16,38 @@ from manforge.verification.test_cases import (
 
 
 # ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
-
-@pytest.fixture
-def model():
-    return J2Isotropic3D()
-
-
-@pytest.fixture
-def params():
-    return {"E": 210_000.0, "nu": 0.3, "sigma_y0": 250.0, "H": 1_000.0}
-
-
-# ---------------------------------------------------------------------------
 # estimate_yield_strain
 # ---------------------------------------------------------------------------
 
-def test_estimate_yield_strain_approx(model, params):
+def test_estimate_yield_strain_approx(model, steel_params):
     """Estimated yield strain matches the analytical J2 3D uniaxial value.
 
     For J2 under uniaxial strain [eps,0,0,0,0,0], the von Mises stress is
     2*mu*eps (derivable from the deviatoric stress of the uniaxial elastic
     state), so yield occurs at eps_y = sigma_y0 / (2*mu).
     """
-    E  = params["E"]
-    nu = params["nu"]
+    E  = steel_params["E"]
+    nu = steel_params["nu"]
     mu = E / (2.0 * (1.0 + nu))
-    eps_y_expected = params["sigma_y0"] / (2.0 * mu)
+    eps_y_expected = steel_params["sigma_y0"] / (2.0 * mu)
 
-    eps_y = estimate_yield_strain(model, params)
+    eps_y = estimate_yield_strain(model, steel_params)
 
     assert abs(eps_y - eps_y_expected) / eps_y_expected < 0.01  # 1% tolerance
 
 
-def test_estimate_yield_strain_positive(model, params):
+def test_estimate_yield_strain_positive(model, steel_params):
     """Yield strain must be strictly positive."""
-    eps_y = estimate_yield_strain(model, params)
+    eps_y = estimate_yield_strain(model, steel_params)
     assert eps_y > 0.0
 
 
-def test_estimate_yield_strain_respects_sigma_y0(model, params):
+def test_estimate_yield_strain_respects_sigma_y0(model, steel_params):
     """Harder material (larger sigma_y0) gives larger yield strain."""
-    params_soft = dict(params, sigma_y0=100.0)
-    params_hard = dict(params, sigma_y0=500.0)
-    eps_soft = estimate_yield_strain(model, params_soft)
-    eps_hard = estimate_yield_strain(model, params_hard)
+    steel_params_soft = dict(steel_params, sigma_y0=100.0)
+    steel_params_hard = dict(steel_params, sigma_y0=500.0)
+    eps_soft = estimate_yield_strain(model, steel_params_soft)
+    eps_hard = estimate_yield_strain(model, steel_params_hard)
     assert eps_hard > eps_soft
 
 
@@ -72,47 +55,47 @@ def test_estimate_yield_strain_respects_sigma_y0(model, params):
 # generate_single_step_cases
 # ---------------------------------------------------------------------------
 
-def test_generate_single_step_cases_count(model, params):
+def test_generate_single_step_cases_count(model, steel_params):
     """5 test cases are generated for a 3D SOLID model."""
-    cases = generate_single_step_cases(model, params)
+    cases = generate_single_step_cases(model, steel_params)
     assert len(cases) == 5
 
 
-def test_generate_single_step_cases_keys(model, params):
+def test_generate_single_step_cases_keys(model, steel_params):
     """Each case has the required keys for compare_solvers."""
-    cases = generate_single_step_cases(model, params)
+    cases = generate_single_step_cases(model, steel_params)
     required = {"strain_inc", "stress_n", "state_n", "params"}
     for case in cases:
         assert required.issubset(case.keys())
 
 
-def test_generate_single_step_cases_shapes(model, params):
+def test_generate_single_step_cases_shapes(model, steel_params):
     """strain_inc and stress_n have shape (6,) for SOLID_3D."""
-    cases = generate_single_step_cases(model, params)
+    cases = generate_single_step_cases(model, steel_params)
     for case in cases:
         assert np.asarray(case["strain_inc"]).shape == (6,)
         assert np.asarray(case["stress_n"]).shape   == (6,)
 
 
-def test_generate_single_step_elastic_case_is_small(model, params):
+def test_generate_single_step_elastic_case_is_small(model, steel_params):
     """First case (elastic) uses a strain magnitude smaller than yield."""
-    eps_y = estimate_yield_strain(model, params)
-    cases = generate_single_step_cases(model, params, eps_y=eps_y)
+    eps_y = estimate_yield_strain(model, steel_params)
+    cases = generate_single_step_cases(model, steel_params, eps_y=eps_y)
     elastic_de = np.asarray(cases[0]["strain_inc"])
     assert np.linalg.norm(elastic_de) < eps_y
 
 
-def test_generate_single_step_plastic_case_is_large(model, params):
+def test_generate_single_step_plastic_case_is_large(model, steel_params):
     """Second case (plastic uniaxial) uses a strain larger than yield."""
-    eps_y = estimate_yield_strain(model, params)
-    cases = generate_single_step_cases(model, params, eps_y=eps_y)
+    eps_y = estimate_yield_strain(model, steel_params)
+    cases = generate_single_step_cases(model, steel_params, eps_y=eps_y)
     plastic_de = np.asarray(cases[1]["strain_inc"])
     assert plastic_de[0] > eps_y
 
 
-def test_generate_single_step_prestressed_case_has_nonzero_stress(model, params):
+def test_generate_single_step_prestressed_case_has_nonzero_stress(model, steel_params):
     """Pre-stressed case (last) has a non-zero stress_n."""
-    cases = generate_single_step_cases(model, params)
+    cases = generate_single_step_cases(model, steel_params)
     last_stress = np.asarray(cases[-1]["stress_n"])
     assert np.any(last_stress != 0.0)
 
@@ -121,33 +104,33 @@ def test_generate_single_step_prestressed_case_has_nonzero_stress(model, params)
 # generate_strain_history
 # ---------------------------------------------------------------------------
 
-def test_generate_strain_history_shape(model, params):
+def test_generate_strain_history_shape(model, steel_params):
     """Default strain history has shape (35, ntens)."""
-    history = generate_strain_history(model, params)
+    history = generate_strain_history(model, steel_params)
     assert history.shape == (35, model.ntens)
 
 
-def test_generate_strain_history_axial_only(model, params):
+def test_generate_strain_history_axial_only(model, steel_params):
     """Default history applies strain only in the first component."""
-    history = generate_strain_history(model, params)
+    history = generate_strain_history(model, steel_params)
     # All non-axial columns should be zero
     assert np.all(history[:, 1:] == 0.0)
 
 
-def test_generate_strain_history_returns_to_zero(model, params):
+def test_generate_strain_history_returns_to_zero(model, steel_params):
     """Default history ends at zero strain."""
-    history = generate_strain_history(model, params)
+    history = generate_strain_history(model, steel_params)
     assert abs(history[-1, 0]) < 1e-14
 
 
-def test_generate_strain_history_includes_compression(model, params):
+def test_generate_strain_history_includes_compression(model, steel_params):
     """Default history reaches negative strains (compression)."""
-    history = generate_strain_history(model, params)
+    history = generate_strain_history(model, steel_params)
     assert np.any(history[:, 0] < 0.0)
 
 
-def test_generate_strain_history_custom_scale(model, params):
+def test_generate_strain_history_custom_scale(model, steel_params):
     """Custom eps_y scales the history proportionally."""
     eps_y = 2e-3
-    history = generate_strain_history(model, params, eps_y=eps_y)
+    history = generate_strain_history(model, steel_params, eps_y=eps_y)
     assert abs(np.max(history[:, 0]) - 5.0 * eps_y) < 1e-12

--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -9,15 +9,8 @@ raises NotImplementedError as expected.
 import jax.numpy as jnp
 import pytest
 
-import manforge  # noqa: F401 — enables float64
-from manforge.models.j2_isotropic import J2Isotropic3D
 from manforge.verification.fd_check import check_tangent, TangentCheckResult
 from manforge.verification.fortran_bridge import FortranUMAT
-
-
-@pytest.fixture
-def model():
-    return J2Isotropic3D()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Fixture consolidation**: `conftest.py` now provides `model()`, `initial_state()`, `lame_constants()` shared fixtures, centralizes the JAX float64 side-effect import, and adds the Fortran `sys.path` setup — eliminating duplicate definitions that were copy-pasted across 10+ test files
- **pytest markers**: Registered `slow` and `fortran` markers in `pyproject.toml`; `test_fitting.py` and both Fortran test files now use `pytestmark`; `make test` uses `-m "not slow"` instead of `--ignore`
- **Assertion standardization**: Replaced 74 `assert jnp.allclose(...)` calls (which print only `AssertionError: False` on failure) with `np.testing.assert_allclose(...)` (which prints both arrays and the diff) across 7 files

Net: 220 insertions, 300 deletions — 244 tests all pass.

## Test plan

- [ ] `make test` → 239 passed, 5 deselected
- [ ] `uv run pytest tests/ -m "slow"` → 5 passed
- [ ] `uv run pytest tests/ -m "not fortran"` — deselects Fortran tests without compiled modules
- [ ] No `PytestUnknownMarkWarning` warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)