### PR TITLE
refactor(core): centralize residual builders, NR solvers, and dispatch helpers

### DIFF
--- a/src/manforge/core/jacobian.py
+++ b/src/manforge/core/jacobian.py
@@ -126,7 +126,7 @@ def ad_jacobian_blocks(
             stress = result.stress_trial
             dlambda = jnp.zeros(())
             stress_trial = result.stress_trial
-            state = result._state_n
+            state = result.state
         else:
             stress = result.return_mapping.stress
             dlambda = result.return_mapping.dlambda
@@ -146,14 +146,12 @@ def ad_jacobian_blocks(
     ntens = model.ntens
     C = model.elastic_stiffness()
 
-    if model.hardening_type == "implicit":
-        return _jacobian_blocks_implicit(
-            model, stress, state, dlambda, stress_trial, C, state_n, ntens
-        )
-    else:
-        return _jacobian_blocks_explicit(
-            model, stress, state, dlambda, stress_trial, C, state_n, ntens
-        )
+    _blocks_fn = (
+        _jacobian_blocks_implicit
+        if model.hardening_type == "implicit"
+        else _jacobian_blocks_explicit
+    )
+    return _blocks_fn(model, stress, state, dlambda, stress_trial, C, state_n, ntens)
 
 
 # ---------------------------------------------------------------------------
@@ -164,16 +162,9 @@ def _jacobian_blocks_explicit(
     model, stress, state, dlambda, stress_trial, C, state_n, ntens
 ):
     """Build JacobianBlocks for the explicit (ntens+1) residual system."""
+    from manforge.core.residual import make_explicit_residual
 
-    def residual_fn(x):
-        sig = x[:ntens]
-        dl = x[ntens]
-        st = model.hardening_increment(dl, sig, state_n)
-        n = jax.grad(lambda s: model.yield_function(s, st))(sig)
-        R_stress = sig - stress_trial + dl * (C @ n)
-        R_yield = model.yield_function(sig, st)
-        return jnp.concatenate([R_stress, R_yield.reshape(1)])
-
+    residual_fn = make_explicit_residual(model, stress_trial, C, state_n)
     x_conv = jnp.concatenate([stress, dlambda.reshape(1)])
     J = jax.jacobian(residual_fn)(x_conv)  # (ntens+1, ntens+1)
 

--- a/src/manforge/core/residual.py
+++ b/src/manforge/core/residual.py
@@ -1,31 +1,68 @@
-"""Augmented residual system for implicit hardening laws.
+"""Residual builders for return-mapping systems.
 
-When a model has ``hardening_type == 'implicit'``, the return-mapping
-residual is extended from (ntens+1) to
-(ntens+1+n_state) equations by treating the state variables as independent
-unknowns:
+Two factory functions are provided:
 
-    x = [σ  (ntens),  Δλ (1),  q_flat (n_state)]
+- :func:`make_explicit_residual` — for ``hardening_type == 'explicit'``.
+  Builds the (ntens+1) residual ``[R_stress, R_yield]`` with x = [σ, Δλ].
 
-    R(x) = [ R_stress ]  ntens equations
-            [ R_yield  ]  1 equation
-            [ R_state  ]  n_state equations
+- :func:`make_augmented_residual` — for ``hardening_type == 'implicit'``.
+  Extends the system to (ntens+1+n_state) equations by treating state
+  variables as additional unknowns:
 
-where
+      x = [σ  (ntens),  Δλ (1),  q_flat (n_state)]
 
-    R_stress = σ - σ_trial + Δλ C n(σ, q)
-    R_yield  = f(σ, q)
-    R_state  = flatten(model.hardening_residual(q, Δλ, σ, q_n))
+      R(x) = [ R_stress ]  ntens equations
+              [ R_yield  ]  1 equation
+              [ R_state  ]  n_state equations
 
-This module provides a factory function that builds the residual callable.
-The same callable is used by both the Newton-Raphson solver
-(:mod:`manforge.core.return_mapping`) and the consistent tangent computation
+  where
+
+      R_stress = σ - σ_trial + Δλ C n(σ, q)
+      R_yield  = f(σ, q)
+      R_state  = flatten(model.hardening_residual(q, Δλ, σ, q_n))
+
+Both callables are used by the Newton-Raphson solver
+(:mod:`manforge.core.solver`) and the consistent tangent computation
 (:mod:`manforge.core.tangent`).
 """
 
 import jax
 import jax.numpy as jnp
 from jax.flatten_util import ravel_pytree
+
+
+def make_explicit_residual(model, stress_trial, C, state_n):
+    """Build the residual function for explicit-state models.
+
+    Parameters
+    ----------
+    model : MaterialModel
+        Constitutive model with ``hardening_type == 'explicit'``.
+    stress_trial : jnp.ndarray, shape (ntens,)
+        Elastic trial stress σ_trial = σ_n + C Δε.
+    C : jnp.ndarray, shape (ntens, ntens)
+        Elastic stiffness tensor.
+    state_n : dict
+        Internal state at the beginning of the increment.
+
+    Returns
+    -------
+    residual_fn : callable
+        ``residual_fn(x) -> jnp.ndarray`` of shape ``(ntens+1,)``
+        where x = [σ (ntens), Δλ (1)].
+    """
+    ntens = model.ntens
+
+    def residual_fn(x):
+        sig = x[:ntens]
+        dl = x[ntens]
+        st = model.hardening_increment(dl, sig, state_n)
+        n = jax.grad(lambda s: model.yield_function(s, st))(sig)
+        R_stress = sig - stress_trial + dl * (C @ n)
+        R_yield = model.yield_function(sig, st)
+        return jnp.concatenate([R_stress, R_yield.reshape(1)])
+
+    return residual_fn
 
 
 def make_augmented_residual(model, stress_trial, C, state_n):
@@ -81,3 +118,14 @@ def make_augmented_residual(model, stress_trial, C, state_n):
         return jnp.concatenate([R_stress, R_yield.reshape(1), R_state_flat])
 
     return residual_fn, n_state, unflatten_fn
+
+
+def select_residual_builder(model):
+    """Return the appropriate residual builder for *model*.
+
+    Returns :func:`make_explicit_residual` for ``hardening_type == 'explicit'``
+    and :func:`make_augmented_residual` for ``hardening_type == 'implicit'``.
+    """
+    if model.hardening_type == "implicit":
+        return make_augmented_residual
+    return make_explicit_residual

--- a/src/manforge/core/solver.py
+++ b/src/manforge/core/solver.py
@@ -1,0 +1,143 @@
+"""Newton-Raphson solvers for return-mapping systems.
+
+Two solvers are provided:
+
+- :func:`_explicit_nr` — scalar NR on Δλ for ``hardening_type == 'explicit'``.
+- :func:`_augmented_nr` — vector NR on [σ, Δλ, q_flat] for
+  ``hardening_type == 'implicit'``.
+
+Both return a 5-tuple ``(stress, state_new, dlambda, n_iterations,
+residual_history)`` consumed by :func:`~manforge.core.stress_update.return_mapping`.
+"""
+
+import jax
+import jax.numpy as jnp
+from jax.flatten_util import ravel_pytree
+
+from manforge.core.residual import make_augmented_residual, make_explicit_residual
+
+
+def _explicit_nr(model, stress_trial, C, state_n, max_iter, tol):
+    """Newton-Raphson solver for the explicit (ntens+1) residual system.
+
+    Scalar NR on Δλ: evaluates the full residual at each step and uses
+    ``jax.grad`` to compute dR/dΔλ for the update.
+
+    Parameters
+    ----------
+    model : MaterialModel
+        Constitutive model with ``hardening_type == 'explicit'``.
+    stress_trial : jnp.ndarray, shape (ntens,)
+    C : jnp.ndarray, shape (ntens, ntens)
+    state_n : dict
+    max_iter : int
+    tol : float
+
+    Returns
+    -------
+    stress : jnp.ndarray, shape (ntens,)
+    state_new : dict
+    dlambda : jnp.ndarray, scalar
+    n_iterations : int
+    residual_history : list[float]
+    """
+    ntens = model.ntens
+
+    dlambda = jnp.array(0.0)
+    stress = stress_trial
+    state_new = state_n
+
+    residual_history = []
+    n_iterations = 0
+
+    for _iteration in range(max_iter):
+        # Evaluate state and flow direction at current stress, then update stress,
+        # then re-evaluate state at the new stress (two calls is intentional).
+        state_new = model.hardening_increment(dlambda, stress, state_n)
+        n = jax.grad(lambda s: model.yield_function(s, state_new))(stress)
+        stress = stress_trial - dlambda * (C @ n)
+        state_new = model.hardening_increment(dlambda, stress, state_n)
+        f = model.yield_function(stress, state_new)
+        residual_history.append(float(jnp.abs(f)))
+
+        if jnp.abs(f) < tol:
+            break
+
+        def _f_residual(dl, _stress=stress):
+            st = model.hardening_increment(dl, _stress, state_n)
+            nn = jax.grad(lambda s: model.yield_function(s, st))(_stress)
+            s_upd = stress_trial - dl * (C @ nn)
+            return model.yield_function(s_upd, st)
+
+        dfddl = jax.grad(_f_residual)(dlambda)
+        dlambda = dlambda - f / dfddl
+        n_iterations += 1
+
+    else:
+        raise RuntimeError(
+            f"_explicit_nr: NR did not converge in {max_iter} iterations "
+            f"(|f| = {float(jnp.abs(f)):.3e}, tol = {tol:.3e})"
+        )
+
+    return stress, state_new, dlambda, n_iterations, residual_history
+
+
+def _augmented_nr(model, stress_trial, C, state_n, max_iter, tol):
+    """Newton-Raphson solver for the augmented (ntens+1+n_state) residual system.
+
+    Used when ``model.hardening_type == 'implicit'``.
+
+    Parameters
+    ----------
+    model : MaterialModel
+    stress_trial : jnp.ndarray, shape (ntens,)
+    C : jnp.ndarray, shape (ntens, ntens)
+    state_n : dict
+    max_iter : int
+    tol : float
+
+    Returns
+    -------
+    stress : jnp.ndarray, shape (ntens,)
+    state_new : dict
+    dlambda : jnp.ndarray, scalar
+    n_iterations : int
+    residual_history : list[float]
+    """
+    ntens = model.ntens
+    residual_fn, n_state, unflatten_fn = make_augmented_residual(
+        model, stress_trial, C, state_n
+    )
+
+    flat_state_n, _ = ravel_pytree(state_n)
+    x = jnp.concatenate([stress_trial, jnp.array([0.0]), flat_state_n])
+
+    residual_history = []
+    n_iterations = 0
+    for _iteration in range(max_iter):
+        R = residual_fn(x)
+        res_norm = float(jnp.max(jnp.abs(R)))
+        residual_history.append(res_norm)
+        if res_norm < tol:
+            break
+        J = jax.jacobian(residual_fn)(x)
+        dx = jnp.linalg.solve(J, R)
+        x = x - dx
+        n_iterations += 1
+    else:
+        raise RuntimeError(
+            f"_augmented_nr: NR did not converge in {max_iter} iterations "
+            f"(||R||_inf = {float(jnp.max(jnp.abs(R))):.3e}, tol = {tol:.3e})"
+        )
+
+    stress = x[:ntens]
+    dlambda = jnp.asarray(x[ntens])
+    state_new = unflatten_fn(x[ntens + 1:])
+    return stress, state_new, dlambda, n_iterations, residual_history
+
+
+def _select_nr(model):
+    """Return the NR solver function appropriate for *model*."""
+    if model.hardening_type == "implicit":
+        return _augmented_nr
+    return _explicit_nr

--- a/src/manforge/core/stress_update.py
+++ b/src/manforge/core/stress_update.py
@@ -60,11 +60,65 @@ Notes
 
 from dataclasses import dataclass, field
 
-import jax
 import jax.numpy as jnp
-from jax.flatten_util import ravel_pytree
 
-from manforge.core.tangent import augmented_consistent_tangent, consistent_tangent
+from manforge.core.solver import _select_nr
+from manforge.core.tangent import _select_tangent
+
+_VALID_METHODS = ("auto", "numerical_newton", "user_defined")
+
+
+def _validate_method(method: str) -> None:
+    if method not in _VALID_METHODS:
+        raise ValueError(
+            f"method must be 'auto', 'numerical_newton', or 'user_defined'; "
+            f"got {method!r}"
+        )
+
+
+def _try_user_corrector(model, stress_trial, C, state_n, method):
+    """Attempt user_defined_corrector; return ReturnMappingResult or None.
+
+    Returns None when method='auto' and the model has no corrector hook.
+    Raises NotImplementedError when method='user_defined' and hook is absent.
+    """
+    if method == "numerical_newton":
+        return None
+    _result = model.user_defined_corrector(stress_trial, C, state_n)
+    if _result is not None:
+        if len(_result) == 5:
+            stress, state_new, dlambda, n_iter, res_hist = _result
+        else:
+            stress, state_new, dlambda = _result
+            n_iter, res_hist = 0, []
+        return ReturnMappingResult(
+            stress=stress,
+            state=state_new,
+            dlambda=dlambda,
+            n_iterations=n_iter,
+            residual_history=res_hist,
+        )
+    if method == "user_defined":
+        raise NotImplementedError(
+            f"{type(model).__name__} does not implement user_defined_corrector; "
+            "cannot use method='user_defined'."
+        )
+    return None
+
+
+def _try_user_tangent(model, rm, stress_n, state_n, C, method):
+    """Attempt user_defined_tangent; return ddsdde array or None."""
+    if method == "numerical_newton":
+        return None
+    ddsdde = model.user_defined_tangent(rm.stress, rm.state, rm.dlambda, C, state_n)
+    if ddsdde is not None:
+        return ddsdde
+    if method == "user_defined":
+        raise NotImplementedError(
+            f"{type(model).__name__} does not implement user_defined_tangent; "
+            "cannot use method='user_defined'."
+        )
+    return None
 
 
 @dataclass
@@ -167,64 +221,6 @@ class StressUpdateResult:
         return self.return_mapping.residual_history
 
 
-def _augmented_nr(model, stress_trial, C, state_n, max_iter, tol):
-    """Newton-Raphson solver for the augmented (ntens+1+n_state) residual system.
-
-    Used when ``model.hardening_type == 'implicit'``.
-
-    Parameters
-    ----------
-    model : MaterialModel
-    stress_trial : jnp.ndarray, shape (ntens,)
-    C : jnp.ndarray, shape (ntens, ntens)
-    state_n : dict
-    max_iter : int
-    tol : float
-
-    Returns
-    -------
-    stress : jnp.ndarray, shape (ntens,)
-    state_new : dict
-    dlambda : jnp.ndarray, scalar
-    n_iterations : int
-        Number of Newton updates performed.
-    residual_history : list[float]
-        Residual norm (inf-norm) at the start of each iteration.
-    """
-    from manforge.core.residual import make_augmented_residual
-
-    ntens = model.ntens
-    residual_fn, n_state, unflatten_fn = make_augmented_residual(
-        model, stress_trial, C, state_n
-    )
-
-    flat_state_n, _ = ravel_pytree(state_n)
-    x = jnp.concatenate([stress_trial, jnp.array([0.0]), flat_state_n])
-
-    residual_history = []
-    n_iterations = 0
-    for _iteration in range(max_iter):
-        R = residual_fn(x)
-        res_norm = float(jnp.max(jnp.abs(R)))
-        residual_history.append(res_norm)
-        if res_norm < tol:
-            break
-        J = jax.jacobian(residual_fn)(x)
-        dx = jnp.linalg.solve(J, R)
-        x = x - dx
-        n_iterations += 1
-    else:
-        raise RuntimeError(
-            f"_augmented_nr: NR did not converge in {max_iter} iterations "
-            f"(||R||_inf = {float(jnp.max(jnp.abs(R))):.3e}, tol = {tol:.3e})"
-        )
-
-    stress = x[:ntens]
-    dlambda = jnp.asarray(x[ntens])
-    state_new = unflatten_fn(x[ntens + 1 :])
-    return stress, state_new, dlambda, n_iterations, residual_history
-
-
 def return_mapping(
     model,
     stress_trial: jnp.ndarray,
@@ -283,71 +279,17 @@ def return_mapping(
     ValueError
         If ``method`` is not one of the recognised values.
     """
-    if method not in ("auto", "numerical_newton", "user_defined"):
-        raise ValueError(
-            f"method must be 'auto', 'numerical_newton', or 'user_defined'; "
-            f"got {method!r}"
-        )
+    _validate_method(method)
 
-    _n_iter = 0
-    _res_hist = []
-
-    if method != "numerical_newton":
-        _result = model.user_defined_corrector(stress_trial, C, state_n)
-        if _result is not None:
-            if len(_result) == 5:
-                stress, state_new, dlambda, _n_iter, _res_hist = _result
-            else:
-                stress, state_new, dlambda = _result
-            return ReturnMappingResult(
-                stress=stress,
-                state=state_new,
-                dlambda=dlambda,
-                n_iterations=_n_iter,
-                residual_history=_res_hist,
-            )
-        if method == "user_defined":
-            raise NotImplementedError(
-                f"{type(model).__name__} does not implement user_defined_corrector; "
-                "cannot use method='user_defined'."
-            )
+    rm = _try_user_corrector(model, stress_trial, C, state_n, method)
+    if rm is not None:
+        return rm
 
     # numerical_newton path
-    if model.hardening_type == "implicit":
-        stress, state_new, dlambda, _n_iter, _res_hist = _augmented_nr(
-            model, stress_trial, C, state_n, max_iter, tol
-        )
-    else:
-        dlambda = jnp.array(0.0)
-        stress = stress_trial
-        state_new = state_n
-
-        for _iteration in range(max_iter):
-            state_new = model.hardening_increment(dlambda, stress, state_n)
-            n = jax.grad(lambda s: model.yield_function(s, state_new))(stress)
-            stress = stress_trial - dlambda * (C @ n)
-            state_new = model.hardening_increment(dlambda, stress, state_n)
-            f = model.yield_function(stress, state_new)
-            _res_hist.append(float(jnp.abs(f)))
-
-            if jnp.abs(f) < tol:
-                break
-
-            def _f_residual(dl, _stress=stress):
-                st = model.hardening_increment(dl, _stress, state_n)
-                nn = jax.grad(lambda s: model.yield_function(s, st))(_stress)
-                s_upd = stress_trial - dl * (C @ nn)
-                return model.yield_function(s_upd, st)
-
-            dfddl = jax.grad(_f_residual)(dlambda)
-            dlambda = dlambda - f / dfddl
-            _n_iter += 1
-
-        else:
-            raise RuntimeError(
-                f"return_mapping: NR did not converge in {max_iter} iterations "
-                f"(|f| = {float(jnp.abs(f)):.3e}, tol = {tol:.3e})"
-            )
+    nr = _select_nr(model)
+    stress, state_new, dlambda, _n_iter, _res_hist = nr(
+        model, stress_trial, C, state_n, max_iter, tol
+    )
 
     return ReturnMappingResult(
         stress=stress,
@@ -415,11 +357,7 @@ def stress_update(
     ValueError
         If ``method`` is not one of the recognised values.
     """
-    if method not in ("auto", "numerical_newton", "user_defined"):
-        raise ValueError(
-            f"method must be 'auto', 'numerical_newton', or 'user_defined'; "
-            f"got {method!r}"
-        )
+    _validate_method(method)
 
     # ------------------------------------------------------------------
     # Step 1 — elastic stiffness and trial stress
@@ -451,33 +389,19 @@ def stress_update(
     # ------------------------------------------------------------------
     # Step 4 — consistent tangent
     # ------------------------------------------------------------------
-    if method != "numerical_newton":
-        _ddsdde = model.user_defined_tangent(
-            rm.stress, rm.state, rm.dlambda, C, state_n
+    _ddsdde = _try_user_tangent(model, rm, stress_n, state_n, C, method)
+    if _ddsdde is not None:
+        return StressUpdateResult(
+            return_mapping=rm,
+            ddsdde=_ddsdde,
+            stress_trial=stress_trial,
+            is_plastic=True,
+            _state_n=state_n,
         )
-        if _ddsdde is not None:
-            return StressUpdateResult(
-                return_mapping=rm,
-                ddsdde=_ddsdde,
-                stress_trial=stress_trial,
-                is_plastic=True,
-                _state_n=state_n,
-            )
-        if method == "user_defined":
-            raise NotImplementedError(
-                f"{type(model).__name__} does not implement user_defined_tangent; "
-                "cannot use method='user_defined'."
-            )
 
     # Autodiff tangent
-    if model.hardening_type == "implicit":
-        ddsdde = augmented_consistent_tangent(
-            model, rm.stress, rm.state, rm.dlambda, stress_n, state_n
-        )
-    else:
-        ddsdde = consistent_tangent(
-            model, rm.stress, rm.state, rm.dlambda, stress_n, state_n
-        )
+    tangent_fn = _select_tangent(model)
+    ddsdde = tangent_fn(model, rm.stress, rm.state, rm.dlambda, stress_n, state_n)
 
     return StressUpdateResult(
         return_mapping=rm,

--- a/src/manforge/core/tangent.py
+++ b/src/manforge/core/tangent.py
@@ -25,6 +25,8 @@ import jax
 import jax.numpy as jnp
 from jax.flatten_util import ravel_pytree
 
+from manforge.core.residual import make_augmented_residual, make_explicit_residual
+
 
 def consistent_tangent(model, stress, state, dlambda, stress_n, state_n):
     """Compute the consistent (algorithmic) tangent dσ_{n+1}/dΔε.
@@ -60,20 +62,12 @@ def consistent_tangent(model, stress, state, dlambda, stress_n, state_n):
     n_conv = jax.grad(lambda s: model.yield_function(s, state))(stress)
     stress_trial = stress + dlambda * (C @ n_conv)
 
-    # --- Full coupled residual as function of x = [σ (ntens), Δλ (1)] ---
-    def _residual_vec(x):
-        sig = x[:ntens]
-        dl = x[ntens]
-        st = model.hardening_increment(dl, sig, state_n)
-        nn = jax.grad(lambda s: model.yield_function(s, st))(sig)
-        R1 = sig - stress_trial + dl * (C @ nn)
-        R2 = model.yield_function(sig, st)
-        return jnp.concatenate([R1, R2.reshape(1)])
+    residual_fn = make_explicit_residual(model, stress_trial, C, state_n)
 
     # ∂R/∂x  — JAX computes all coupling terms automatically, including
     # ∂(state)/∂σ that arises with stress-dependent hardening increments.
     x_conv = jnp.concatenate([stress, dlambda.reshape(1)])
-    A = jax.jacobian(_residual_vec)(x_conv)  # (ntens+1, ntens+1)
+    A = jax.jacobian(residual_fn)(x_conv)  # (ntens+1, ntens+1)
 
     # ∂R/∂ε  →  right-hand side  (−∂R/∂ε = [C; 0])
     rhs = jnp.vstack([C, jnp.zeros((1, ntens))])  # (ntens+1, ntens)
@@ -112,8 +106,6 @@ def augmented_consistent_tangent(model, stress, state, dlambda, stress_n, state_
     jnp.ndarray, shape (ntens, ntens)
         Consistent tangent dσ_{n+1}/dΔε.
     """
-    from manforge.core.residual import make_augmented_residual
-
     ntens = model.ntens
     C = model.elastic_stiffness()
 
@@ -139,3 +131,10 @@ def augmented_consistent_tangent(model, stress, state, dlambda, stress_n, state_
 
     # Extract dσ/dε (top ntens rows)
     return dxde[:ntens, :]
+
+
+def _select_tangent(model):
+    """Return the consistent-tangent function appropriate for *model*."""
+    if model.hardening_type == "implicit":
+        return augmented_consistent_tangent
+    return consistent_tangent


### PR DESCRIPTION
## Summary

Internal cleanup of the `stress_update` / `return_mapping` / `consistent_tangent` / `ad_jacobian_blocks` pipeline. **Public API, dataclass fields, and numerical behavior are unchanged.** All 422 tests pass.

- **Unified explicit residual builder**: extracted `make_explicit_residual` in `residual.py`, replacing three near-identical inline definitions in `tangent.py`, `jacobian.py`, and the NR loop. Analogous to the already-factored `make_augmented_residual` for the implicit path. Added `select_residual_builder(model)` dispatch helper.
- **New `solver.py` module**: `_explicit_nr` and `_augmented_nr` (moved from `stress_update.py`) with `_select_nr(model)` dispatch. The double `hardening_increment` call in `_explicit_nr` is preserved intentionally — it is a semi-implicit predictor-corrector whose behavior differs from a single-call form for stress-dependent hardening (AF/Chaboche kinematic); collapsing it shifts converged stress by ~1.9% in those models.
- **Common dispatch helpers in `stress_update.py`**: `_validate_method`, `_try_user_corrector`, `_try_user_tangent` eliminate duplicated method validation and `user_defined` hook dispatch between `return_mapping` and `stress_update`. 3-tuple/5-tuple protocol conversion is encapsulated in `_try_user_corrector`.
- **`_select_tangent(model)`** added to `tangent.py`; `stress_update.py` now delegates tangent selection to it.
- **Fixed private field access**: `jacobian.py` elastic-step branch changed from `result._state_n` to `result.state` (public property, behavior-equivalent for elastic steps).

## Test plan

- [x] `make test` — 422 tests pass
- [x] `uv run pytest tests/test_tangent_fd.py tests/test_jacobian_blocks.py tests/test_return_mapping_result.py tests/test_multidim_return_mapping.py -v` — all pass

## Notes

- `hardening_type = "explicit"/"implicit"` naming is acknowledged as misleading (both paths use NR; the real distinction is 1D-reduced vs. augmented system dimension). A follow-up PR will rename these to `"reduced"/"augmented"` as a breaking change after this refactor is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)