### PR TITLE
refactor!: rename user_defined_corrector → user_defined_return_mapping, return ReturnMappingResult

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ Stress-state base classes (choose the appropriate one):
 
 Each base provides branch-free operator methods (`_dev`, `_vonmises`, `isotropic_C`, `_I_vol`, `_I_dev`) tailored to its stress state. The `_vonmises` in `MaterialModelPS` and `MaterialModel1D` includes the missing-component correction (n_missing × p²).
 
-Optional hooks for user-supplied implementations: `user_defined_corrector(stress_trial, C, state_n)` → 3-tuple `(stress, state, dlambda)` or 5-tuple `(..., n_iterations, residual_history)`; `user_defined_tangent(stress, state, dlambda, C, state_n)` → `(ntens, ntens)` array. Both default to `None` (framework falls back to autodiff/NR).
+Optional hooks for user-supplied implementations: `user_defined_return_mapping(stress_trial, C, state_n)` → `ReturnMappingResult` or `None`; `user_defined_tangent(stress, state, dlambda, C, state_n)` → `(ntens, ntens)` array or `None`. Both default to `None` (framework falls back to autodiff/NR).
 
 The reference implementation is `src/manforge/models/j2_isotropic.py` (J2Isotropic3D, J2IsotropicPS, J2Isotropic1D).
 
@@ -76,7 +76,7 @@ The reference implementation is `src/manforge/models/j2_isotropic.py` (J2Isotrop
 - `stress_update.py`: Two-level API:
   - `stress_update(model, deps, stress_n, state_n, method="auto")` → `StressUpdateResult` — full constitutive integration (elastic trial → yield check → return mapping → consistent tangent). Equivalent to one UMAT call.
   - `return_mapping(model, stress_trial, C, state_n, method="auto")` → `ReturnMappingResult` — plastic correction only (closest point projection). Dispatches on `model.hardening_type`: `"reduced"` → scalar NR on Δλ; `"augmented"` → (ntens+1+n_state) vector NR (max 50 iter, tol=1e-10).
-  - `method` values: `"auto"` (use `user_defined_corrector` if present, else `"numerical_newton"`), `"numerical_newton"` (framework NR), `"user_defined"` (requires model to implement `user_defined_corrector`).
+  - `method` values: `"auto"` (use `user_defined_return_mapping` if present, else `"numerical_newton"`), `"numerical_newton"` (framework NR), `"user_defined"` (requires model to implement `user_defined_return_mapping`).
   - `ReturnMappingResult` fields: `stress`, `state`, `dlambda`, `n_iterations`, `residual_history`.
   - `StressUpdateResult` fields: `return_mapping` (None for elastic), `ddsdde`, `stress_trial`, `is_plastic`. Convenience properties `stress`, `state`, `dlambda`, `n_iterations`, `residual_history` delegate to `return_mapping` (or elastic defaults).
 - `jacobian.py`: `JacobianBlocks` dataclass and `ad_jacobian_blocks(model, result, state_n)` — computes the residual Jacobian at the converged point via `jax.jacobian` and decomposes it into named blocks (`dstress_dsigma`, `dyield_dsigma`, `dstate_dstate`, etc.). For augmented models, state blocks are keyed by variable name (e.g. `jac.dstate_dsigma["alpha"]`). Accepts both `StressUpdateResult` and `ReturnMappingResult`. Used for step-by-step verification of analytical derivatives.

--- a/examples/example_verify_j2_analytical.py
+++ b/examples/example_verify_j2_analytical.py
@@ -3,7 +3,7 @@
 Demonstrates the step-by-step workflow for verifying closed-form solutions:
 
 1. Run stress_update (numerical_newton) to get the numerical reference
-2. Call user_defined_corrector / user_defined_tangent to get analytical results
+2. Call user_defined_return_mapping / user_defined_tangent to get analytical results
 3. Compare element-by-element with numpy.testing
 4. Use ad_jacobian_blocks to inspect individual derivative blocks
 
@@ -77,12 +77,10 @@ print("  stress_trial    : PASS")
 print()
 
 # You can also call the hooks directly:
-stress_new, state_new, dlambda = model.user_defined_corrector(
-    result_ad.stress_trial, C, state0
-)
-npt.assert_allclose(result_ad.stress, stress_new, rtol=1e-10)
-npt.assert_allclose(result_ad.dlambda, dlambda, rtol=1e-10)
-print("  user_defined_corrector (direct call): PASS")
+rm_an = model.user_defined_return_mapping(result_ad.stress_trial, C, state0)
+npt.assert_allclose(result_ad.stress, rm_an.stress, rtol=1e-10)
+npt.assert_allclose(result_ad.dlambda, rm_an.dlambda, rtol=1e-10)
+print("  user_defined_return_mapping (direct call): PASS")
 
 ddsdde_an = model.user_defined_tangent(
     result_ad.stress, result_ad.state, result_ad.dlambda, C, state0
@@ -165,13 +163,11 @@ step_idx = first_plastic + 5  # a few steps into plastic regime
 rm = driver_result.step_results[step_idx]
 state_prev = driver_result.step_results[step_idx - 1].state
 
-# Call user_defined_corrector with the same inputs
-stress_an, state_an, dlambda_an = model.user_defined_corrector(
-    rm.stress_trial, C, state_prev
-)
-npt.assert_allclose(rm.stress, stress_an, rtol=1e-10)
-npt.assert_allclose(rm.dlambda, dlambda_an, rtol=1e-10)
-print(f"  Step {step_idx} user_defined_corrector: PASS")
+# Call user_defined_return_mapping with the same inputs
+rm_an = model.user_defined_return_mapping(rm.stress_trial, C, state_prev)
+npt.assert_allclose(rm.stress, rm_an.stress, rtol=1e-10)
+npt.assert_allclose(rm.dlambda, rm_an.dlambda, rtol=1e-10)
+print(f"  Step {step_idx} user_defined_return_mapping: PASS")
 
 # Call user_defined_tangent
 ddsdde_an = model.user_defined_tangent(

--- a/src/manforge/core/material.py
+++ b/src/manforge/core/material.py
@@ -320,13 +320,13 @@ class MaterialModel(ABC):
         sq_norm = jnp.dot(s_m, s_m) + self.stress_state.n_missing * p ** 2
         return smooth_sqrt(1.5 * sq_norm)
 
-    def user_defined_corrector(
+    def user_defined_return_mapping(
         self,
         stress_trial: jnp.ndarray,
         C: jnp.ndarray,
         state_n: dict,
     ):
-        """User-supplied return mapping corrector (optional).
+        """User-supplied return mapping (optional).
 
         Override to provide a model-specific plastic correction algorithm.
         The implementation may use any solver internally — closed-form
@@ -346,16 +346,13 @@ class MaterialModel(ABC):
         Returns
         -------
         None
-            Signals that no user-defined corrector is available; the
+            Signals that no user-defined return mapping is available; the
             framework falls back to ``numerical_newton``.
-        tuple[jnp.ndarray, dict, jnp.ndarray]
-            ``(stress_new, state_new, dlambda)`` — converged stress,
-            updated state dict, and plastic multiplier increment Δλ.
-        tuple[jnp.ndarray, dict, jnp.ndarray, int, list]
-            ``(stress_new, state_new, dlambda, n_iterations, residual_history)``
-            — same as above plus the iteration count and residual-norm history
-            from the corrector's internal solver, which are stored in the
-            returned :class:`~manforge.core.stress_update.ReturnMappingResult`.
+        ReturnMappingResult
+            Converged result with fields ``stress``, ``state``, ``dlambda``,
+            ``n_iterations`` (default 0 for closed-form solvers), and
+            ``residual_history`` (default ``[]`` for closed-form solvers).
+            Import via ``from manforge.core import ReturnMappingResult``.
         """
         return None
 

--- a/src/manforge/core/stress_update.py
+++ b/src/manforge/core/stress_update.py
@@ -25,8 +25,8 @@ Algorithm (stress_update)
      (reduced hardening), or augmented (ntens+1+n_state) vector NR (augmented).
 
    *user_defined*  (model-supplied, opt-in)
-     Calls ``model.user_defined_corrector(σ_trial, C, state_n)`` if the model
-     provides one.  The corrector may use any algorithm internally (closed-form,
+     Calls ``model.user_defined_return_mapping(σ_trial, C, state_n)`` if the
+     model provides one.  May use any algorithm internally (closed-form,
      custom NR, etc.).
 
 4. Consistent tangent — path selected by ``method``:
@@ -76,31 +76,20 @@ def _validate_method(method: str) -> None:
         )
 
 
-def _try_user_corrector(model, stress_trial, C, state_n, method):
-    """Attempt user_defined_corrector; return ReturnMappingResult or None.
+def _try_user_return_mapping(model, stress_trial, C, state_n, method):
+    """Attempt user_defined_return_mapping; return ReturnMappingResult or None.
 
-    Returns None when method='auto' and the model has no corrector hook.
+    Returns None when method='auto' and the model has no return mapping hook.
     Raises NotImplementedError when method='user_defined' and hook is absent.
     """
     if method == "numerical_newton":
         return None
-    _result = model.user_defined_corrector(stress_trial, C, state_n)
-    if _result is not None:
-        if len(_result) == 5:
-            stress, state_new, dlambda, n_iter, res_hist = _result
-        else:
-            stress, state_new, dlambda = _result
-            n_iter, res_hist = 0, []
-        return ReturnMappingResult(
-            stress=stress,
-            state=state_new,
-            dlambda=dlambda,
-            n_iterations=n_iter,
-            residual_history=res_hist,
-        )
+    rm = model.user_defined_return_mapping(stress_trial, C, state_n)
+    if rm is not None:
+        return rm
     if method == "user_defined":
         raise NotImplementedError(
-            f"{type(model).__name__} does not implement user_defined_corrector; "
+            f"{type(model).__name__} does not implement user_defined_return_mapping; "
             "cannot use method='user_defined'."
         )
     return None
@@ -251,13 +240,13 @@ def return_mapping(
     method : {"auto", "numerical_newton", "user_defined"}, optional
         Solver strategy.
 
-        * ``"auto"``             — use ``model.user_defined_corrector`` if
-                                   available, else ``"numerical_newton"``
+        * ``"auto"``             — use ``model.user_defined_return_mapping``
+                                   if available, else ``"numerical_newton"``
                                    (default).
         * ``"numerical_newton"`` — framework generic NR solver (explicit:
                                    scalar NR on Δλ; implicit: augmented
                                    vector NR).
-        * ``"user_defined"``     — require ``model.user_defined_corrector``;
+        * ``"user_defined"``     — require ``model.user_defined_return_mapping``;
                                    raise ``NotImplementedError`` if absent.
     max_iter : int, optional
         Maximum Newton iterations (default 50, ``numerical_newton`` only).
@@ -275,13 +264,13 @@ def return_mapping(
         If the NR iteration does not converge within ``max_iter`` steps.
     NotImplementedError
         If ``method="user_defined"`` and the model does not implement
-        ``user_defined_corrector``.
+        ``user_defined_return_mapping``.
     ValueError
         If ``method`` is not one of the recognised values.
     """
     _validate_method(method)
 
-    rm = _try_user_corrector(model, stress_trial, C, state_n, method)
+    rm = _try_user_return_mapping(model, stress_trial, C, state_n, method)
     if rm is not None:
         return rm
 

--- a/src/manforge/models/af_kinematic.py
+++ b/src/manforge/models/af_kinematic.py
@@ -39,7 +39,7 @@ Notes
 -----
 * gamma=0 reduces to Prager's linear kinematic hardening rule with modulus C_k.
 * The saturated backstress magnitude under monotonic loading is C_k / gamma.
-* No user_defined_corrector or user_defined_tangent is provided; the
+* No user_defined_return_mapping or user_defined_tangent is provided; the
   generic numerical_newton + JAX autodiff path is used, which is exactly what
   this model is designed to test.
 """

--- a/src/manforge/models/j2_isotropic.py
+++ b/src/manforge/models/j2_isotropic.py
@@ -26,6 +26,7 @@ import jax.numpy as jnp
 
 from manforge.core.material import MaterialModel3D, MaterialModelPS, MaterialModel1D
 from manforge.core.stress_state import SOLID_3D, PLANE_STRESS, UNIAXIAL_1D, StressState
+from manforge.core.stress_update import ReturnMappingResult
 
 
 class J2Isotropic3D(MaterialModel3D):
@@ -100,7 +101,7 @@ class J2Isotropic3D(MaterialModel3D):
     # Analytical solver hooks
     # ------------------------------------------------------------------
 
-    def user_defined_corrector(self, stress_trial, C, state_n):
+    def user_defined_return_mapping(self, stress_trial, C, state_n):
         """J2 radial return — closed-form plastic correction.
 
         Notes
@@ -118,8 +119,7 @@ class J2Isotropic3D(MaterialModel3D):
 
         Returns
         -------
-        tuple[jnp.ndarray, dict, jnp.ndarray]
-            ``(stress_new, state_new, dlambda)``
+        ReturnMappingResult
         """
         mu = self.E / (2.0 * (1.0 + self.nu))
         ep_n = state_n["ep"]
@@ -134,7 +134,11 @@ class J2Isotropic3D(MaterialModel3D):
         # Radial return: σ_new = σ_trial − (3μΔλ/σ_vm) s_trial
         stress_new = stress_trial - (3.0 * mu * dlambda / sigma_vm_trial) * s_trial
 
-        return stress_new, {"ep": ep_n + dlambda}, jnp.asarray(dlambda)
+        return ReturnMappingResult(
+            stress=stress_new,
+            state={"ep": ep_n + dlambda},
+            dlambda=jnp.asarray(dlambda),
+        )
 
     def user_defined_tangent(self, stress, state, dlambda, C, state_n):
         """J2 algorithmic consistent tangent — closed-form (de Souza Neto).
@@ -286,7 +290,7 @@ class J2Isotropic1D(MaterialModel1D):
     # Analytical solver hooks
     # ------------------------------------------------------------------
 
-    def user_defined_corrector(self, stress_trial, C, state_n):
+    def user_defined_return_mapping(self, stress_trial, C, state_n):
         """1D J2 radial return — closed-form.
 
         Δλ = (|σ_trial| − σ_y) / (E + H)
@@ -300,7 +304,7 @@ class J2Isotropic1D(MaterialModel1D):
 
         Returns
         -------
-        tuple[jnp.ndarray, dict, jnp.ndarray]
+        ReturnMappingResult
         """
         E = C[0, 0]
         ep_n = state_n["ep"]
@@ -309,7 +313,11 @@ class J2Isotropic1D(MaterialModel1D):
         dlambda = (sigma_vm_trial - sigma_y) / (E + self.H)
         n = stress_trial / sigma_vm_trial  # sign(σ_trial) as length-1 array
         stress_new = stress_trial - E * dlambda * n
-        return stress_new, {"ep": ep_n + dlambda}, jnp.asarray(dlambda)
+        return ReturnMappingResult(
+            stress=stress_new,
+            state={"ep": ep_n + dlambda},
+            dlambda=jnp.asarray(dlambda),
+        )
 
     def user_defined_tangent(self, stress, state, dlambda, C, state_n):
         """1D consistent tangent D^ep = [[E · H / (E + H)]].

--- a/tests/integration/test_analytical_j2.py
+++ b/tests/integration/test_analytical_j2.py
@@ -47,18 +47,16 @@ def test_plastic_corrector_standalone_plastic(model):
     stress_trial = C @ strain_inc
     state_n = model.initial_state()
 
-    result = model.user_defined_corrector(stress_trial, C, state_n)
-    assert result is not None, "plastic_corrector should return a result for plastic step"
-
-    stress_new, state_new, dlambda = result
+    rm = model.user_defined_return_mapping(stress_trial, C, state_n)
+    assert rm is not None, "plastic_corrector should return a result for plastic step"
 
     # Yield consistency: f(σ_new, state_new) ≈ 0
-    f_final = model.yield_function(stress_new, state_new)
+    f_final = model.yield_function(rm.stress, rm.state)
     assert abs(float(f_final)) < 1e-8, f"|f| = {float(abs(f_final)):.3e}"
 
     # State update: ep_new = ep_n + dlambda
     ep_n = float(state_n["ep"])
-    assert abs(float(state_new["ep"]) - (ep_n + float(dlambda))) < 1e-12
+    assert abs(float(rm.state["ep"]) - (ep_n + float(rm.dlambda))) < 1e-12
 
 
 def test_plastic_corrector_dlambda_positive(model):
@@ -68,8 +66,8 @@ def test_plastic_corrector_dlambda_positive(model):
     stress_trial = C @ strain_inc
     state_n = model.initial_state()
 
-    _, _, dlambda = model.user_defined_corrector(stress_trial, C, state_n)
-    assert float(dlambda) > 0.0
+    rm = model.user_defined_return_mapping(stress_trial, C, state_n)
+    assert float(rm.dlambda) > 0.0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `user_defined_corrector` を `user_defined_return_mapping` にリネーム — 実装内容 (return mapping 全体) と名前を一致させ、`return_mapping()` 関数との整合性を確保
- 返り値を 3-tuple / 5-tuple から `ReturnMappingResult` に統一 — フィールド名で契約が自己文書化される
- フレームワーク側の `len(_result) == 5` 分岐と `(0, [])` パディングを削除してシンプル化

## Test plan

- [x] `make test-unit` — 193 passed
- [x] `make test-integration` — 174 passed
- [x] `uv run python examples/example_verify_j2_analytical.py` — all verifications passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)