### PR TITLE
fix: J2 user_defined residual history + augmented NR L2 norm

### DIFF
--- a/src/manforge/core/solver.py
+++ b/src/manforge/core/solver.py
@@ -66,7 +66,7 @@ def _augmented_nr(model, stress_trial, C, state_n, max_iter, tol):
     n_iterations = 0
     for _iteration in range(max_iter):
         R = residual_fn(x)
-        res_norm = float(np.max(np.abs(np.array(R))))
+        res_norm = float(np.linalg.norm(np.array(R)))
         residual_history.append(res_norm)
         if res_norm < tol:
             break
@@ -77,7 +77,7 @@ def _augmented_nr(model, stress_trial, C, state_n, max_iter, tol):
     else:
         raise RuntimeError(
             f"_augmented_nr: NR did not converge in {max_iter} iterations "
-            f"(||R||_inf = {float(np.max(np.abs(np.array(R)))):.3e}, tol = {tol:.3e})"
+            f"(||R||_2 = {float(np.linalg.norm(np.array(R))):.3e}, tol = {tol:.3e})"
         )
 
     stress = x[:ntens]

--- a/src/manforge/core/stress_update.py
+++ b/src/manforge/core/stress_update.py
@@ -126,16 +126,17 @@ class ReturnMappingResult:
     dlambda : anp.ndarray, scalar
         Plastic multiplier increment Δλ.
     n_iterations : int
-        Number of Newton updates performed by the framework's numerical solver.
-        Zero when ``method="user_defined"`` (the model's own corrector is
-        responsible for convergence tracking).
+        Number of Newton updates performed.  For ``numerical_newton`` plastic
+        steps this equals the number of NR updates (J2 linear hardening
+        converges in exactly 1).  For closed-form ``user_defined`` correctors
+        the recommended convention is ``1`` (one closed-form solve).
     residual_history : list[float]
-        Residual norm recorded at the start of each NR iteration by the
-        framework's numerical solver.  For ``method="numerical_newton"``
-        plastic steps ``len(residual_history) == n_iterations + 1`` (initial
-        residual plus one entry after each Newton update; the last entry is the
-        converged residual below ``tol``).  Empty when ``method="user_defined"``
-        unless the corrector returns a 5-tuple with its own history.
+        Residual norms.  The convention for both paths is
+        ``len(residual_history) == n_iterations + 1``: initial residual at
+        index 0, then one entry per update, with the final entry being the
+        converged residual (< ``tol`` for ``numerical_newton``, 0.0 for
+        closed-form ``user_defined``).  Closed-form implementations should
+        therefore supply ``[float(f_trial), 0.0]``.
     """
 
     stress: anp.ndarray

--- a/src/manforge/models/j2_isotropic.py
+++ b/src/manforge/models/j2_isotropic.py
@@ -128,9 +128,10 @@ class J2Isotropic3D(MaterialModel3D):
         sigma_y = self.sigma_y0 + self.H * ep_n
         s_trial = self._dev(stress_trial)
         sigma_vm_trial = self._vonmises(stress_trial)
+        f_trial = sigma_vm_trial - sigma_y  # > 0 (caller ensures plasticity)
 
-        # Δλ = (σ_vm_trial − σ_y) / (3μ + H)
-        dlambda = (sigma_vm_trial - sigma_y) / (3.0 * mu + self.H)
+        # Δλ = f_trial / (3μ + H)
+        dlambda = f_trial / (3.0 * mu + self.H)
 
         # Radial return: σ_new = σ_trial − (3μΔλ/σ_vm) s_trial
         stress_new = stress_trial - (3.0 * mu * dlambda / sigma_vm_trial) * s_trial
@@ -139,6 +140,8 @@ class J2Isotropic3D(MaterialModel3D):
             stress=stress_new,
             state={"ep": ep_n + dlambda},
             dlambda=anp.asarray(dlambda),
+            n_iterations=1,
+            residual_history=[float(f_trial), 0.0],
         )
 
     def user_defined_tangent(self, stress, state, dlambda, C, state_n):
@@ -311,13 +314,16 @@ class J2Isotropic1D(MaterialModel1D):
         ep_n = state_n["ep"]
         sigma_y = self.sigma_y0 + self.H * ep_n
         sigma_vm_trial = anp.abs(stress_trial[0])
-        dlambda = (sigma_vm_trial - sigma_y) / (E + self.H)
+        f_trial = sigma_vm_trial - sigma_y  # > 0 (caller ensures plasticity)
+        dlambda = f_trial / (E + self.H)
         n = stress_trial / sigma_vm_trial  # sign(σ_trial) as length-1 array
         stress_new = stress_trial - E * dlambda * n
         return ReturnMappingResult(
             stress=stress_new,
             state={"ep": ep_n + dlambda},
             dlambda=anp.asarray(dlambda),
+            n_iterations=1,
+            residual_history=[float(f_trial), 0.0],
         )
 
     def user_defined_tangent(self, stress, state, dlambda, C, state_n):

--- a/tests/integration/test_convergence_history.py
+++ b/tests/integration/test_convergence_history.py
@@ -38,13 +38,14 @@ def test_elastic_step_no_history(j2_model):
 # Analytical path: closed-form, no NR
 # ---------------------------------------------------------------------------
 
-def test_analytical_path_no_history(j2_model):
+def test_analytical_path_history(j2_model):
     deps = anp.array([3e-3, 0.0, 0.0, 0.0, 0.0, 0.0])
     result = stress_update(j2_model, deps, anp.zeros(6), j2_model.initial_state(),
                             method="user_defined")
     assert result.is_plastic is True
-    assert result.n_iterations == 0
-    assert result.residual_history == []
+    assert result.n_iterations == 1
+    assert len(result.residual_history) == 2
+    assert result.residual_history[-1] == 0.0
 
 
 # ---------------------------------------------------------------------------
@@ -127,15 +128,20 @@ def test_augmented_nr_quadratic_convergence(ow_model):
 # StrainDriver integration: access history via step_results
 # ---------------------------------------------------------------------------
 
-def test_driver_j2_analytical_no_history(j2_model):
-    """J2 uses analytical plastic_corrector by default: NR history is empty."""
+def test_driver_j2_analytical_history(j2_model):
+    """J2 user_defined_return_mapping records n_iterations=1 and 2-entry history."""
     driver = StrainDriver()
     load = FieldHistory(FieldType.STRAIN, "Strain", np.linspace(0.0, 5e-3, 20))
     dr = driver.run(j2_model, load)
 
     for rm in dr.step_results:
-        assert rm.n_iterations == 0
-        assert rm.residual_history == []
+        if rm.is_plastic:
+            assert rm.n_iterations == 1
+            assert len(rm.residual_history) == 2
+            assert rm.residual_history[-1] == 0.0
+        else:
+            assert rm.n_iterations == 0
+            assert rm.residual_history == []
 
 
 def test_driver_j2_autodiff_has_history(j2_model):


### PR DESCRIPTION
## Summary

#29 マージ後に追加した 2 コミットを main に取り込む。

- **J2 参照実装に n_iterations/residual_history を明示**: `user_defined_return_mapping` は参照実装であり、モデル作成者のテンプレとして読まれる。`n_iterations=1`・`residual_history=[f_trial, 0.0]` を省略せず記載し、`len(residual_history) == n_iterations + 1` の規約と整合させた。`ReturnMappingResult` docstring にも closed-form 向け推奨規約を追記。
- **augmented NR の residual norm を L∞ → L2 に修正**: NR 反復の収束判定には L2 (二乗和平方根) が慣例。stress / dlambda / state が混在するベクトル全体の「大きさ」を測る指標として L2 が自然。エラーメッセージも `||R||_inf` → `||R||_2` に更新。

## Test plan

- [x] `make test` — 366 passed, 30 deselected

🤖 Generated with [Claude Code](https://claude.com/claude-code)