### PR TITLE
refactor!: compare_solvers を StressUpdateResult 前提に再設計 + compare_jacobians 追加 (Phase 0)

### DIFF
--- a/src/manforge/simulation/driver.py
+++ b/src/manforge/simulation/driver.py
@@ -189,6 +189,7 @@ class StressDriver(DriverBase):
         model,
         load: FieldHistory,
         collect_state: dict[str, FieldType] | None = None,
+        method: str = "auto",
     ) -> DriverResult:
         """Run the stress-controlled loading history.
 
@@ -204,6 +205,10 @@ class StressDriver(DriverBase):
             State variables to include in the result.  Example::
 
                 collect_state={"ep": FieldType.STRAIN}
+
+        method : {"auto", "numerical_newton", "user_defined"}, optional
+            Passed to :func:`~manforge.core.stress_update.stress_update`
+            at every inner iteration (default ``"auto"``).
 
         Returns
         -------
@@ -242,7 +247,7 @@ class StressDriver(DriverBase):
             residual = np.full(ntens, np.inf)
             rm = None
             for _ in range(self.max_iter):
-                rm = stress_update(model, deps, stress_n, state_n)
+                rm = stress_update(model, deps, stress_n, state_n, method=method)
                 residual = sigma_target - np.array(rm.stress)
                 if float(np.max(np.abs(residual))) < self.tol:
                     converged = True

--- a/src/manforge/verification/__init__.py
+++ b/src/manforge/verification/__init__.py
@@ -1,6 +1,11 @@
 """Verification utilities for constitutive model validation."""
 
-from manforge.verification.compare import compare_solvers, SolverComparisonResult
+from manforge.verification.compare import (
+    compare_solvers,
+    SolverComparisonResult,
+    compare_jacobians,
+    JacobianComparisonResult,
+)
 from manforge.verification.fd_check import check_tangent, TangentCheckResult
 from manforge.verification.fortran_bridge import FortranUMAT
 from manforge.verification.test_cases import (
@@ -12,6 +17,8 @@ from manforge.verification.test_cases import (
 __all__ = [
     "compare_solvers",
     "SolverComparisonResult",
+    "compare_jacobians",
+    "JacobianComparisonResult",
     "check_tangent",
     "TangentCheckResult",
     "FortranUMAT",

--- a/src/manforge/verification/compare.py
+++ b/src/manforge/verification/compare.py
@@ -1,19 +1,23 @@
-"""Generic solver-vs-solver comparison utility.
+"""Generic solver-vs-solver and Jacobian comparison utilities.
 
-Provides :func:`compare_solvers`, which compares two callable solvers
-across a set of strain-increment test cases and reports element-wise
-relative errors in stress and tangent.
+Provides :func:`compare_solvers` and :func:`compare_jacobians` for
+verifying that two constitutive-model implementations agree.
 
 A *solver* is any callable with the signature::
 
-    solver(strain_inc, stress_n, state_n)
-        -> (stress_new, state_new, ddsdde)
+    solver(model, strain_inc, stress_n, state_n) -> StressUpdateResult
 """
 
 from dataclasses import dataclass, field
 
 import numpy as np
 
+_EPS = 1e-300  # zero-division guard — no physical meaning
+
+
+# ---------------------------------------------------------------------------
+# compare_solvers
+# ---------------------------------------------------------------------------
 
 @dataclass
 class SolverComparisonResult:
@@ -31,9 +35,20 @@ class SolverComparisonResult:
         Maximum relative stress error across all cases.
     max_tangent_rel_err : float
         Maximum relative tangent error across all cases.
+    max_state_rel_err : dict[str, float]
+        Per state-variable maximum relative error across all cases.
+    max_trial_rel_err : float
+        Maximum relative stress_trial error across all cases.
     details : list[dict]
-        Per-case records with keys ``"case_index"``, ``"stress_rel_err"``,
-        ``"tangent_rel_err"``, ``"passed"``.
+        Per-case records.  Each dict contains:
+
+        ``"case_index"``, ``"stress_rel_err"``, ``"tangent_rel_err"``,
+        ``"state_rel_err"`` (dict), ``"trial_rel_err"``,
+        ``"is_plastic_match"``, ``"elastic_branch_match"``, ``"passed"``.
+
+        Optional keys (when requested): ``"n_iterations_a"``,
+        ``"n_iterations_b"``, ``"residual_history_a"``,
+        ``"residual_history_b"``.
     """
 
     passed: bool
@@ -41,24 +56,34 @@ class SolverComparisonResult:
     n_passed: int
     max_stress_rel_err: float
     max_tangent_rel_err: float
+    max_state_rel_err: dict = field(default_factory=dict)
+    max_trial_rel_err: float = 0.0
     details: list = field(default_factory=list)
 
 
 def compare_solvers(
+    model,
     solver_a,
     solver_b,
     test_cases: list,
+    *,
     stress_tol: float = 1e-6,
     tangent_tol: float = 1e-5,
-    denom_offset: float = 1.0,
+    state_tol: float = 1e-6,
+    check_state: bool = True,
+    check_residual_history: bool = False,
+    check_n_iterations: bool = False,
+    check_is_plastic: bool = True,
 ) -> SolverComparisonResult:
-    """Compare two solvers for a set of test cases.
+    """Compare two solvers across a set of test cases.
 
     Parameters
     ----------
+    model : MaterialModel
+        Constitutive model instance — passed as first argument to each solver.
     solver_a : callable
-        Reference solver: ``(strain_inc, stress_n, state_n)``
-        → ``(stress, state, ddsdde)``.
+        Reference solver: ``(model, strain_inc, stress_n, state_n)``
+        → ``StressUpdateResult``.
     solver_b : callable
         Candidate solver with the same signature.
     test_cases : list[dict]
@@ -71,8 +96,16 @@ def compare_solvers(
         Per-case pass threshold for relative stress error (default 1e-6).
     tangent_tol : float, optional
         Per-case pass threshold for relative tangent error (default 1e-5).
-    denom_offset : float, optional
-        Small additive offset in the denominator (default 1.0, suitable for MPa).
+    state_tol : float, optional
+        Per-case pass threshold for state relative error (default 1e-6).
+    check_state : bool, optional
+        Whether to include state error in pass/fail (default True).
+    check_residual_history : bool, optional
+        Include ``residual_history_a/b`` in detail records (default False).
+    check_n_iterations : bool, optional
+        Include ``n_iterations_a/b`` in detail records (default False).
+    check_is_plastic : bool, optional
+        Fail the case when ``is_plastic`` flags disagree (default True).
 
     Returns
     -------
@@ -81,6 +114,8 @@ def compare_solvers(
     details = []
     max_stress_err = 0.0
     max_tangent_err = 0.0
+    max_state_err: dict[str, float] = {}
+    max_trial_err = 0.0
     n_passed = 0
 
     for idx, case in enumerate(test_cases):
@@ -88,31 +123,64 @@ def compare_solvers(
         stress_n   = case["stress_n"]
         state_n    = case["state_n"]
 
-        stress_a, _state_a, ddsdde_a = solver_a(strain_inc, stress_n, state_n)
-        stress_b, _state_b, ddsdde_b = solver_b(strain_inc, stress_n, state_n)
+        ra = solver_a(model, strain_inc, stress_n, state_n)
+        rb = solver_b(model, strain_inc, stress_n, state_n)
 
-        stress_a  = np.asarray(stress_a,  dtype=float)
-        stress_b  = np.asarray(stress_b,  dtype=float)
-        ddsdde_a  = np.asarray(ddsdde_a,  dtype=float)
-        ddsdde_b  = np.asarray(ddsdde_b,  dtype=float)
+        stress_a  = np.asarray(ra.stress,  dtype=float)
+        stress_b  = np.asarray(rb.stress,  dtype=float)
+        ddsdde_a  = np.asarray(ra.ddsdde,  dtype=float)
+        ddsdde_b  = np.asarray(rb.ddsdde,  dtype=float)
+        trial_a   = np.asarray(ra.stress_trial, dtype=float)
+        trial_b   = np.asarray(rb.stress_trial, dtype=float)
 
-        s_denom = np.abs(stress_a)  + denom_offset
-        t_denom = np.abs(ddsdde_a)  + denom_offset
+        stress_rel_err  = float(np.max(np.abs(stress_b  - stress_a)  / (np.abs(stress_a)  + _EPS)))
+        tangent_rel_err = float(np.max(np.abs(ddsdde_b  - ddsdde_a)  / (np.abs(ddsdde_a)  + _EPS)))
+        trial_rel_err   = float(np.max(np.abs(trial_b   - trial_a)   / (np.abs(trial_a)   + _EPS)))
 
-        stress_rel_err  = float(np.max(np.abs(stress_b  - stress_a)  / s_denom))
-        tangent_rel_err = float(np.max(np.abs(ddsdde_b  - ddsdde_a)  / t_denom))
+        is_plastic_match    = bool(ra.is_plastic == rb.is_plastic)
+        elastic_branch_match = bool((ra.return_mapping is None) == (rb.return_mapping is None))
 
-        case_passed = (stress_rel_err <= stress_tol) and (tangent_rel_err <= tangent_tol)
+        # state comparison
+        state_rel_err: dict[str, float] = {}
+        if check_state:
+            for key in ra.state:
+                va = np.asarray(ra.state[key], dtype=float)
+                vb = np.asarray(rb.state.get(key, np.zeros_like(va)), dtype=float)
+                state_rel_err[key] = float(np.max(np.abs(vb - va) / (np.abs(va) + _EPS)))
 
-        details.append({
-            "case_index":      idx,
-            "stress_rel_err":  stress_rel_err,
-            "tangent_rel_err": tangent_rel_err,
-            "passed":          case_passed,
-        })
+        case_passed = (
+            stress_rel_err  <= stress_tol
+            and tangent_rel_err <= tangent_tol
+        )
+        if check_state and state_rel_err:
+            case_passed = case_passed and all(v <= state_tol for v in state_rel_err.values())
+        if check_is_plastic:
+            case_passed = case_passed and is_plastic_match
+
+        rec = {
+            "case_index":          idx,
+            "stress_rel_err":      stress_rel_err,
+            "tangent_rel_err":     tangent_rel_err,
+            "state_rel_err":       state_rel_err,
+            "trial_rel_err":       trial_rel_err,
+            "is_plastic_match":    is_plastic_match,
+            "elastic_branch_match": elastic_branch_match,
+            "passed":              case_passed,
+        }
+        if check_n_iterations:
+            rec["n_iterations_a"] = ra.n_iterations
+            rec["n_iterations_b"] = rb.n_iterations
+        if check_residual_history:
+            rec["residual_history_a"] = ra.residual_history
+            rec["residual_history_b"] = rb.residual_history
+
+        details.append(rec)
 
         max_stress_err  = max(max_stress_err,  stress_rel_err)
         max_tangent_err = max(max_tangent_err, tangent_rel_err)
+        max_trial_err   = max(max_trial_err,   trial_rel_err)
+        for key, val in state_rel_err.items():
+            max_state_err[key] = max(max_state_err.get(key, 0.0), val)
         if case_passed:
             n_passed += 1
 
@@ -122,5 +190,103 @@ def compare_solvers(
         n_passed=n_passed,
         max_stress_rel_err=max_stress_err,
         max_tangent_rel_err=max_tangent_err,
+        max_state_rel_err=max_state_err,
+        max_trial_rel_err=max_trial_err,
         details=details,
+    )
+
+
+# ---------------------------------------------------------------------------
+# compare_jacobians
+# ---------------------------------------------------------------------------
+
+@dataclass
+class JacobianComparisonResult:
+    """Result of comparing Jacobian blocks from two StressUpdateResults.
+
+    Attributes
+    ----------
+    passed : bool
+        ``True`` if every block is within ``rtol``.
+    blocks : dict[str, float]
+        Block name → maximum relative error.  Dict-valued blocks use
+        ``"block_name::var"`` as the key.
+    max_rel_err : float
+        Maximum relative error across all blocks.
+    """
+
+    passed: bool
+    blocks: dict
+    max_rel_err: float
+
+
+def compare_jacobians(
+    model,
+    result_a,
+    result_b,
+    state_n: dict,
+    *,
+    rtol: float = 1e-8,
+) -> JacobianComparisonResult:
+    """Compare Jacobian blocks from two StressUpdateResults.
+
+    Parameters
+    ----------
+    model : MaterialModel
+        Constitutive model instance.
+    result_a : StressUpdateResult
+        First result (e.g. from ``method="numerical_newton"``).
+    result_b : StressUpdateResult
+        Second result (e.g. from ``method="user_defined"``).
+    state_n : dict
+        Initial state at the start of the step (before the increment).
+    rtol : float, optional
+        Relative tolerance for pass/fail (default 1e-8).
+
+    Returns
+    -------
+    JacobianComparisonResult
+    """
+    from manforge.core.jacobian import ad_jacobian_blocks
+
+    jac_a = ad_jacobian_blocks(model, result_a, state_n)
+    jac_b = ad_jacobian_blocks(model, result_b, state_n)
+
+    _SCALAR_BLOCKS = [
+        "dstress_dsigma",
+        "dstress_ddlambda",
+        "dyield_dsigma",
+        "dyield_ddlambda",
+    ]
+    _DICT_BLOCKS = [
+        "dstress_dstate",
+        "dyield_dstate",
+        "dstate_dsigma",
+        "dstate_ddlambda",
+        "dstate_dstate",
+    ]
+
+    block_errs: dict[str, float] = {}
+
+    for name in _SCALAR_BLOCKS:
+        va = np.asarray(getattr(jac_a, name), dtype=float)
+        vb = np.asarray(getattr(jac_b, name), dtype=float)
+        block_errs[name] = float(np.max(np.abs(vb - va) / (np.abs(va) + _EPS)))
+
+    for name in _DICT_BLOCKS:
+        da = getattr(jac_a, name)
+        db = getattr(jac_b, name)
+        if da is None or db is None:
+            continue
+        for key in da:
+            va = np.asarray(da[key], dtype=float)
+            vb = np.asarray(db.get(key, np.zeros_like(va)), dtype=float)
+            block_errs[f"{name}::{key}"] = float(np.max(np.abs(vb - va) / (np.abs(va) + _EPS)))
+
+    max_err = max(block_errs.values()) if block_errs else 0.0
+
+    return JacobianComparisonResult(
+        passed=max_err <= rtol,
+        blocks=block_errs,
+        max_rel_err=max_err,
     )

--- a/tests/fortran/test_compare_solvers.py
+++ b/tests/fortran/test_compare_solvers.py
@@ -7,25 +7,26 @@ Covers:
 - compare_solvers works with mixed plastic/elastic test cases
 """
 
+import dataclasses
+
 import autograd.numpy as anp
 import numpy as np
 import pytest
 
-from manforge.core.stress_update import stress_update
+from manforge.core.stress_update import stress_update, StressUpdateResult
 from manforge.verification.compare import compare_solvers, SolverComparisonResult
 
 
-def _make_solver(model, method):
-    """Return a SolverFn bound to the given model and method."""
-    def _solve(strain_inc, stress_n, state_n):
-        _r = stress_update(
+def _make_solver(method):
+    """Return a solver callable bound to the given method."""
+    def _solve(model, strain_inc, stress_n, state_n):
+        return stress_update(
             model,
             anp.asarray(strain_inc),
             anp.asarray(stress_n),
             state_n,
             method=method,
         )
-        return _r.stress, _r.state, _r.ddsdde
     return _solve
 
 
@@ -67,8 +68,8 @@ def test_cases(model):
 
 def test_identical_solvers_pass(model, test_cases):
     """Comparing a solver to itself gives zero error and passes."""
-    solver = _make_solver(model, "numerical_newton")
-    result = compare_solvers(solver, solver, test_cases)
+    solver = _make_solver("numerical_newton")
+    result = compare_solvers(model, solver, solver, test_cases)
 
     assert isinstance(result, SolverComparisonResult)
     assert result.passed
@@ -84,10 +85,10 @@ def test_identical_solvers_pass(model, test_cases):
 
 def test_autodiff_vs_analytical_pass(model, test_cases):
     """autodiff and analytical solvers must agree within default tolerances."""
-    solver_ad = _make_solver(model, "numerical_newton")
-    solver_an = _make_solver(model, "user_defined")
+    solver_ad = _make_solver("numerical_newton")
+    solver_an = _make_solver("user_defined")
 
-    result = compare_solvers(solver_ad, solver_an, test_cases)
+    result = compare_solvers(model, solver_ad, solver_an, test_cases)
 
     assert result.passed, (
         f"Solvers disagree: max_stress_err={result.max_stress_rel_err:.3e}, "
@@ -104,16 +105,19 @@ def test_autodiff_vs_analytical_pass(model, test_cases):
 
 def test_wrong_solver_fails(model, test_cases):
     """A solver that returns wrong stress must be flagged as failed."""
-    solver_ad = _make_solver(model, "numerical_newton")
+    solver_ad = _make_solver("numerical_newton")
 
-    def bad_solver(strain_inc, stress_n, state_n):
-        _r = stress_update(
+    def bad_solver(model, strain_inc, stress_n, state_n):
+        r = stress_update(
             model, anp.asarray(strain_inc), anp.asarray(stress_n),
             state_n, method="numerical_newton"
         )
-        return _r.stress * 1.1, _r.state, _r.ddsdde  # 10% error in stress
+        if r.return_mapping is not None:
+            bad_rm = dataclasses.replace(r.return_mapping, stress=r.return_mapping.stress * 1.1)
+            return dataclasses.replace(r, return_mapping=bad_rm)
+        return r
 
-    result = compare_solvers(solver_ad, bad_solver, test_cases, stress_tol=1e-6)
+    result = compare_solvers(model, solver_ad, bad_solver, test_cases, stress_tol=1e-6)
 
     # At least the plastic cases should fail
     assert not result.passed
@@ -126,26 +130,28 @@ def test_wrong_solver_fails(model, test_cases):
 
 def test_result_details_length(model, test_cases):
     """details list length equals the number of test cases."""
-    solver = _make_solver(model, "numerical_newton")
-    result = compare_solvers(solver, solver, test_cases)
+    solver = _make_solver("numerical_newton")
+    result = compare_solvers(model, solver, solver, test_cases)
     assert len(result.details) == len(test_cases)
 
 
 def test_result_details_keys(model, test_cases):
     """Each detail record has the required keys."""
-    solver = _make_solver(model, "numerical_newton")
-    result = compare_solvers(solver, solver, test_cases)
+    solver = _make_solver("numerical_newton")
+    result = compare_solvers(model, solver, solver, test_cases)
+    required = {
+        "case_index", "stress_rel_err", "tangent_rel_err",
+        "state_rel_err", "trial_rel_err",
+        "is_plastic_match", "elastic_branch_match", "passed",
+    }
     for d in result.details:
-        assert "case_index"      in d
-        assert "stress_rel_err"  in d
-        assert "tangent_rel_err" in d
-        assert "passed"          in d
+        assert required <= d.keys()
 
 
 def test_empty_test_cases(model):
     """compare_solvers with an empty list passes vacuously."""
-    solver = _make_solver(model, "numerical_newton")
-    result = compare_solvers(solver, solver, [])
+    solver = _make_solver("numerical_newton")
+    result = compare_solvers(model, solver, solver, [])
     assert result.passed
     assert result.n_cases == 0
     assert result.n_passed == 0

--- a/tests/integration/test_stress_driver.py
+++ b/tests/integration/test_stress_driver.py
@@ -241,3 +241,23 @@ def test_strain_driver_general_shape(model):
     result = StrainDriver().run(model, load)
     assert result.stress.shape == (N, 6)
     assert result.stress[-1, 0] > model.sigma_y0
+
+
+# ---------------------------------------------------------------------------
+# StressDriver method argument
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("method", ["numerical_newton", "user_defined"])
+def test_stress_driver_method_arg(model_3d, method):
+    """StressDriver.run must accept a method argument and return step_results."""
+    sigma_y0 = model_3d.sigma_y0
+    N = 10
+    stress_history = np.zeros((N, 6))
+    stress_history[:, 0] = np.linspace(0.0, 1.5 * sigma_y0, N)
+
+    result = StressDriver().run(model_3d, stress_load(stress_history), method=method)
+
+    assert len(result.step_results) == N
+    from manforge.core.stress_update import StressUpdateResult
+    for sr in result.step_results:
+        assert isinstance(sr, StressUpdateResult)

--- a/tests/unit/test_compare_jacobians.py
+++ b/tests/unit/test_compare_jacobians.py
@@ -1,0 +1,58 @@
+"""Tests for compare_jacobians."""
+
+import numpy as np
+import pytest
+
+from manforge.core.stress_update import stress_update
+from manforge.verification.compare import compare_jacobians, JacobianComparisonResult
+
+
+def _result(model, strain_scale):
+    deps = np.zeros(model.ntens)
+    deps[0] = strain_scale
+    state0 = model.initial_state()
+    return stress_update(model, deps, np.zeros(model.ntens), state0), state0
+
+
+class TestCompareJacobiansJ2:
+    def test_returns_result_type(self, model):
+        r_ad, state0 = _result(model, 3e-3)
+        r_an, _ = _result(model, 3e-3)
+        out = compare_jacobians(model, r_ad, r_an, state0)
+        assert isinstance(out, JacobianComparisonResult)
+
+    def test_identical_results_zero_error(self, model):
+        r, state0 = _result(model, 3e-3)
+        out = compare_jacobians(model, r, r, state0)
+        assert out.passed
+        assert out.max_rel_err == pytest.approx(0.0, abs=1e-15)
+
+    def test_numerical_newton_vs_user_defined_plastic(self, model):
+        """Jacobian blocks of autodiff and analytical solvers must agree < 1e-10."""
+        r_ad, state0 = _result(model, 3e-3)
+        r_an, _ = _result(model, 3e-3)
+        r_an_ud = stress_update(model, np.array([3e-3] + [0.0] * (model.ntens - 1)),
+                                np.zeros(model.ntens), state0, method="user_defined")
+        out = compare_jacobians(model, r_ad, r_an_ud, state0, rtol=1e-8)
+        assert out.passed, (
+            f"max_rel_err={out.max_rel_err:.3e}, blocks={out.blocks}"
+        )
+
+    def test_elastic_step_does_not_raise(self, model):
+        """Elastic step (dlambda=0) should not raise in compare_jacobians."""
+        r, state0 = _result(model, 1e-5)
+        assert not r.is_plastic
+        out = compare_jacobians(model, r, r, state0)
+        assert out.passed
+
+    def test_blocks_dict_populated(self, model):
+        """blocks dict should contain at least the four scalar block keys."""
+        r, state0 = _result(model, 3e-3)
+        out = compare_jacobians(model, r, r, state0)
+        for key in ("dstress_dsigma", "dstress_ddlambda", "dyield_dsigma", "dyield_ddlambda"):
+            assert key in out.blocks
+
+    def test_max_rel_err_equals_max_of_blocks(self, model):
+        r, state0 = _result(model, 3e-3)
+        out = compare_jacobians(model, r, r, state0)
+        assert out.max_rel_err == pytest.approx(max(out.blocks.values()), abs=1e-15)


### PR DESCRIPTION
## Summary

- `compare_solvers` の solver コールバック契約を `(strain_inc, stress_n, state_n) -> tuple` から `(model, strain_inc, stress_n, state_n) -> StressUpdateResult` に変更 (破壊的変更)
- `SolverComparisonResult` に `state_rel_err` / `trial_rel_err` / `is_plastic_match` / `elastic_branch_match` を追加。`denom_offset=1.0` の擬似相対誤差 (MPa 前提) を廃止し純粋な相対誤差に変更
- `compare_jacobians` 新設: `ad_jacobian_blocks` を 2 回呼び `dstress_dsigma` / `dstate_dstate` 等のブロック別相対誤差表を返す (`JacobianComparisonResult`)
- `StressDriver.run` に `method: str = "auto"` 引数追加 (`StrainDriver.run` との対称化)

## Motivation

`compare_solvers` は `ReturnMappingResult` / `StressUpdateResult` 導入以前の遺物で、`state` を `_state_a, _state_b` と捨てていた (compare.py:91)。同パッケージの `check_tangent` / `ad_jacobian_blocks` は既に `StressUpdateResult` を直接消費しており、`compare_solvers` だけが旧 API の孤立した外れ値だった。

本 PR で Step 3 (内部変数一致確認) と Step 4 (Jacobian ブロック別比較) を正しく支えられる基盤が整う。

## Breaking changes

- solver コールバック引数に `model` が追加 (既存 caller は `tests/fortran/test_compare_solvers.py` の 1 箇所のみ、本 PR で同時修正)
- `compare_solvers` の位置引数順が `(solver_a, solver_b, ...)` → `(model, solver_a, solver_b, ...)` に変更
- `denom_offset` 引数削除

## Test plan

- [x] `tests/unit/test_compare_jacobians.py` — 新規 6 テスト (identical zero error / analytical vs autodiff < 1e-8 / elastic step / blocks dict / max_rel_err 整合)
- [x] `tests/fortran/test_compare_solvers.py` — 新契約に書き換え、全 6 テスト合格
- [x] `tests/integration/test_stress_driver.py` — `StressDriver.run(method=...)` の 2 パラメータテスト追加
- [x] `make test` 全 25 テスト合格

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)