### PR TITLE
feat: @verified_against_fortran デコレータと Fortran バインディングレジストリ (Phase 1)

### DIFF
--- a/src/manforge/core/material.py
+++ b/src/manforge/core/material.py
@@ -78,6 +78,8 @@ class MaterialModel(ABC):
                 f"{cls.__name__}: augmented hardening models must implement "
                 "state_residual()"
             )
+        from manforge.verification.fortran_registry import collect_bindings
+        cls._fortran_bindings = collect_bindings(cls)
 
     @property
     def ntens(self) -> int:

--- a/src/manforge/models/j2_isotropic.py
+++ b/src/manforge/models/j2_isotropic.py
@@ -27,6 +27,7 @@ import autograd.numpy as anp
 from manforge.core.material import MaterialModel3D, MaterialModelPS, MaterialModel1D
 from manforge.core.stress_state import SOLID_3D, PLANE_STRESS, UNIAXIAL_1D, StressState
 from manforge.core.stress_update import ReturnMappingResult
+from manforge.verification.fortran_registry import verified_against_fortran
 
 
 class J2Isotropic3D(MaterialModel3D):
@@ -83,6 +84,10 @@ class J2Isotropic3D(MaterialModel3D):
     # Material physics — reduced hardening (hardening_type = "reduced")
     # ------------------------------------------------------------------
 
+    @verified_against_fortran(
+        "j2_isotropic_3d_elastic_stiffness",
+        test="tests/fortran/test_j2_bindings.py::test_check_bindings_elastic_stiffness",
+    )
     def elastic_stiffness(self) -> anp.ndarray:
         """Isotropic elastic stiffness tensor."""
         mu = self.E / (2.0 * (1.0 + self.nu))

--- a/src/manforge/verification/__init__.py
+++ b/src/manforge/verification/__init__.py
@@ -15,6 +15,12 @@ from manforge.verification.test_cases import (
     generate_single_step_cases,
     generate_strain_history,
 )
+from manforge.verification.fortran_registry import (
+    FortranBinding,
+    verified_against_fortran,
+    collect_bindings,
+    check_bindings,
+)
 
 __all__ = [
     "compare_solvers",
@@ -29,4 +35,8 @@ __all__ = [
     "estimate_yield_strain",
     "generate_single_step_cases",
     "generate_strain_history",
+    "FortranBinding",
+    "verified_against_fortran",
+    "collect_bindings",
+    "check_bindings",
 ]

--- a/src/manforge/verification/fortran_registry.py
+++ b/src/manforge/verification/fortran_registry.py
@@ -1,0 +1,144 @@
+"""Fortran subroutine binding registry.
+
+Provides a decorator and helpers that record the correspondence between
+Python methods and Fortran subroutines.  The decorator attaches a function
+attribute only — runtime behaviour is unchanged.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class FortranBinding:
+    """Metadata linking a Python method to a Fortran subroutine.
+
+    Parameters
+    ----------
+    subroutine:
+        Exact subroutine name as passed to :meth:`FortranUMAT.call`.
+    test:
+        Pytest node id of the test that verifies this binding
+        (e.g. ``"tests/fortran/test_j2_bindings.py::test_check_bindings_elastic_stiffness"``).
+        Not executed at runtime — recorded as a machine-readable pointer.
+    notes:
+        Free-form annotation (e.g. sign convention differences).
+    """
+
+    subroutine: str
+    test: str | None = None
+    notes: str = ""
+
+
+def verified_against_fortran(
+    subroutine: str,
+    *,
+    test: str | None = None,
+    notes: str = "",
+) -> Callable:
+    """Attach a :class:`FortranBinding` to a method.  Runtime behaviour unchanged.
+
+    Usage::
+
+        @verified_against_fortran(
+            "j2_isotropic_3d_elastic_stiffness",
+            test="tests/fortran/test_j2_bindings.py::test_check_bindings_elastic_stiffness",
+        )
+        def elastic_stiffness(self):
+            ...
+    """
+    binding = FortranBinding(subroutine=subroutine, test=test, notes=notes)
+
+    def decorator(fn: Callable) -> Callable:
+        fn.__fortran_binding__ = binding
+        return fn
+
+    return decorator
+
+
+def collect_bindings(cls) -> dict[str, FortranBinding]:
+    """Collect methods decorated with :func:`verified_against_fortran`.
+
+    Traverses ``cls.__mro__`` from base to derived so that overrides in
+    subclasses shadow the parent's binding.  ``object`` and dunder names
+    are excluded.
+
+    Parameters
+    ----------
+    cls:
+        The class to inspect (typically a concrete :class:`MaterialModel` subclass).
+
+    Returns
+    -------
+    dict[str, FortranBinding]
+        Mapping from method name to its :class:`FortranBinding`.
+    """
+    bindings: dict[str, FortranBinding] = {}
+    for klass in reversed(cls.__mro__):
+        if klass is object:
+            continue
+        for name, obj in klass.__dict__.items():
+            if name.startswith("__"):
+                continue
+            if hasattr(obj, "__fortran_binding__"):
+                bindings[name] = obj.__fortran_binding__
+    return bindings
+
+
+def check_bindings(
+    model,
+    fortran,
+    cases: dict[str, tuple[tuple, tuple]],
+    *,
+    rtol: float = 1e-10,
+) -> dict[str, tuple[bool, float]]:
+    """Compare registered Python methods against their Fortran counterparts.
+
+    Only methods listed in *cases* are checked.  Methods that return
+    non-array types (e.g. ``dict``) are not suitable for this helper — test
+    them individually.
+
+    Parameters
+    ----------
+    model:
+        An instantiated :class:`MaterialModel`.
+    fortran:
+        A :class:`FortranUMAT` instance (module must be importable).
+    cases:
+        ``{method_name: (py_args, fortran_args)}``.
+        *py_args* is passed to ``getattr(model, method_name)(*py_args)``.
+        *fortran_args* is passed to ``fortran.call(subroutine, *fortran_args)``.
+    rtol:
+        Relative tolerance threshold.  A result is ``ok`` when
+        ``max_rel_err < rtol``.
+
+    Returns
+    -------
+    dict[str, tuple[bool, float]]
+        ``{method_name: (ok, max_rel_err)}``.
+
+    Raises
+    ------
+    KeyError
+        If a method in *cases* is not in ``model._fortran_bindings``.
+    """
+    bindings: dict[str, FortranBinding] = getattr(model, "_fortran_bindings", {})
+    results: dict[str, tuple[bool, float]] = {}
+
+    for method_name, (py_args, fortran_args) in cases.items():
+        binding = bindings[method_name]
+
+        py_out = getattr(model, method_name)(*py_args)
+        f_out = fortran.call(binding.subroutine, *fortran_args)
+
+        py_arr = np.asarray(py_out, dtype=float).ravel()
+        f_arr = np.asarray(f_out, dtype=float).ravel()
+
+        max_rel_err = float(np.max(np.abs(py_arr - f_arr) / (np.abs(f_arr) + 1e-14)))
+        results[method_name] = (max_rel_err < rtol, max_rel_err)
+
+    return results

--- a/tests/fortran/test_j2_bindings.py
+++ b/tests/fortran/test_j2_bindings.py
@@ -1,0 +1,38 @@
+"""Registry cross-validation: J2 Python methods vs Fortran subroutines.
+
+Requires the compiled j2_isotropic_3d module:
+
+    make fortran-build-umat
+
+If the module is not available, all tests in this file are skipped.
+"""
+
+import pytest
+
+pytest.importorskip(
+    "j2_isotropic_3d",
+    reason="j2_isotropic_3d not compiled -- run: make fortran-build-umat",
+)
+
+pytestmark = pytest.mark.fortran
+
+from manforge.models.j2_isotropic import J2Isotropic3D
+from manforge.verification import FortranUMAT, check_bindings
+
+
+def test_elastic_stiffness_binding_registered():
+    bindings = J2Isotropic3D._fortran_bindings
+    assert "elastic_stiffness" in bindings
+    assert bindings["elastic_stiffness"].subroutine == "j2_isotropic_3d_elastic_stiffness"
+
+
+def test_check_bindings_elastic_stiffness(model):
+    fortran = FortranUMAT("j2_isotropic_3d")
+    cases = {
+        "elastic_stiffness": ((), (model.E, model.nu)),
+    }
+    results = check_bindings(model, fortran, cases, rtol=1e-10)
+
+    ok, max_err = results["elastic_stiffness"]
+    assert ok, f"elastic_stiffness mismatch: max_rel_err={max_err:.2e}"
+    assert max_err < 1e-10

--- a/tests/unit/test_fortran_registry.py
+++ b/tests/unit/test_fortran_registry.py
@@ -1,0 +1,88 @@
+"""Unit tests for fortran_registry (Fortran binary not required)."""
+
+import pytest
+
+from manforge.core.material import MaterialModel3D
+from manforge.models.j2_isotropic import J2Isotropic3D
+from manforge.verification.fortran_registry import (
+    FortranBinding,
+    collect_bindings,
+    verified_against_fortran,
+)
+
+
+def test_decorator_attaches_binding():
+    @verified_against_fortran("foo_sub", test="tests/foo.py::bar", notes="hi")
+    def f():
+        pass
+
+    assert f.__fortran_binding__ == FortranBinding("foo_sub", "tests/foo.py::bar", "hi")
+
+
+def test_decorator_does_not_change_behavior():
+    @verified_against_fortran("foo_sub")
+    def add(a, b):
+        return a + b
+
+    assert add(2, 3) == 5
+
+
+def test_collect_bindings_via_mro():
+    class Base:
+        @verified_against_fortran("base_sub")
+        def m(self): ...
+
+    class Child(Base):
+        pass
+
+    assert collect_bindings(Child)["m"].subroutine == "base_sub"
+
+
+def test_collect_bindings_override_wins():
+    class Base:
+        @verified_against_fortran("base_sub")
+        def m(self): ...
+
+    class Child(Base):
+        @verified_against_fortran("child_sub")
+        def m(self): ...
+
+    assert collect_bindings(Child)["m"].subroutine == "child_sub"
+
+
+def test_collect_bindings_excludes_undecorated():
+    class MyClass:
+        def plain(self): ...
+
+        @verified_against_fortran("bound_sub")
+        def bound(self): ...
+
+    result = collect_bindings(MyClass)
+    assert "bound" in result
+    assert "plain" not in result
+
+
+def test_collect_bindings_excludes_dunders():
+    class MyClass:
+        @verified_against_fortran("init_sub")
+        def __init__(self): ...
+
+    result = collect_bindings(MyClass)
+    assert "__init__" not in result
+
+
+def test_abstract_base_has_no_fortran_bindings():
+    """Intermediate abstract classes must not get _fortran_bindings."""
+    assert not hasattr(MaterialModel3D, "_fortran_bindings")
+
+
+def test_j2_concrete_has_fortran_bindings():
+    assert hasattr(J2Isotropic3D, "_fortran_bindings")
+    assert "elastic_stiffness" in J2Isotropic3D._fortran_bindings
+
+
+def test_j2_elastic_stiffness_binding_fields():
+    binding = J2Isotropic3D._fortran_bindings["elastic_stiffness"]
+    assert binding.subroutine == "j2_isotropic_3d_elastic_stiffness"
+    assert binding.test is not None
+    assert "test_j2_bindings" in binding.test


### PR DESCRIPTION
## Summary

- `src/manforge/verification/fortran_registry.py` を新規追加: `FortranBinding` dataclass、`@verified_against_fortran` デコレータ、`collect_bindings`、`check_bindings` ヘルパ
- `MaterialModel.__init_subclass__` 末尾で concrete subclass に `_fortran_bindings` を自動収集
- `J2Isotropic3D.elastic_stiffness` にリファレンスとして 1 件デコレータを適用
- `verification/__init__.py` から 4 シンボルを re-export

Closes #31

## 設計原則

- **破壊的変更ゼロ・完全 opt-in** — デコレータは関数属性を付けるだけで実行時挙動は不変
- **循環 import 回避** — `material.py` 内の import は関数内に遅延 (`manforge.verification` → `manforge.core` の依存を防ぐ)
- **Phase 1 の scope** — `elastic_stiffness` (scalar/ndarray 返し) のみ。`dict` 返しメソッド (`update_state` など) への展開は Phase 2 以降

## Test plan

- [x] `tests/unit/test_fortran_registry.py` — レジストリ単体挙動 9 件 (Fortran 不要)
- [x] `tests/fortran/test_j2_bindings.py` — binding 登録確認 + `check_bindings` クロスチェック 2 件
- [x] 既存 unit (214 件) + integration (192 件) すべて pass、退行なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)