### PR TITLE
refactor: consolidate verification/ layer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ JAX autodiff computes yield function gradients and the Hessian needed for the ta
 - `fitting/optimizer.py`: `fit_params()` wraps scipy.optimize (L-BFGS-B, Nelder-Mead, differential_evolution); loss defined in `fitting/objective.py`; uses drivers from `simulation/`
 - `verification/fd_check.py`: Compares AD tangent vs central finite differences
 - `verification/fortran_bridge.py`: f2py interface; calls compiled UMAT and compares output element-wise to Python (stress tol: 1e-6, tangent tol: 1e-5)
-- `verification/compare.py`: `compare_solvers` (batch) and `iter_compare_solvers` (generator, yields `SolverCaseResult` per case — exposes raw `result_a`/`result_b` for direct use with `compare_jacobians`).
+- `verification/compare.py`: `SolverComparison` (a `Comparator` subclass). `run(model, test_cases)` returns `SolverComparisonResult`; `iter_run` yields one `SolverCaseResult` per case with raw `result_a`/`result_b` for direct use with `compare_jacobians`.
 
 ### StressState and dimensionality
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,10 @@ src/manforge/
 │   ├── objective.py       # 残差二乗和
 │   └── optimizer.py       # fit_params() + FitResult
 ├── verification/
-│   ├── compare.py         # compare_solvers()
+│   ├── comparator.py      # Comparator ABC + 共有 rel-err ヘルパー
+│   ├── compare.py         # SolverComparison / compare_jacobians
+│   ├── umat_crosscheck.py # ReturnMappingCrosscheck / StressUpdateCrosscheck
+│   ├── fortran_registry.py# @verified_against_fortran デコレータ
 │   ├── fd_check.py        # check_tangent()
 │   ├── fortran_bridge.py  # FortranUMAT — f2py ラッパー
 │   └── test_cases.py      # estimate_yield_strain / generate_*
@@ -457,12 +460,12 @@ result = check_tangent(
 print(result.passed, result.max_rel_err)
 ```
 
-### compare_solvers でソルバ同士の比較
+### SolverComparison でソルバ同士の比較
 
 ```python
 import numpy as np
 from manforge.core.stress_update import stress_update
-from manforge.verification.compare import compare_solvers
+from manforge.verification import SolverComparison
 from manforge.verification.test_cases import generate_single_step_cases
 
 def make_solver(method):
@@ -472,33 +475,28 @@ def make_solver(method):
 
 # 弾性・塑性・多軸・剪断ケースを自動生成
 cases = generate_single_step_cases(model)
-result = compare_solvers(
-    model,
-    solver_a=make_solver("numerical_newton"),
-    solver_b=make_solver("user_defined"),
-    test_cases=cases,
+cs = SolverComparison(
+    make_solver("numerical_newton"),
+    make_solver("user_defined"),
 )
+result = cs.run(model, cases)
 print(f"Passed: {result.passed}  max_stress_err={result.max_stress_rel_err:.2e}")
 ```
 
 `generate_single_step_cases` は `estimate_yield_strain` で降伏ひずみを自動推定し、5 ケース (弾性・塑性・多軸・剪断・プレストレス) を生成する。
 
-`iter_compare_solvers` を使うとケースごとに `SolverCaseResult` を受け取るジェネレータになる。最初の失敗ケースで打ち切って Jacobian 比較などの詳細デバッグが可能:
+`cs.iter_run` を使うとケースごとに `SolverCaseResult` を受け取るジェネレータになる。最初の失敗ケースで打ち切って Jacobian 比較などの詳細デバッグが可能:
 
 ```python
-from manforge.verification.compare import iter_compare_solvers, compare_jacobians
+from manforge.verification import compare_jacobians
 
-for case in iter_compare_solvers(model, solver_a, solver_b, cases):
-    # case.case_index, case.stress_rel_err, case.passed など
+for case in cs.iter_run(model, cases):
     if not case.passed:
-        print(f"Case {case.case_index} failed: stress_err={case.stress_rel_err:.2e}")
-        # result_a / result_b をそのまま compare_jacobians に渡せる
-        state_n = cases[case.case_index]["state_n"]
+        print(f"Case {case.index} failed: stress_err={case.stress_rel_err:.2e}")
+        state_n = cases[case.index]["state_n"]
         jac = compare_jacobians(model, case.result_a, case.result_b, state_n)
         break
 ```
-
-既存の `compare_solvers` はそのまま使える（後方互換）。
 
 ### Fortran UMAT クロス検証
 

--- a/examples/example_j2_uniaxial.py
+++ b/examples/example_j2_uniaxial.py
@@ -17,7 +17,7 @@ import manforge  # noqa: F401 — enables JAX float64
 from manforge.models.j2_isotropic import J2Isotropic1D
 from manforge.simulation.driver import StrainDriver
 from manforge.simulation.types import FieldHistory, FieldType
-from manforge.verification.fd_check import check_tangent
+from manforge.verification import check_tangent
 
 try:
     import matplotlib

--- a/src/manforge/verification/comparator.py
+++ b/src/manforge/verification/comparator.py
@@ -1,4 +1,4 @@
-"""Comparator ABC — shared base for compare_solvers and crosscheck harnesses.
+"""Comparator ABC — shared base for SolverComparison and crosscheck harnesses.
 
 A Comparator holds the static configuration of *what to compare* (ref/cand
 implementations, tolerances) in ``__init__`` and accepts *what to apply it to*
@@ -16,6 +16,61 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
 from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+# Stress rel-err denominator: additive offset avoids 0/0 on unloading to zero stress.
+_STRESS_NORM = 1.0
+# State/tangent/Jacobian rel-err denominator: pure relative (values don't go to zero).
+_EPS = 1e-300
+
+
+def _stress_rel_err(ref: np.ndarray, cand: np.ndarray) -> float:
+    """Max component-wise stress relative error with additive denominator."""
+    return float(np.max(np.abs(cand - ref) / (np.abs(ref) + _STRESS_NORM)))
+
+
+def _state_rel_err(
+    ref_dict: dict[str, Any],
+    cand_dict: dict[str, Any],
+) -> dict[str, float]:
+    """Per state-variable relative error."""
+    errs: dict[str, float] = {}
+    for key in ref_dict:
+        va = np.asarray(ref_dict[key], dtype=float)
+        vb = np.asarray(cand_dict.get(key, np.zeros_like(va)), dtype=float)
+        errs[key] = float(np.max(np.abs(vb - va) / (np.abs(va) + _EPS)))
+    return errs
+
+
+def _tangent_rel_err(ref: Any, cand: Any) -> float | None:
+    """Max tangent relative error; returns None if either arg is None."""
+    if ref is None or cand is None:
+        return None
+    ra = np.asarray(ref, dtype=float)
+    ca = np.asarray(cand, dtype=float)
+    return float(np.max(np.abs(ca - ra) / (np.abs(ra) + _EPS)))
+
+
+def _array_rel_err(ref: np.ndarray, cand: np.ndarray) -> float:
+    """Generic array relative error for trial stress, Jacobian blocks, etc."""
+    return float(np.max(np.abs(cand - ref) / (np.abs(ref) + _EPS)))
+
+
+def _case_passed(
+    s_err: float,
+    st_errs: dict[str, float],
+    t_err: float | None,
+    stress_tol: float,
+    state_tol: float,
+    tangent_tol: float,
+) -> bool:
+    ok = s_err <= stress_tol
+    ok = ok and all(v <= state_tol for v in st_errs.values())
+    if t_err is not None:
+        ok = ok and t_err <= tangent_tol
+    return ok
 
 
 @dataclass
@@ -64,6 +119,12 @@ class Comparator(ABC):
     subclasses — they only need to implement ``iter_run``.
     """
 
+    _result_cls: type[ComparisonResult] = ComparisonResult
+
+    def _aggregate_extra(self, cases: list[CaseResult]) -> dict:
+        """Extra kwargs to pass to ``_result_cls``. Override in subclasses."""
+        return {}
+
     def run(self, *args, **kwargs) -> ComparisonResult:
         """Run over all cases, collect results, return aggregate."""
         cases: list[CaseResult] = []
@@ -88,7 +149,7 @@ class Comparator(ABC):
             if not cr.b_converged:
                 n_b_nc += 1
 
-        return ComparisonResult(
+        return self._result_cls(
             passed=n_passed == len(cases),
             n_cases=len(cases),
             n_passed=n_passed,
@@ -98,6 +159,7 @@ class Comparator(ABC):
             cases=cases,
             n_a_nonconverged=n_a_nc,
             n_b_nonconverged=n_b_nc,
+            **self._aggregate_extra(cases),
         )
 
     @abstractmethod

--- a/src/manforge/verification/compare.py
+++ b/src/manforge/verification/compare.py
@@ -28,12 +28,18 @@ from typing import TYPE_CHECKING, Callable
 
 import numpy as np
 
-from manforge.verification.comparator import CaseResult, ComparisonResult, Comparator
+from manforge.verification.comparator import (
+    CaseResult,
+    ComparisonResult,
+    Comparator,
+    _array_rel_err,
+    _state_rel_err,
+    _stress_rel_err,
+    _tangent_rel_err,
+)
 
 if TYPE_CHECKING:
     from manforge.core.stress_update import StressUpdateResult
-
-_EPS = 1e-300  # zero-division guard — no physical meaning
 
 
 # ---------------------------------------------------------------------------
@@ -67,12 +73,10 @@ class SolverComparisonResult(ComparisonResult):
     """Aggregate result from :class:`SolverComparison`.
 
     Extends :class:`~manforge.verification.ComparisonResult` with
-    ``max_trial_rel_err`` and a legacy ``details`` list for backwards
-    compatibility with existing tests that inspect ``result.details``.
+    ``max_trial_rel_err``.
     """
 
     max_trial_rel_err: float = 0.0
-    details: list = field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------
@@ -99,10 +103,6 @@ class SolverComparison(Comparator):
         Whether to include state error in pass/fail (default True).
     check_is_plastic : bool, optional
         Fail the case when ``is_plastic`` flags disagree (default True).
-    check_residual_history : bool, optional
-        Include ``residual_history_a/b`` in ``details`` records (default False).
-    check_n_iterations : bool, optional
-        Include ``n_iterations_a/b`` in ``details`` records (default False).
 
     Examples
     --------
@@ -120,6 +120,11 @@ class SolverComparison(Comparator):
                 break
     """
 
+    _result_cls = SolverComparisonResult
+
+    def _aggregate_extra(self, cases):
+        return {"max_trial_rel_err": max((c.trial_rel_err for c in cases), default=0.0)}
+
     def __init__(
         self,
         solver_a: Callable,
@@ -130,8 +135,6 @@ class SolverComparison(Comparator):
         state_tol: float = 1e-6,
         check_state: bool = True,
         check_is_plastic: bool = True,
-        check_residual_history: bool = False,
-        check_n_iterations: bool = False,
     ) -> None:
         self.solver_a = solver_a
         self.solver_b = solver_b
@@ -140,8 +143,6 @@ class SolverComparison(Comparator):
         self.state_tol = state_tol
         self.check_state = check_state
         self.check_is_plastic = check_is_plastic
-        self.check_residual_history = check_residual_history
-        self.check_n_iterations = check_n_iterations
 
     def iter_run(
         self,
@@ -168,26 +169,24 @@ class SolverComparison(Comparator):
             ra = self.solver_a(model, strain_inc, stress_n, state_n)
             rb = self.solver_b(model, strain_inc, stress_n, state_n)
 
-            stress_a  = np.asarray(ra.stress,  dtype=float)
-            stress_b  = np.asarray(rb.stress,  dtype=float)
-            ddsdde_a  = np.asarray(ra.ddsdde,  dtype=float)
-            ddsdde_b  = np.asarray(rb.ddsdde,  dtype=float)
-            trial_a   = np.asarray(ra.stress_trial, dtype=float)
-            trial_b   = np.asarray(rb.stress_trial, dtype=float)
+            stress_a = np.asarray(ra.stress, dtype=float)
+            stress_b = np.asarray(rb.stress, dtype=float)
+            trial_a  = np.asarray(ra.stress_trial, dtype=float)
+            trial_b  = np.asarray(rb.stress_trial, dtype=float)
 
-            stress_rel_err  = float(np.max(np.abs(stress_b  - stress_a)  / (np.abs(stress_a)  + _EPS)))
-            tangent_rel_err = float(np.max(np.abs(ddsdde_b  - ddsdde_a)  / (np.abs(ddsdde_a)  + _EPS)))
-            trial_rel_err   = float(np.max(np.abs(trial_b   - trial_a)   / (np.abs(trial_a)   + _EPS)))
+            stress_rel_err  = _stress_rel_err(stress_a, stress_b)
+            tangent_rel_err = _tangent_rel_err(
+                np.asarray(ra.ddsdde, dtype=float),
+                np.asarray(rb.ddsdde, dtype=float),
+            ) or 0.0
+            trial_rel_err   = _array_rel_err(trial_a, trial_b)
 
             is_plastic_match     = bool(ra.is_plastic == rb.is_plastic)
             elastic_branch_match = bool((ra.return_mapping is None) == (rb.return_mapping is None))
 
-            state_rel_err: dict[str, float] = {}
-            if self.check_state:
-                for key in ra.state:
-                    va = np.asarray(ra.state[key], dtype=float)
-                    vb = np.asarray(rb.state.get(key, np.zeros_like(va)), dtype=float)
-                    state_rel_err[key] = float(np.max(np.abs(vb - va) / (np.abs(va) + _EPS)))
+            state_rel_err: dict[str, float] = (
+                _state_rel_err(ra.state, rb.state) if self.check_state else {}
+            )
 
             case_passed = stress_rel_err <= self.stress_tol and tangent_rel_err <= self.tangent_tol
             if self.check_state and state_rel_err:
@@ -213,79 +212,6 @@ class SolverComparison(Comparator):
                 b_residual_history=list(rb.residual_history),
                 b_converged=rb.converged,
             )
-
-    def run(
-        self,
-        model,
-        test_cases: list,
-    ) -> SolverComparisonResult:
-        """Compare solvers across all test cases and return aggregate result.
-
-        Parameters
-        ----------
-        model : MaterialModel
-        test_cases : list[dict]
-
-        Returns
-        -------
-        SolverComparisonResult
-        """
-        cases: list[SolverCaseResult] = []
-        max_s_err = 0.0
-        max_t_err = 0.0
-        max_st_err: dict[str, float] = {}
-        max_trial_err = 0.0
-        n_passed = 0
-        n_a_nc = 0
-        n_b_nc = 0
-        details = []
-
-        for cr in self.iter_run(model, test_cases):
-            cases.append(cr)
-
-            rec: dict = {
-                "case_index":           cr.index,
-                "stress_rel_err":       cr.stress_rel_err,
-                "tangent_rel_err":      cr.tangent_rel_err,
-                "state_rel_err":        cr.state_rel_err,
-                "trial_rel_err":        cr.trial_rel_err,
-                "is_plastic_match":     cr.is_plastic_match,
-                "elastic_branch_match": cr.elastic_branch_match,
-                "passed":               cr.passed,
-            }
-            if self.check_n_iterations:
-                rec["n_iterations_a"] = cr.result_a.n_iterations
-                rec["n_iterations_b"] = cr.result_b.n_iterations
-            if self.check_residual_history:
-                rec["residual_history_a"] = cr.result_a.residual_history
-                rec["residual_history_b"] = cr.result_b.residual_history
-            details.append(rec)
-
-            max_s_err    = max(max_s_err,    cr.stress_rel_err or 0.0)
-            max_t_err    = max(max_t_err,    cr.tangent_rel_err or 0.0)
-            max_trial_err = max(max_trial_err, cr.trial_rel_err)
-            for key, val in cr.state_rel_err.items():
-                max_st_err[key] = max(max_st_err.get(key, 0.0), val)
-            if cr.passed:
-                n_passed += 1
-            if not cr.a_converged:
-                n_a_nc += 1
-            if not cr.b_converged:
-                n_b_nc += 1
-
-        return SolverComparisonResult(
-            passed=n_passed == len(test_cases),
-            n_cases=len(test_cases),
-            n_passed=n_passed,
-            max_stress_rel_err=max_s_err,
-            max_tangent_rel_err=max_t_err,
-            max_state_rel_err=max_st_err,
-            max_trial_rel_err=max_trial_err,
-            cases=cases,
-            details=details,
-            n_a_nonconverged=n_a_nc,
-            n_b_nonconverged=n_b_nc,
-        )
 
 
 # ---------------------------------------------------------------------------
@@ -362,7 +288,7 @@ def compare_jacobians(
     for name in _SCALAR_BLOCKS:
         va = np.asarray(getattr(jac_a, name), dtype=float)
         vb = np.asarray(getattr(jac_b, name), dtype=float)
-        block_errs[name] = float(np.max(np.abs(vb - va) / (np.abs(va) + _EPS)))
+        block_errs[name] = _array_rel_err(va, vb)
 
     for name in _DICT_BLOCKS:
         da = getattr(jac_a, name)
@@ -372,7 +298,7 @@ def compare_jacobians(
         for key in da:
             va = np.asarray(da[key], dtype=float)
             vb = np.asarray(db.get(key, np.zeros_like(va)), dtype=float)
-            block_errs[f"{name}::{key}"] = float(np.max(np.abs(vb - va) / (np.abs(va) + _EPS)))
+            block_errs[f"{name}::{key}"] = _array_rel_err(va, vb)
 
     max_err = max(block_errs.values()) if block_errs else 0.0
 

--- a/src/manforge/verification/test_cases.py
+++ b/src/manforge/verification/test_cases.py
@@ -9,13 +9,12 @@ estimate_yield_strain
     Estimate the uniaxial yield strain via bisection on the yield surface.
 generate_single_step_cases
     Generate a set of single-increment test cases for use with
-    :func:`~manforge.verification.compare.compare_solvers`.
+    :class:`~manforge.verification.SolverComparison`.
 generate_strain_history
     Generate a default tension-unload-compression strain history for
     multi-step comparison.
 """
 
-import numpy as np
 import numpy as np
 
 from manforge.core.stress_update import stress_update
@@ -83,7 +82,7 @@ def generate_single_step_cases(model, eps_y=None) -> list[dict]:
     -------
     list[dict]
         Each dict has keys ``"strain_inc"``, ``"stress_n"``, ``"state_n"``
-        — compatible with :func:`~manforge.verification.compare.compare_solvers`.
+        — compatible with :class:`~manforge.verification.SolverComparison`.
     """
     if eps_y is None:
         eps_y = estimate_yield_strain(model)

--- a/src/manforge/verification/umat_crosscheck.py
+++ b/src/manforge/verification/umat_crosscheck.py
@@ -51,10 +51,16 @@ from typing import Any, Callable
 import numpy as np
 
 from manforge.core.stress_update import stress_update
-from manforge.verification.comparator import CaseResult, ComparisonResult, Comparator
+from manforge.verification.comparator import (
+    CaseResult,
+    ComparisonResult,
+    Comparator,
+    _case_passed,
+    _state_rel_err,
+    _stress_rel_err,
+    _tangent_rel_err,
+)
 from manforge.simulation.integrator import PythonIntegrator
-
-_STRESS_NORM = 1.0  # additive denominator for stress rel-err; avoids 0/0 on unloading
 
 
 # ---------------------------------------------------------------------------
@@ -160,48 +166,6 @@ def _default_parse_umat_ddsdde(
 
 
 # ---------------------------------------------------------------------------
-# Error calculation helpers
-# ---------------------------------------------------------------------------
-
-_EPS = 1e-300  # zero-division guard for state/tangent
-
-
-def _stress_rel_err(f_stress: np.ndarray, py_stress: np.ndarray) -> float:
-    return float(np.max(np.abs(f_stress - py_stress) / (np.abs(py_stress) + _STRESS_NORM)))
-
-
-def _state_rel_err(
-    f_state: dict[str, Any],
-    py_state: dict[str, Any],
-) -> dict[str, float]:
-    errs: dict[str, float] = {}
-    for key in py_state:
-        va = np.asarray(py_state[key], dtype=float)
-        vb = np.asarray(f_state.get(key, np.zeros_like(va)), dtype=float)
-        errs[key] = float(np.max(np.abs(vb - va) / (np.abs(va) + _EPS)))
-    return errs
-
-
-def _tangent_rel_err(f_ddsdde: np.ndarray, py_ddsdde: np.ndarray) -> float:
-    return float(np.max(np.abs(f_ddsdde - py_ddsdde) / (np.abs(py_ddsdde) + _EPS)))
-
-
-def _case_passed(
-    s_err: float,
-    st_errs: dict[str, float],
-    t_err: float | None,
-    stress_tol: float,
-    state_tol: float,
-    tangent_tol: float,
-) -> bool:
-    ok = s_err <= stress_tol
-    ok = ok and all(v <= state_tol for v in st_errs.values())
-    if t_err is not None:
-        ok = ok and t_err <= tangent_tol
-    return ok
-
-
-# ---------------------------------------------------------------------------
 # ReturnMappingCrosscheck
 # ---------------------------------------------------------------------------
 
@@ -247,6 +211,8 @@ class ReturnMappingCrosscheck(Comparator):
                 print(f"case {cr.index} stress_err={cr.stress_rel_err:.2e}")
                 break
     """
+
+    _result_cls = CrosscheckResult
 
     def __init__(
         self,
@@ -337,30 +303,6 @@ class ReturnMappingCrosscheck(Comparator):
                 a_converged=py_su.converged,
             )
 
-    def run(
-        self,
-        model,
-        test_cases: list[dict],
-    ) -> CrosscheckResult:
-        """Compare Python return_mapping and Fortran UMAT across all cases.
-
-        Returns
-        -------
-        CrosscheckResult
-        """
-        base = super().run(model, test_cases)
-        return CrosscheckResult(
-            passed=base.passed,
-            n_cases=base.n_cases,
-            n_passed=base.n_passed,
-            max_stress_rel_err=base.max_stress_rel_err,
-            max_state_rel_err=base.max_state_rel_err,
-            max_tangent_rel_err=base.max_tangent_rel_err,
-            cases=list(base.cases),  # type: ignore[arg-type]
-            n_a_nonconverged=base.n_a_nonconverged,
-            n_b_nonconverged=base.n_b_nonconverged,
-        )
-
 
 # ---------------------------------------------------------------------------
 # StressUpdateCrosscheck
@@ -413,6 +355,8 @@ class StressUpdateCrosscheck(Comparator):
                 break
     """
 
+    _result_cls = CrosscheckResult
+
     def __init__(
         self,
         integrator_a,
@@ -460,11 +404,10 @@ class StressUpdateCrosscheck(Comparator):
             f_stress = np.asarray(rb.stress, dtype=np.float64)
             f_state  = {k: np.asarray(v) for k, v in rb.state.items()}
 
-            f_ddsdde: np.ndarray | None = None
-            t_err: float | None = None
-            if rb.ddsdde is not None:
-                f_ddsdde = np.asarray(rb.ddsdde, dtype=np.float64)
-                t_err = _tangent_rel_err(f_ddsdde, py_ddsdde)
+            f_ddsdde = (
+                np.asarray(rb.ddsdde, dtype=np.float64) if rb.ddsdde is not None else None
+            )
+            t_err = _tangent_rel_err(py_ddsdde, f_ddsdde)
 
             s_err  = _stress_rel_err(f_stress, py_stress)
             st_err = _state_rel_err(f_state, py_state)
@@ -491,26 +434,3 @@ class StressUpdateCrosscheck(Comparator):
                 b_converged=rb.converged,
             )
 
-    def run(
-        self,
-        driver,
-        load,
-    ) -> CrosscheckResult:
-        """Compare both integrators over all steps.
-
-        Returns
-        -------
-        CrosscheckResult
-        """
-        base = super().run(driver, load)
-        return CrosscheckResult(
-            passed=base.passed,
-            n_cases=base.n_cases,
-            n_passed=base.n_passed,
-            max_stress_rel_err=base.max_stress_rel_err,
-            max_state_rel_err=base.max_state_rel_err,
-            max_tangent_rel_err=base.max_tangent_rel_err,
-            cases=list(base.cases),  # type: ignore[arg-type]
-            n_a_nonconverged=base.n_a_nonconverged,
-            n_b_nonconverged=base.n_b_nonconverged,
-        )

--- a/tests/fortran/test_compare_solvers.py
+++ b/tests/fortran/test_compare_solvers.py
@@ -95,7 +95,7 @@ def test_autodiff_vs_analytical_pass(model, test_cases):
     assert result.passed, (
         f"Solvers disagree: max_stress_err={result.max_stress_rel_err:.3e}, "
         f"max_tangent_err={result.max_tangent_rel_err:.3e}\n"
-        f"Details: {result.details}"
+        f"Failed cases: {[c.index for c in result.cases if not c.passed]}"
     )
     assert result.max_stress_rel_err  < 1e-6
     assert result.max_tangent_rel_err < 1e-5
@@ -130,26 +130,29 @@ def test_wrong_solver_fails(model, test_cases):
 # Result structure
 # ---------------------------------------------------------------------------
 
-def test_result_details_length(model, test_cases):
-    """details list length equals the number of test cases."""
+def test_result_cases_length(model, test_cases):
+    """cases list length equals the number of test cases."""
     solver = _make_solver("numerical_newton")
     cs = SolverComparison(solver, solver)
     result = cs.run(model, test_cases)
-    assert len(result.details) == len(test_cases)
+    assert len(result.cases) == len(test_cases)
 
 
-def test_result_details_keys(model, test_cases):
-    """Each detail record has the required keys."""
+def test_result_case_fields(model, test_cases):
+    """Each SolverCaseResult has the required attributes."""
+    from manforge.verification.compare import SolverCaseResult
     solver = _make_solver("numerical_newton")
     cs = SolverComparison(solver, solver)
     result = cs.run(model, test_cases)
-    required = {
-        "case_index", "stress_rel_err", "tangent_rel_err",
-        "state_rel_err", "trial_rel_err",
-        "is_plastic_match", "elastic_branch_match", "passed",
-    }
-    for d in result.details:
-        assert required <= d.keys()
+    for c in result.cases:
+        assert isinstance(c, SolverCaseResult)
+        assert c.index >= 0
+        assert c.stress_rel_err is not None
+        assert c.tangent_rel_err is not None
+        assert isinstance(c.state_rel_err, dict)
+        assert isinstance(c.is_plastic_match, bool)
+        assert isinstance(c.elastic_branch_match, bool)
+        assert isinstance(c.passed, bool)
 
 
 def test_empty_test_cases(model):

--- a/tests/fortran/test_test_cases.py
+++ b/tests/fortran/test_test_cases.py
@@ -1,9 +1,4 @@
-"""Unit tests for UMATVerifier and the test_cases module.
-
-These tests do NOT require the compiled Fortran module.  They verify the
-test case generation utilities and the structure of VerificationResult
-using the Python J2 model only.
-"""
+"""Unit tests for the test_cases module (pure-Python, no Fortran needed)."""
 
 import numpy as np
 import pytest
@@ -63,7 +58,7 @@ def test_generate_single_step_cases_count(model):
 
 
 def test_generate_single_step_cases_keys(model):
-    """Each case has the required keys for compare_solvers."""
+    """Each case has the required keys for SolverComparison."""
     cases = generate_single_step_cases(model)
     required = {"strain_inc", "stress_n", "state_n"}
     for case in cases:

--- a/tests/integration/test_verification.py
+++ b/tests/integration/test_verification.py
@@ -10,7 +10,7 @@ import autograd.numpy as anp
 import pytest
 
 from manforge.verification.fd_check import check_tangent, TangentCheckResult
-from manforge.verification.fortran_bridge import FortranUMAT
+from manforge.verification import FortranUMAT
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_iter_compare_solvers.py
+++ b/tests/unit/test_iter_compare_solvers.py
@@ -61,14 +61,14 @@ class TestSolverComparisonIterRun:
         solver_b = _solver("numerical_newton")
         cs = SolverComparison(solver_a, solver_b)
         batch = cs.run(model, test_cases)
-        cases = list(cs.iter_run(model, test_cases))
+        iter_cases = list(cs.iter_run(model, test_cases))
 
-        assert len(cases) == batch.n_cases
-        for case, detail in zip(cases, batch.details):
-            assert case.index == detail["case_index"]
-            assert case.passed == detail["passed"]
-            assert case.stress_rel_err == pytest.approx(detail["stress_rel_err"], rel=1e-12)
-            assert case.tangent_rel_err == pytest.approx(detail["tangent_rel_err"], rel=1e-12)
+        assert len(iter_cases) == batch.n_cases
+        for iter_c, batch_c in zip(iter_cases, batch.cases):
+            assert iter_c.index == batch_c.index
+            assert iter_c.passed == batch_c.passed
+            assert iter_c.stress_rel_err == pytest.approx(batch_c.stress_rel_err, rel=1e-12)
+            assert iter_c.tangent_rel_err == pytest.approx(batch_c.tangent_rel_err, rel=1e-12)
 
     def test_early_break_on_failure(self, model, test_cases):
         solver_a = _solver("numerical_newton")


### PR DESCRIPTION
## Summary

- **共有ヘルパーを `comparator.py` に統合**: `_stress_rel_err` / `_state_rel_err` / `_tangent_rel_err` / `_array_rel_err` / `_case_passed` を一元化。stress rel-err の分母を `+1.0`（`compare.py` の `+1e-300` を統一）に揃え、unloading 時の 0/0 を防止
- **`run()` 3 重実装を解消**: `Comparator` ABC に `_result_cls` + `_aggregate_extra()` フックを追加。`SolverComparison` / `ReturnMappingCrosscheck` / `StressUpdateCrosscheck` の `run()` override を全廃
- **legacy `details` API を撤去**: `SolverComparisonResult.details`、`check_residual_history`、`check_n_iterations` を削除。テストを `result.cases`（`SolverCaseResult` リスト）ベースに移行
- **名前の負債を解消**: `test_umat_verifier.py` → `test_test_cases.py` にリネーム。`compare_solvers` / `iter_compare_solvers` への参照を docstring / README / CLAUDE.md で一掃。`FortranUMAT` の deep import を公開 API に統一

## Test plan

- [x] `make test-unit` — 236 passed
- [x] `make test-integration` — 195 passed, 29 deselected
- [x] `make test` — 430 passed, 30 deselected
- [ ] `make test-fortran` — Fortran コンパイル環境で確認（`test_test_cases.py` のリネームが pytest に収集されること、`test_compare_solvers.py` の移行テストが通ること）

## Breaking changes

後方互換不要の前提で実施。`SolverComparisonResult.details`、`SolverComparison(check_residual_history=...)` / `(check_n_iterations=...)` は削除済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)