### PR TITLE
refactor: Driver/Crosscheck — Integrator を init で受け取る統一設計 (Part 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ strain_history = np.zeros((100, 6))
 strain_history[:, 0] = np.linspace(0.0, 5e-3, 100)   # ε11 を増加
 load = FieldHistory(FieldType.STRAIN, "Strain", strain_history)
 
-result = StrainDriver().run(PythonIntegrator(model), load)
+result = StrainDriver(PythonIntegrator(model)).run(load)
 print(f"Final σ11: {result.stress[-1, 0]:.1f} MPa")
 ```
 
@@ -192,13 +192,13 @@ from manforge.simulation.types import FieldHistory, FieldType
 strain_history = np.zeros((100, 6))
 strain_history[:, 0] = np.linspace(0, 5e-3, 100)
 load = FieldHistory(FieldType.STRAIN, "Strain", strain_history)
-result = StrainDriver().run(PythonIntegrator(model), load)
+result = StrainDriver(PythonIntegrator(model)).run(load)
 result.stress    # np.ndarray (N, ntens) — 各ステップの σ_{n+1}
 result.strain    # np.ndarray (N, ntens)
 
 # 状態変数収集
-result = StrainDriver().run(
-    PythonIntegrator(model), load,
+result = StrainDriver(PythonIntegrator(model)).run(
+    load,
     collect_state={"ep": FieldType.STRAIN}
 )
 result.fields["ep"].data   # np.ndarray (N,) — 等価塑性ひずみ履歴
@@ -207,7 +207,7 @@ result.fields["ep"].data   # np.ndarray (N,) — 等価塑性ひずみ履歴
 stress_target = np.zeros((100, 6))
 stress_target[:, 0] = np.linspace(0, 300.0, 100)
 stress_load = FieldHistory(FieldType.STRESS, "Stress", stress_target)
-result = StressDriver().run(PythonIntegrator(model), stress_load)
+result = StressDriver(PythonIntegrator(model)).run(stress_load)
 ```
 
 Driver は必ず `StressIntegrator` を受け取る。bare `MaterialModel` を渡すと `TypeError` になる。Integrator クラスは 3 種類:
@@ -229,15 +229,15 @@ print(step.dlambda, step.n_iterations)
 
 ```python
 from manforge.simulation.driver import StrainDriver
+from manforge.simulation.integrator import PythonIntegrator
 from manforge.simulation.types import FieldHistory, FieldType
 import numpy as np
 
 load = FieldHistory(FieldType.STRAIN, "Strain", np.linspace(0, 5e-3, 100))
-driver = StrainDriver()
-integrator = PythonIntegrator(model)
+driver = StrainDriver(PythonIntegrator(model))
 
 # 塑性開始ステップで break
-for step in driver.iter_run(integrator, load):
+for step in driver.iter_run(load):
     # step.i           — 0-based ステップ番号
     # step.strain      — 累積ひずみ (ntens,)
     # step.result      — StressUpdateResult (stress, state, ddsdde, dlambda, ...)
@@ -252,7 +252,6 @@ for step in driver.iter_run(integrator, load):
 
 ```python
 from manforge.simulation.driver import StrainDriver
-from manforge.simulation.driver import StrainDriver
 from manforge.fitting import fit_params
 
 fit_config = {
@@ -260,7 +259,9 @@ fit_config = {
     "H":        (500.0, (0.0,  5000.0)),
 }
 result = fit_params(
-    model, StrainDriver(), exp_data,
+    model,
+    driver_factory=lambda i: StrainDriver(i),
+    exp_data=exp_data,
     fit_config=fit_config,
     fixed_params={"E": 210_000.0, "nu": 0.3},
     method="L-BFGS-B",
@@ -385,7 +386,7 @@ strain_history = np.zeros((150, 6))
 strain_history[:50, 0]  = np.linspace(0, 1e-2, 50)
 strain_history[50:, 0]  = np.linspace(1e-2, -1e-2, 100)
 load = FieldHistory(FieldType.STRAIN, "Strain", strain_history)
-result = StrainDriver().run(PythonIntegrator(model_af), load)
+result = StrainDriver(PythonIntegrator(model_af)).run(load)
 ```
 
 飽和 backstress の比較:

--- a/benchmarks/bench_autodiff.py
+++ b/benchmarks/bench_autodiff.py
@@ -66,12 +66,11 @@ def _make_driver_step():
     strain_history = np.zeros((40, 6))
     strain_history[:, 0] = np.linspace(0.0, 5e-3, 40)
 
-    driver = StrainDriver()
     integrator = PythonIntegrator(model)
     load = FieldHistory(FieldType.STRAIN, "eps", strain_history)
 
     def run():
-        driver.run(integrator, load)
+        StrainDriver(integrator).run(load)
 
     return run
 

--- a/examples/crosscheck_umat_advanced.py
+++ b/examples/crosscheck_umat_advanced.py
@@ -28,8 +28,6 @@ sys.path.insert(0, os.path.abspath(_fortran_dir))
 
 from manforge.models.j2_isotropic import J2Isotropic3D
 from manforge.simulation import (
-    StrainDriver,
-    StressDriver,
     PythonNumericalIntegrator,
     PythonAnalyticalIntegrator,
     FortranIntegrator,
@@ -116,7 +114,7 @@ py_int2 = PythonAnalyticalIntegrator(model)
 fc_int2 = _make_fc_int(fortran_j2)
 
 cc2 = StressUpdateCrosscheck(py_int2, fc_int2)
-result2 = cc2.run(StrainDriver(), load)
+result2 = cc2.run(load)
 
 print(f"  passed           : {result2.passed}  ({result2.n_passed}/{result2.n_cases} steps)")
 print(f"  max stress err   : {result2.max_stress_rel_err:.2e}")
@@ -142,7 +140,7 @@ fc_int3 = _make_fc_int(fortran_j2)
 cc3 = StressUpdateCrosscheck(py_int3, fc_int3)
 
 print("  Normal run (printing every 5th step):")
-for cr in cc3.iter_run(StrainDriver(), load):
+for cr in cc3.iter_run(load):
     if cr.index % 5 == 0:
         print(
             f"    step {cr.index:2d}: stress_err={cr.stress_rel_err:.1e}  "
@@ -161,7 +159,7 @@ fc_int3_bad = FortranIntegrator(
 )
 cc3_bad = StressUpdateCrosscheck(py_int3, fc_int3_bad)
 first_fail_index = None
-for cr in cc3_bad.iter_run(StrainDriver(), load):
+for cr in cc3_bad.iter_run(load):
     if not cr.passed:
         first_fail_index = cr.index
         print(f"    First failure at step {cr.index}: stress_err={cr.stress_rel_err:.2e}")
@@ -187,7 +185,7 @@ stress_load = FieldHistory(FieldType.STRESS, "sigma", stress_data)
 py_int4 = PythonNumericalIntegrator(model)
 fc_int4 = _make_fc_int(fortran_j2)
 cc4 = StressUpdateCrosscheck(py_int4, fc_int4)
-result4 = cc4.run(StressDriver(), stress_load)
+result4 = cc4.run(stress_load)
 
 print(f"  passed        : {result4.passed}  ({result4.n_passed}/{result4.n_cases} steps)")
 print(f"  max stress err: {result4.max_stress_rel_err:.2e}")

--- a/examples/crosscheck_umat_external.py
+++ b/examples/crosscheck_umat_external.py
@@ -26,7 +26,7 @@ _fortran_dir = os.path.join(os.path.dirname(__file__), "..", "fortran")
 sys.path.insert(0, os.path.abspath(_fortran_dir))
 
 from manforge.models.j2_isotropic import J2Isotropic3D
-from manforge.simulation import StrainDriver, PythonNumericalIntegrator, FortranIntegrator
+from manforge.simulation import PythonNumericalIntegrator, FortranIntegrator
 from manforge.simulation.types import FieldHistory, FieldType
 from manforge.verification import FortranUMAT, StressUpdateCrosscheck, generate_strain_history
 
@@ -76,7 +76,7 @@ cc = StressUpdateCrosscheck(py_int, fc_int)
 # ---------------------------------------------------------------------------
 # 5. Run and inspect the result
 # ---------------------------------------------------------------------------
-result = cc.run(StrainDriver(), load)
+result = cc.run(load)
 
 print(f"passed             : {result.passed}")
 print(f"n_cases            : {result.n_cases}")

--- a/examples/example_fit_j2.py
+++ b/examples/example_fit_j2.py
@@ -33,7 +33,7 @@ except ImportError:
 # True model
 # ---------------------------------------------------------------------------
 true_model = J2Isotropic1D(E=210_000.0, nu=0.3, sigma_y0=250.0, H=1_000.0)
-driver = StrainDriver()
+driver_factory = lambda i: StrainDriver(i)
 
 # ---------------------------------------------------------------------------
 # Generate synthetic "experimental" data
@@ -42,7 +42,7 @@ rng = np.random.default_rng(42)
 N = 50
 strain_exp = np.linspace(0.0, 5e-3, N)
 load = FieldHistory(FieldType.STRAIN, "Strain", strain_exp)
-stress_clean = driver.run(PythonIntegrator(true_model), load).stress[:, 0]
+stress_clean = driver_factory(PythonIntegrator(true_model)).run(load).stress[:, 0]
 
 # Add small Gaussian noise (~0.5 MPa std) to simulate measurement scatter
 noise_std = 0.5
@@ -71,7 +71,7 @@ print("  Running optimisation …")
 
 result = fit_params(
     true_model,
-    driver,
+    driver_factory,
     exp_data,
     fit_config,
     fixed_params=fixed_params,
@@ -99,7 +99,7 @@ if HAS_MATPLOTLIB:
         E=true_model.E, nu=true_model.nu,
         sigma_y0=fitted_sigma_y0, H=fitted_H,
     )
-    stress_fitted = driver.run(PythonIntegrator(fitted_model), load).stress[:, 0]
+    stress_fitted = driver_factory(PythonIntegrator(fitted_model)).run(load).stress[:, 0]
 
     fig, axes = plt.subplots(1, 2, figsize=(12, 4))
 

--- a/examples/example_j2_uniaxial.py
+++ b/examples/example_j2_uniaxial.py
@@ -43,12 +43,10 @@ model = J2Isotropic1D(
 # ---------------------------------------------------------------------------
 # Simulation
 # ---------------------------------------------------------------------------
-driver = StrainDriver()
-
 N = 100
 strain_history = np.linspace(0.0, 5e-3, N)   # cumulative ε11
 load = FieldHistory(FieldType.STRAIN, "Strain", strain_history)
-result = driver.run(PythonIntegrator(model), load)
+result = StrainDriver(PythonIntegrator(model)).run(load)
 stress_history = result.stress[:, 0]   # σ11
 
 # ---------------------------------------------------------------------------

--- a/examples/example_ow_convergence.py
+++ b/examples/example_ow_convergence.py
@@ -100,9 +100,8 @@ print("=" * 60)
 print("  Part 3: StrainDriver — OW history across loading steps")
 print("=" * 60)
 
-driver = StrainDriver()
 load = FieldHistory(FieldType.STRAIN, "Strain", np.linspace(0.0, 5e-3, 20))
-dr = driver.run(PythonIntegrator(ow), load)
+dr = StrainDriver(PythonIntegrator(ow)).run(load)
 
 elastic_count = sum(1 for rm in dr.step_results if not rm.is_plastic)
 plastic_count = sum(1 for rm in dr.step_results if rm.is_plastic)

--- a/examples/example_verify_j2_analytical.py
+++ b/examples/example_verify_j2_analytical.py
@@ -142,11 +142,10 @@ print("=" * 60)
 print("  Part 3: Driver step-by-step verification")
 print("=" * 60)
 
-driver = StrainDriver()
 N = 30
 strain_history = np.linspace(0.0, 5e-3, N)
 load = FieldHistory(FieldType.STRAIN, "Strain", strain_history)
-driver_result = driver.run(PythonIntegrator(model), load)
+driver_result = StrainDriver(PythonIntegrator(model)).run(load)
 
 # Find the first plastic step
 first_plastic = None

--- a/src/manforge/fitting/objective.py
+++ b/src/manforge/fitting/objective.py
@@ -23,7 +23,7 @@ def residual_sum_of_squares(stress_computed, stress_experiment, weights=None):
     return float(np.sum(sq))
 
 
-def build_objective(model, driver, exp_data, fixed_params=None):
+def build_objective(model, driver_factory, exp_data, fixed_params=None):
     """Build a scalar objective function for use with scipy.optimize.
 
     Parameters
@@ -31,8 +31,10 @@ def build_objective(model, driver, exp_data, fixed_params=None):
     model : MaterialModel
         Template model instance — used to determine the class and stress_state.
         A new instance is constructed each evaluation with the current params.
-    driver : DriverBase
-        Pre-configured driver instance.
+    driver_factory : callable
+        ``driver_factory(integrator) -> DriverBase`` — called once per
+        objective evaluation to construct a driver bound to the current
+        integrator.  Example: ``lambda i: StrainDriver(i)``.
     exp_data : dict
         Must contain ``"strain"`` and ``"stress"``.  Optionally ``"weights"``.
     fixed_params : dict or None
@@ -55,7 +57,8 @@ def build_objective(model, driver, exp_data, fixed_params=None):
     def objective(free_params: dict) -> float:
         all_params = {**fixed, **free_params}
         m = model_cls(stress_state=stress_state, **all_params)
-        result = driver.run(PythonIntegrator(m), load)
+        integrator = PythonIntegrator(m)
+        result = driver_factory(integrator).run(load)
         stress_comp = result.stress
         if stress_exp.ndim == 1:
             stress_comp = stress_comp[:, 0]

--- a/src/manforge/fitting/optimizer.py
+++ b/src/manforge/fitting/optimizer.py
@@ -43,7 +43,7 @@ class FitResult:
 
 def fit_params(
     model,
-    driver,
+    driver_factory,
     exp_data: dict,
     fit_config: dict,
     fixed_params: dict | None = None,
@@ -55,8 +55,10 @@ def fit_params(
     ----------
     model : MaterialModel
         Constitutive model instance.
-    driver : UniaxialDriver or GeneralDriver
-        Loading driver.
+    driver_factory : callable
+        ``driver_factory(integrator) -> DriverBase`` — constructs a driver
+        bound to the given integrator for each objective evaluation.
+        Example: ``lambda i: StrainDriver(i)``.
     exp_data : dict
         ``{"strain": ..., "stress": ..., "weights": ...}``  (weights optional).
     fit_config : dict
@@ -96,7 +98,7 @@ def fit_params(
     ]
 
     # Build objective — accepts a dict of free params
-    obj_fn = build_objective(model, driver, exp_data, fixed_params=fixed)
+    obj_fn = build_objective(model, driver_factory, exp_data, fixed_params=fixed)
 
     history: list[dict] = []
 

--- a/src/manforge/simulation/driver.py
+++ b/src/manforge/simulation/driver.py
@@ -2,9 +2,10 @@
 
 All drivers share the same interface via :class:`DriverBase`:
 
-* Input  — a :class:`~manforge.simulation.integrator.StressIntegrator` and a
+* Input  — the driver holds a :class:`~manforge.simulation.integrator.StressIntegrator`
+  (passed at construction) and receives a
   :class:`~manforge.simulation.types.FieldHistory` containing the prescribed
-  loading history (strain or stress).
+  loading history (strain or stress) at each :meth:`run` / :meth:`iter_run` call.
 * Output — :class:`~manforge.simulation.types.DriverResult` containing
   stress and strain at every step, plus any explicitly requested state
   variables.
@@ -14,8 +15,8 @@ Conventions
 - Stress and strain arrays use the engineering-shear Voigt convention:
     σ, ε = [11, 22, 33, 12, 13, 23]
 - *Cumulative* quantities are the input; increments are computed internally.
-- Drivers require a :class:`~manforge.simulation.integrator.StressIntegrator`.
-  Wrap bare ``MaterialModel`` objects with
+- Drivers require a :class:`~manforge.simulation.integrator.StressIntegrator`
+  at construction time.  Wrap bare ``MaterialModel`` objects with
   :class:`~manforge.simulation.integrator.PythonIntegrator` (auto solver),
   :class:`~manforge.simulation.integrator.PythonNumericalIntegrator`
   (numerical Newton-Raphson), or
@@ -49,26 +50,29 @@ def _check_integrator(obj) -> None:
 class DriverBase(ABC):
     """Abstract base for all simulation drivers.
 
-    Subclasses implement :meth:`iter_run` and :meth:`run`.  Both accept a
-    :class:`~manforge.simulation.integrator.StressIntegrator` (not a bare
-    ``MaterialModel``) as their first argument.
+    Parameters
+    ----------
+    integrator : StressIntegrator
+        Constitutive integrator — use
+        :class:`~manforge.simulation.integrator.PythonIntegrator`,
+        :class:`~manforge.simulation.integrator.PythonNumericalIntegrator`,
+        :class:`~manforge.simulation.integrator.PythonAnalyticalIntegrator`, or
+        :class:`~manforge.simulation.integrator.FortranIntegrator`.
     """
+
+    def __init__(self, integrator) -> None:
+        _check_integrator(integrator)
+        self.integrator = integrator
 
     @abstractmethod
     def iter_run(
         self,
-        integrator,
         load: FieldHistory,
     ) -> Iterator[DriverStep]:
         """Yield per-step results as a generator.
 
         Parameters
         ----------
-        integrator : StressIntegrator
-            Constitutive integrator — use :class:`~manforge.simulation.integrator.PythonIntegrator`,
-            :class:`~manforge.simulation.integrator.PythonNumericalIntegrator`,
-            :class:`~manforge.simulation.integrator.PythonAnalyticalIntegrator`, or
-            :class:`~manforge.simulation.integrator.FortranIntegrator`.
         load : FieldHistory
             Loading history (same requirements as :meth:`run`).
 
@@ -83,8 +87,8 @@ class DriverBase(ABC):
         --------
         Break on plasticity onset::
 
-            integrator = PythonIntegrator(model)
-            for step in driver.iter_run(integrator, load):
+            driver = StrainDriver(PythonIntegrator(model))
+            for step in driver.iter_run(load):
                 if step.result.is_plastic:
                     print(f"Plasticity at step {step.i}")
                     break
@@ -92,16 +96,14 @@ class DriverBase(ABC):
 
     def run(
         self,
-        integrator,
         load: FieldHistory,
+        *,
         collect_state: dict[str, FieldType] | None = None,
     ) -> DriverResult:
         """Run the loading simulation.
 
         Parameters
         ----------
-        integrator : StressIntegrator
-            Constitutive integrator.
         load : FieldHistory
             Loading history.  The ``type`` and shape of ``load.data`` must
             match the driver's expectations (see subclass documentation).
@@ -118,16 +120,15 @@ class DriverBase(ABC):
         -------
         DriverResult
         """
-        _check_integrator(integrator)
         step_results = []
         strain_rows = []
-        for step in self.iter_run(integrator, load):
+        for step in self.iter_run(load):
             step_results.append(step.result)
             strain_rows.append(step.strain)
         strain_out = (
             np.stack(strain_rows)
             if strain_rows
-            else np.zeros((0, integrator.ntens))
+            else np.zeros((0, self.integrator.ntens))
         )
         return DriverResult(
             step_results=step_results,
@@ -148,19 +149,18 @@ class StrainDriver(DriverBase):
 
     Parameters
     ----------
-    (none — stateless, all inputs passed to :meth:`run`)
+    integrator : StressIntegrator
+        Constitutive integrator.
     """
 
     def iter_run(
         self,
-        integrator,
         load: FieldHistory,
     ) -> Iterator[DriverStep]:
         """Yield per-step results for the strain-controlled loading history.
 
         Parameters
         ----------
-        integrator : StressIntegrator
         load : FieldHistory
             Must have ``type = FieldType.STRAIN``.  ``load.data`` shape:
 
@@ -171,7 +171,7 @@ class StrainDriver(DriverBase):
         ------
         DriverStep
         """
-        _check_integrator(integrator)
+        integrator = self.integrator
         data = np.asarray(load.data, dtype=float)
         uniaxial = data.ndim == 1
         ntens = integrator.ntens
@@ -212,6 +212,8 @@ class StressDriver(DriverBase):
 
     Parameters
     ----------
+    integrator : StressIntegrator
+        Constitutive integrator.
     max_iter : int, optional
         Maximum Newton-Raphson iterations per step (default 20).
     tol : float, optional
@@ -219,13 +221,13 @@ class StressDriver(DriverBase):
         (default 1e-8).
     """
 
-    def __init__(self, max_iter: int = 20, tol: float = 1e-8):
+    def __init__(self, integrator, *, max_iter: int = 20, tol: float = 1e-8):
+        super().__init__(integrator)
         self.max_iter = max_iter
         self.tol = tol
 
     def iter_run(
         self,
-        integrator,
         load: FieldHistory,
         *,
         raise_on_nonconverged: bool = True,
@@ -234,7 +236,6 @@ class StressDriver(DriverBase):
 
         Parameters
         ----------
-        integrator : StressIntegrator
         load : FieldHistory
             Must have ``type = FieldType.STRESS`` and
             ``load.data`` shape ``(N, ntens)`` — cumulative target stress
@@ -255,7 +256,7 @@ class StressDriver(DriverBase):
         RuntimeError
             If NR does not converge and ``raise_on_nonconverged=True``.
         """
-        _check_integrator(integrator)
+        integrator = self.integrator
         stress_history = np.asarray(load.data, dtype=float)
         ntens = integrator.ntens
 
@@ -315,15 +316,14 @@ class StressDriver(DriverBase):
 
     def run(
         self,
-        integrator,
         load: FieldHistory,
+        *,
         collect_state: dict[str, FieldType] | None = None,
     ) -> DriverResult:
         """Run the stress-controlled loading history.
 
         Parameters
         ----------
-        integrator : StressIntegrator
         load : FieldHistory
             Must have ``type = FieldType.STRESS`` and
             ``load.data`` shape ``(N, ntens)`` — cumulative target stress
@@ -341,20 +341,18 @@ class StressDriver(DriverBase):
             If Newton-Raphson does not converge within ``max_iter`` iterations
             at any step.
         """
-        _check_integrator(integrator)
         step_results = []
         strain_rows = []
-        for step in self.iter_run(integrator, load, raise_on_nonconverged=True):
+        for step in self.iter_run(load, raise_on_nonconverged=True):
             step_results.append(step.result)
             strain_rows.append(step.strain)
         strain_out = (
             np.stack(strain_rows)
             if strain_rows
-            else np.zeros((0, integrator.ntens))
+            else np.zeros((0, self.integrator.ntens))
         )
         return DriverResult(
             step_results=step_results,
             strain=strain_out,
             collect_state=collect_state,
         )
-

--- a/src/manforge/verification/umat_crosscheck.py
+++ b/src/manforge/verification/umat_crosscheck.py
@@ -1,8 +1,11 @@
 """Multi-step crosscheck: two StressIntegrators over a loading history.
 
 :class:`StressUpdateCrosscheck` is a :class:`~manforge.verification.Comparator`
-subclass that drives two integrators through the same loading sequence via a
-Driver, then compares stress / state / tangent at every step.
+subclass that drives two integrators through the same loading sequence, then
+compares stress / state / tangent at every step.  The driver type is determined
+automatically from ``load.type``: :class:`~manforge.simulation.StrainDriver` for
+``FieldType.STRAIN`` and :class:`~manforge.simulation.StressDriver` for
+``FieldType.STRESS``.
 
 Phase 5 workflow
 ----------------
@@ -10,7 +13,7 @@ Phase 5 workflow
 
     from manforge.verification import StressUpdateCrosscheck, FortranUMAT
     from manforge.simulation import (
-        StrainDriver, PythonNumericalIntegrator, FortranIntegrator,
+        PythonNumericalIntegrator, FortranIntegrator,
     )
     from manforge.simulation.types import FieldHistory, FieldType
     import numpy as np
@@ -30,7 +33,7 @@ Phase 5 workflow
     )
 
     cc = StressUpdateCrosscheck(py_int, fc_int)
-    result = cc.run(StrainDriver(), load)
+    result = cc.run(load)
     assert result.passed
     print(f"max stress rel error = {result.max_stress_rel_err:.2e}")
 
@@ -50,6 +53,8 @@ from dataclasses import dataclass, field
 
 import numpy as np
 
+from manforge.simulation.driver import StrainDriver, StressDriver
+from manforge.simulation.types import FieldType
 from manforge.verification.comparator_base import (
     CaseResult,
     ComparisonResult,
@@ -103,8 +108,9 @@ class StressUpdateCrosscheck(Comparator):
     """Compare two :class:`~manforge.simulation.integrator.StressIntegrator` implementations
     over a loading history.
 
-    Drives both integrators through the same multi-step sequence via a Driver,
-    then compares stress / state / tangent at every step.
+    Drives both integrators through the same multi-step sequence and compares
+    stress / state / tangent at every step.  The driver type is selected
+    automatically from ``load.type`` at :meth:`run` / :meth:`iter_run` time.
 
     Parameters
     ----------
@@ -120,13 +126,17 @@ class StressUpdateCrosscheck(Comparator):
         Pass threshold for relative tangent error (default 1e-5).
     state_tol : float, optional
         Pass threshold for per state-variable relative error (default 1e-6).
+    stress_driver_kwargs : dict or None, optional
+        Extra keyword arguments forwarded to :class:`~manforge.simulation.StressDriver`
+        when the load is stress-controlled (e.g. ``{"max_iter": 30, "tol": 1e-10}``).
+        Ignored for strain-controlled loads.
 
     Examples
     --------
     ::
 
         from manforge.simulation import (
-            PythonNumericalIntegrator, FortranIntegrator, StrainDriver,
+            PythonNumericalIntegrator, FortranIntegrator,
         )
 
         py_int = PythonNumericalIntegrator(model)
@@ -139,10 +149,10 @@ class StressUpdateCrosscheck(Comparator):
         )
 
         cc = StressUpdateCrosscheck(py_int, fc_int)
-        result = cc.run(StrainDriver(), load)
+        result = cc.run(load)
         assert result.passed
 
-        for cr in cc.iter_run(StrainDriver(), load):
+        for cr in cc.iter_run(load):
             if not cr.passed:
                 print(f"step {cr.index}: stress_err={cr.stress_rel_err:.2e}")
                 break
@@ -158,34 +168,43 @@ class StressUpdateCrosscheck(Comparator):
         stress_tol: float = 1e-6,
         tangent_tol: float = 1e-5,
         state_tol: float = 1e-6,
+        stress_driver_kwargs: dict | None = None,
     ) -> None:
         self.integrator_a = integrator_a
         self.integrator_b = integrator_b
         self.stress_tol = stress_tol
         self.tangent_tol = tangent_tol
         self.state_tol = state_tol
+        self._stress_driver_kwargs = stress_driver_kwargs or {}
+
+    def _driver_for(self, integrator, load):
+        if load.type == FieldType.STRAIN:
+            return StrainDriver(integrator)
+        if load.type == FieldType.STRESS:
+            return StressDriver(integrator, **self._stress_driver_kwargs)
+        raise ValueError(f"Unsupported load.type: {load.type!r}")
 
     def iter_run(
         self,
-        driver,
         load,
     ) -> Iterator[CrosscheckCaseResult]:
         """Yield per-step crosscheck results.
 
         Parameters
         ----------
-        driver
-            An instantiated driver, e.g. ``StrainDriver()`` or ``StressDriver()``.
         load : FieldHistory
+            Loading history.  ``load.type`` determines whether
+            :class:`~manforge.simulation.StrainDriver` or
+            :class:`~manforge.simulation.StressDriver` is used internally.
 
         Yields
         ------
         CrosscheckCaseResult
         """
-        for sa, sb in zip(
-            driver.iter_run(self.integrator_a, load),
-            driver.iter_run(self.integrator_b, load),
-        ):
+        da = self._driver_for(self.integrator_a, load)
+        db = self._driver_for(self.integrator_b, load)
+
+        for sa, sb in zip(da.iter_run(load), db.iter_run(load)):
             ra = sa.result
             rb = sb.result
 

--- a/tests/fortran/test_umat_crosscheck.py
+++ b/tests/fortran/test_umat_crosscheck.py
@@ -70,7 +70,7 @@ def test_crosscheck_stress_update_numerical_newton(fortran_j2, model):
     fc_int = _make_fc_int(fortran_j2, model)
 
     cc = StressUpdateCrosscheck(py_int, fc_int)
-    result = cc.run(StrainDriver(), _j2_load(model))
+    result = cc.run(_j2_load(model))
 
     assert result.passed, f"max_stress_rel_err = {result.max_stress_rel_err:.2e}"
     assert result.max_stress_rel_err < 1e-6
@@ -83,7 +83,7 @@ def test_crosscheck_stress_update_user_defined(fortran_j2, model):
     fc_int = _make_fc_int(fortran_j2, model)
 
     cc = StressUpdateCrosscheck(py_int, fc_int)
-    result = cc.run(StrainDriver(), _j2_load(model))
+    result = cc.run(_j2_load(model))
 
     assert result.passed, f"max_stress_rel_err = {result.max_stress_rel_err:.2e}"
     assert result.max_stress_rel_err < 1e-6
@@ -101,7 +101,7 @@ def test_crosscheck_stress_update_stress_driven(fortran_j2, model):
     fc_int = _make_fc_int(fortran_j2, model)
 
     cc = StressUpdateCrosscheck(py_int, fc_int)
-    result = cc.run(StressDriver(), load)
+    result = cc.run(load)
 
     assert result.passed, f"max_stress_rel_err = {result.max_stress_rel_err:.2e}"
 
@@ -123,7 +123,7 @@ def test_iter_crosscheck_stress_update_breakable(fortran_j2, model):
     cc = StressUpdateCrosscheck(py_int, fc_int)
 
     found_failure = False
-    for cr in cc.iter_run(StrainDriver(), load):
+    for cr in cc.iter_run(load):
         if not cr.passed:
             found_failure = True
             break
@@ -178,7 +178,7 @@ def test_param_fn_order_sensitivity(fortran_j2, model):
     )
 
     cc = StressUpdateCrosscheck(py_int, fc_int)
-    result = cc.run(StrainDriver(), _j2_load(model))
+    result = cc.run(_j2_load(model))
 
     assert not result.passed, (
         "Expected crosscheck to fail with wrong param_fn order, "

--- a/tests/integration/test_convergence_history.py
+++ b/tests/integration/test_convergence_history.py
@@ -131,9 +131,8 @@ def test_augmented_nr_quadratic_convergence(ow_model):
 
 def test_driver_j2_analytical_history(j2_model):
     """J2 user_defined_return_mapping records n_iterations=1 and 2-entry history."""
-    driver = StrainDriver()
     load = FieldHistory(FieldType.STRAIN, "Strain", np.linspace(0.0, 5e-3, 20))
-    dr = driver.run(PythonIntegrator(j2_model), load)
+    dr = StrainDriver(PythonIntegrator(j2_model)).run(load)
 
     for rm in dr.step_results:
         if rm.is_plastic:
@@ -147,9 +146,8 @@ def test_driver_j2_analytical_history(j2_model):
 
 def test_driver_j2_autodiff_has_history(j2_model):
     """With method='numerical_newton', J2 plastic steps record NR history."""
-    driver = StrainDriver()
     load = FieldHistory(FieldType.STRAIN, "Strain", np.linspace(0.0, 5e-3, 20))
-    dr = driver.run(PythonNumericalIntegrator(j2_model), load)
+    dr = StrainDriver(PythonNumericalIntegrator(j2_model)).run(load)
 
     for rm in dr.step_results:
         if rm.is_plastic:
@@ -162,9 +160,8 @@ def test_driver_j2_autodiff_has_history(j2_model):
 
 @pytest.mark.slow
 def test_driver_ow_step_results_have_history(ow_model):
-    driver = StrainDriver()
     load = FieldHistory(FieldType.STRAIN, "Strain", np.linspace(0.0, 5e-3, 20))
-    dr = driver.run(PythonIntegrator(ow_model), load)
+    dr = StrainDriver(PythonIntegrator(ow_model)).run(load)
 
     for rm in dr.step_results:
         if rm.is_plastic:

--- a/tests/integration/test_driver_iter_run.py
+++ b/tests/integration/test_driver_iter_run.py
@@ -31,37 +31,32 @@ def _stress_load(integrator, n_steps=20, max_stress=300.0):
 
 class TestStrainDriverIterRun:
     def test_yields_driver_step_instances(self, model):
-        driver = StrainDriver()
-        integrator = PythonNumericalIntegrator(model)
-        for step in driver.iter_run(integrator, _strain_load()):
+        driver = StrainDriver(PythonNumericalIntegrator(model))
+        for step in driver.iter_run(_strain_load()):
             assert isinstance(step, DriverStep)
 
     def test_step_index_sequential(self, model):
-        driver = StrainDriver()
-        integrator = PythonNumericalIntegrator(model)
-        indices = [s.i for s in driver.iter_run(integrator, _strain_load(n_steps=10))]
+        driver = StrainDriver(PythonNumericalIntegrator(model))
+        indices = [s.i for s in driver.iter_run(_strain_load(n_steps=10))]
         assert indices == list(range(10))
 
     def test_strain_shape(self, model):
-        driver = StrainDriver()
-        integrator = PythonNumericalIntegrator(model)
-        for step in driver.iter_run(integrator, _strain_load()):
+        driver = StrainDriver(PythonNumericalIntegrator(model))
+        for step in driver.iter_run(_strain_load()):
             assert step.strain.shape == (model.ntens,)
 
     def test_converged_always_true(self, model):
-        driver = StrainDriver()
-        integrator = PythonNumericalIntegrator(model)
-        for step in driver.iter_run(integrator, _strain_load()):
+        driver = StrainDriver(PythonNumericalIntegrator(model))
+        for step in driver.iter_run(_strain_load()):
             assert step.converged is True
             assert step.n_outer_iter == 1
             assert step.residual_inf == 0.0
 
     def test_matches_run_uniaxial(self, model):
         load = _strain_load(n_steps=25)
-        driver = StrainDriver()
         integrator = PythonNumericalIntegrator(model)
-        result_run = driver.run(integrator, load)
-        steps = list(driver.iter_run(integrator, load))
+        result_run = StrainDriver(integrator).run(load)
+        steps = list(StrainDriver(integrator).iter_run(load))
 
         assert len(steps) == len(result_run.step_results)
         for step, rm in zip(steps, result_run.step_results):
@@ -73,19 +68,17 @@ class TestStrainDriverIterRun:
     def test_matches_run_multiaxial(self, model):
         integrator = PythonNumericalIntegrator(model)
         load = _multiaxial_strain_load(integrator, n_steps=20)
-        driver = StrainDriver()
-        result_run = driver.run(integrator, load)
-        steps = list(driver.iter_run(integrator, load))
+        result_run = StrainDriver(integrator).run(load)
+        steps = list(StrainDriver(integrator).iter_run(load))
 
         stress_iter = np.stack([np.array(s.result.stress) for s in steps])
         np.testing.assert_allclose(stress_iter, result_run.stress, rtol=1e-12)
 
     def test_early_break_on_plastic(self, model):
         load = _strain_load(n_steps=30, max_strain=5e-3)
-        driver = StrainDriver()
-        integrator = PythonNumericalIntegrator(model)
+        driver = StrainDriver(PythonNumericalIntegrator(model))
         plastic_steps = []
-        for step in driver.iter_run(integrator, load):
+        for step in driver.iter_run(load):
             if step.result.is_plastic:
                 plastic_steps.append(step.i)
                 break
@@ -96,16 +89,14 @@ class TestStrainDriverIterRun:
         max_strain = 3e-3
         strains = np.linspace(0, max_strain, n)
         load = FieldHistory(FieldType.STRAIN, "Strain", strains)
-        driver = StrainDriver()
-        integrator = PythonNumericalIntegrator(model)
-        for step in driver.iter_run(integrator, load):
+        driver = StrainDriver(PythonNumericalIntegrator(model))
+        for step in driver.iter_run(load):
             np.testing.assert_allclose(step.strain[0], strains[step.i], rtol=1e-12)
 
     def test_state_accessible_from_step(self, model):
         load = _strain_load(n_steps=20, max_strain=5e-3)
-        driver = StrainDriver()
-        integrator = PythonNumericalIntegrator(model)
-        for step in driver.iter_run(integrator, load):
+        driver = StrainDriver(PythonNumericalIntegrator(model))
+        for step in driver.iter_run(load):
             assert "ep" in step.result.state
 
 
@@ -116,34 +107,33 @@ class TestStrainDriverIterRun:
 class TestStressDriverIterRun:
     def test_yields_driver_step_instances(self, model):
         integrator = PythonNumericalIntegrator(model)
-        driver = StressDriver()
-        for step in driver.iter_run(integrator, _stress_load(integrator)):
+        driver = StressDriver(integrator)
+        for step in driver.iter_run(_stress_load(integrator)):
             assert isinstance(step, DriverStep)
 
     def test_step_index_sequential(self, model):
         integrator = PythonNumericalIntegrator(model)
-        driver = StressDriver()
-        indices = [s.i for s in driver.iter_run(integrator, _stress_load(integrator, n_steps=10))]
+        driver = StressDriver(integrator)
+        indices = [s.i for s in driver.iter_run(_stress_load(integrator, n_steps=10))]
         assert indices == list(range(10))
 
     def test_n_outer_iter_positive(self, model):
         integrator = PythonNumericalIntegrator(model)
-        driver = StressDriver()
-        for step in driver.iter_run(integrator, _stress_load(integrator)):
+        driver = StressDriver(integrator)
+        for step in driver.iter_run(_stress_load(integrator)):
             assert step.n_outer_iter >= 1
 
     def test_residual_inf_below_tol(self, model):
         integrator = PythonNumericalIntegrator(model)
-        driver = StressDriver(tol=1e-8)
-        for step in driver.iter_run(integrator, _stress_load(integrator)):
+        driver = StressDriver(integrator, tol=1e-8)
+        for step in driver.iter_run(_stress_load(integrator)):
             assert step.residual_inf < driver.tol
 
     def test_matches_run(self, model):
         integrator = PythonNumericalIntegrator(model)
         load = _stress_load(integrator, n_steps=20)
-        driver = StressDriver()
-        result_run = driver.run(integrator, load)
-        steps = list(driver.iter_run(integrator, load))
+        result_run = StressDriver(integrator).run(load)
+        steps = list(StressDriver(integrator).iter_run(load))
 
         assert len(steps) == len(result_run.step_results)
         for step, rm in zip(steps, result_run.step_results):
@@ -157,9 +147,9 @@ class TestStressDriverIterRun:
         huge_stress = np.zeros((5, model.ntens))
         huge_stress[:, 0] = np.linspace(1e8, 5e8, 5)
         load = FieldHistory(FieldType.STRESS, "Stress", huge_stress)
-        driver = StressDriver(max_iter=3)
+        driver = StressDriver(integrator, max_iter=3)
         with pytest.raises(RuntimeError, match="NR did not converge"):
-            list(driver.iter_run(integrator, load))
+            list(driver.iter_run(load))
 
     def test_nonconverged_opt_in_yields(self, model):
         # raise_on_nonconverged=False on the integrator lets the constitutive NR
@@ -168,9 +158,9 @@ class TestStressDriverIterRun:
         huge_stress = np.zeros((5, model.ntens))
         huge_stress[:, 0] = np.linspace(1e8, 5e8, 5)
         load = FieldHistory(FieldType.STRESS, "Stress", huge_stress)
-        driver = StressDriver(max_iter=3)
+        driver = StressDriver(integrator, max_iter=3)
         steps = []
-        for step in driver.iter_run(integrator, load, raise_on_nonconverged=False):
+        for step in driver.iter_run(load, raise_on_nonconverged=False):
             steps.append(step)
         assert len(steps) == 1
         assert steps[0].converged is False

--- a/tests/integration/test_driver_step_results.py
+++ b/tests/integration/test_driver_step_results.py
@@ -16,7 +16,6 @@ def _uniaxial_strain_load(n_steps=20, max_strain=3e-3):
 
 
 def _uniaxial_stress_load(model, n_steps=20):
-    C = np.array(model.elastic_stiffness())
     max_stress = 300.0
     stresses = np.zeros((n_steps, model.ntens))
     stresses[:, 0] = np.linspace(0, max_stress, n_steps)
@@ -30,77 +29,70 @@ def _uniaxial_stress_load(model, n_steps=20):
 class TestStrainDriverStepResults:
     def test_step_results_length(self, model):
         load = _uniaxial_strain_load(n_steps=20)
-        driver = StrainDriver()
-        result = driver.run(PythonNumericalIntegrator(model), load)
+        result = StrainDriver(PythonNumericalIntegrator(model)).run(load)
         assert len(result.step_results) == 20
 
     def test_step_results_are_return_mapping_results(self, model):
         load = _uniaxial_strain_load(n_steps=10)
-        driver = StrainDriver()
-        result = driver.run(PythonNumericalIntegrator(model), load)
+        result = StrainDriver(PythonNumericalIntegrator(model)).run(load)
         for rm in result.step_results:
             assert isinstance(rm, StressUpdateResult)
 
     def test_step_results_stress_matches_fields(self, model):
         load = _uniaxial_strain_load(n_steps=15)
-        driver = StrainDriver()
-        result = driver.run(PythonNumericalIntegrator(model), load)
+        result = StrainDriver(PythonNumericalIntegrator(model)).run(load)
         stress_from_steps = np.array([np.array(rm.stress) for rm in result.step_results])
         np.testing.assert_allclose(result.stress, stress_from_steps, rtol=1e-12)
 
     def test_plastic_steps_detected(self, model):
         load = _uniaxial_strain_load(n_steps=20, max_strain=5e-3)
-        driver = StrainDriver()
-        result = driver.run(PythonNumericalIntegrator(model), load)
+        result = StrainDriver(PythonNumericalIntegrator(model)).run(load)
         is_plastic = [rm.is_plastic for rm in result.step_results]
         assert any(is_plastic), "expected at least some plastic steps"
         assert not is_plastic[0], "first step (near zero strain) should be elastic"
 
     def test_dlambda_positive_in_plastic_steps(self, model):
         load = _uniaxial_strain_load(n_steps=20, max_strain=5e-3)
-        driver = StrainDriver()
-        result = driver.run(PythonNumericalIntegrator(model), load)
+        result = StrainDriver(PythonNumericalIntegrator(model)).run(load)
         for rm in result.step_results:
             if rm.is_plastic:
                 assert float(rm.dlambda) > 0.0
 
     def test_fields_stress_property(self, model):
         load = _uniaxial_strain_load(n_steps=10)
-        driver = StrainDriver()
-        result = driver.run(PythonNumericalIntegrator(model), load)
+        result = StrainDriver(PythonNumericalIntegrator(model)).run(load)
         assert result.stress.shape == (10, model.ntens)
 
     def test_fields_dict_contains_stress_and_strain(self, model):
         load = _uniaxial_strain_load(n_steps=10)
-        driver = StrainDriver()
-        result = driver.run(PythonNumericalIntegrator(model), load)
+        result = StrainDriver(PythonNumericalIntegrator(model)).run(load)
         fields = result.fields
         assert "Stress" in fields
         assert "Strain" in fields
 
     def test_collect_state_via_fields(self, model):
         load = _uniaxial_strain_load(n_steps=10, max_strain=5e-3)
-        driver = StrainDriver()
-        result = driver.run(PythonNumericalIntegrator(model), load, collect_state={"ep": FieldType.STRAIN})
+        result = StrainDriver(PythonNumericalIntegrator(model)).run(
+            load, collect_state={"ep": FieldType.STRAIN}
+        )
         ep_history = result.fields["ep"].data
         assert ep_history.shape == (10,)
         assert ep_history[-1] > 0.0
 
     def test_collect_state_matches_step_results(self, model):
         load = _uniaxial_strain_load(n_steps=10, max_strain=5e-3)
-        driver = StrainDriver()
-        result = driver.run(PythonNumericalIntegrator(model), load, collect_state={"ep": FieldType.STRAIN})
+        result = StrainDriver(PythonNumericalIntegrator(model)).run(
+            load, collect_state={"ep": FieldType.STRAIN}
+        )
         ep_from_steps = np.array([float(rm.state["ep"]) for rm in result.step_results])
         np.testing.assert_allclose(result.fields["ep"].data, ep_from_steps, rtol=1e-12)
 
     def test_step_n_minus_1_state_is_previous_step(self, model):
         load = _uniaxial_strain_load(n_steps=15, max_strain=5e-3)
-        driver = StrainDriver()
-        result = driver.run(PythonNumericalIntegrator(model), load)
+        result = StrainDriver(PythonNumericalIntegrator(model)).run(load)
         for i in range(1, len(result.step_results)):
             prev_state = result.step_results[i - 1].state
             curr_state_n = result.step_results[i].state
-            # Just verify ep is monotonically non-decreasing
             assert float(curr_state_n["ep"]) >= float(prev_state["ep"])
 
 
@@ -111,21 +103,18 @@ class TestStrainDriverStepResults:
 class TestStressDriverStepResults:
     def test_step_results_length(self, model):
         load = _uniaxial_stress_load(model, n_steps=15)
-        driver = StressDriver()
-        result = driver.run(PythonNumericalIntegrator(model), load)
+        result = StressDriver(PythonNumericalIntegrator(model)).run(load)
         assert len(result.step_results) == 15
 
     def test_step_results_are_return_mapping_results(self, model):
         load = _uniaxial_stress_load(model, n_steps=10)
-        driver = StressDriver()
-        result = driver.run(PythonNumericalIntegrator(model), load)
+        result = StressDriver(PythonNumericalIntegrator(model)).run(load)
         for rm in result.step_results:
             assert isinstance(rm, StressUpdateResult)
 
     def test_fields_stress_property(self, model):
         load = _uniaxial_stress_load(model, n_steps=10)
-        driver = StressDriver()
-        result = driver.run(PythonNumericalIntegrator(model), load)
+        result = StressDriver(PythonNumericalIntegrator(model)).run(load)
         assert result.stress.shape == (10, model.ntens)
 
 
@@ -135,8 +124,7 @@ class TestStressDriverStepResults:
 
 def test_driver_result_is_dataclass(model):
     load = _uniaxial_strain_load(n_steps=5)
-    driver = StrainDriver()
-    result = driver.run(PythonNumericalIntegrator(model), load)
+    result = StrainDriver(PythonNumericalIntegrator(model)).run(load)
     assert isinstance(result, DriverResult)
     assert hasattr(result, "step_results")
     assert hasattr(result, "strain")

--- a/tests/integration/test_driver_with_integrator.py
+++ b/tests/integration/test_driver_with_integrator.py
@@ -28,10 +28,8 @@ def strain_load(model):
 
 def test_strain_driver_numerical_vs_analytical(model, strain_load):
     """PythonNumericalIntegrator and PythonAnalyticalIntegrator give consistent results."""
-    driver = StrainDriver()
-
-    result_num = driver.run(PythonNumericalIntegrator(model), strain_load)
-    result_ana = driver.run(PythonAnalyticalIntegrator(model), strain_load)
+    result_num = StrainDriver(PythonNumericalIntegrator(model)).run(strain_load)
+    result_ana = StrainDriver(PythonAnalyticalIntegrator(model)).run(strain_load)
 
     np.testing.assert_allclose(result_num.stress, result_ana.stress, rtol=1e-6)
     np.testing.assert_allclose(result_num.strain, result_ana.strain, rtol=1e-12)
@@ -40,11 +38,9 @@ def test_strain_driver_numerical_vs_analytical(model, strain_load):
 
 def test_strain_driver_iter_run_numerical_vs_analytical(model, strain_load):
     """iter_run produces consistent steps for numerical and analytical integrators."""
-    driver = StrainDriver()
-
     for step_num, step_ana in zip(
-        driver.iter_run(PythonNumericalIntegrator(model), strain_load),
-        driver.iter_run(PythonAnalyticalIntegrator(model), strain_load),
+        StrainDriver(PythonNumericalIntegrator(model)).iter_run(strain_load),
+        StrainDriver(PythonAnalyticalIntegrator(model)).iter_run(strain_load),
     ):
         np.testing.assert_allclose(step_num.result.stress, step_ana.result.stress, rtol=1e-6)
         assert step_num.result.is_plastic == step_ana.result.is_plastic
@@ -58,9 +54,8 @@ def test_stress_driver_numerical_vs_analytical(model):
     stress_data[:, 0] = targets
     load = FieldHistory(FieldType.STRESS, "sigma", stress_data)
 
-    driver = StressDriver()
-    result_num = driver.run(PythonNumericalIntegrator(model), load)
-    result_ana = driver.run(PythonAnalyticalIntegrator(model), load)
+    result_num = StressDriver(PythonNumericalIntegrator(model)).run(load)
+    result_ana = StressDriver(PythonAnalyticalIntegrator(model)).run(load)
 
     np.testing.assert_allclose(result_num.stress, result_ana.stress, rtol=1e-6, atol=1e-6)
     np.testing.assert_allclose(result_num.strain, result_ana.strain, rtol=1e-6, atol=1e-12)
@@ -68,15 +63,13 @@ def test_stress_driver_numerical_vs_analytical(model):
 
 def test_driver_raises_on_bare_model(model, strain_load):
     """Driver raises TypeError when given a bare MaterialModel."""
-    driver = StrainDriver()
     with pytest.raises(TypeError, match="StressIntegrator"):
-        driver.run(model, strain_load)
+        StrainDriver(model)
 
 
 def test_python_integrator_auto_method(model, strain_load):
     """PythonIntegrator (auto) produces same results as numerical newton for J2 model."""
-    driver = StrainDriver()
-    result_auto = driver.run(PythonIntegrator(model), strain_load)
-    result_num  = driver.run(PythonNumericalIntegrator(model), strain_load)
+    result_auto = StrainDriver(PythonIntegrator(model)).run(strain_load)
+    result_num  = StrainDriver(PythonNumericalIntegrator(model)).run(strain_load)
 
     np.testing.assert_allclose(result_auto.stress, result_num.stress, rtol=1e-6)

--- a/tests/integration/test_kinematic_models.py
+++ b/tests/integration/test_kinematic_models.py
@@ -237,8 +237,8 @@ def test_cyclic_loading_driver(km_model):
     history[10:, 0] = np.linspace(4e-3, -4e-3, 10)
 
     load = FieldHistory(type=FieldType.STRAIN, name="Strain", data=history)
-    result = StrainDriver().run(
-        PythonNumericalIntegrator(km_model), load,
+    result = StrainDriver(PythonNumericalIntegrator(km_model)).run(
+        load,
         collect_state={"alpha": FieldType.STRESS, "ep": FieldType.STRAIN},
     )
 

--- a/tests/integration/test_multidim_return_mapping.py
+++ b/tests/integration/test_multidim_return_mapping.py
@@ -206,7 +206,7 @@ def test_uniaxial_driver_plane_strain(pe_model):
     """StrainDriver (uniaxial) works with a PLANE_STRAIN model."""
     eps_history = np.linspace(0, 5e-3, 20)
     load = FieldHistory(FieldType.STRAIN, "Strain", eps_history)
-    result = StrainDriver().run(PythonNumericalIntegrator(pe_model), load)
+    result = StrainDriver(PythonNumericalIntegrator(pe_model)).run(load)
     assert result.stress.shape == (20, 4)
     # σ11 must increase monotonically for hardening material
     assert np.all(np.diff(result.stress[:, 0]) >= 0)
@@ -218,7 +218,7 @@ def test_general_driver_plane_strain_shapes(pe_model):
     strain_history = np.zeros((N, 4))
     strain_history[:, 0] = np.linspace(0, 5e-3, N)  # ramp eps_11
     load = FieldHistory(FieldType.STRAIN, "Strain", strain_history)
-    result = StrainDriver().run(PythonNumericalIntegrator(pe_model), load)
+    result = StrainDriver(PythonNumericalIntegrator(pe_model)).run(load)
     assert result.stress.shape == (N, 4)
 
 
@@ -227,7 +227,7 @@ def test_plane_strain_sigma33_nonzero(pe_model):
     eps_history = np.zeros((10, 4))
     eps_history[:, 0] = np.linspace(0, 5e-3, 10)  # ramp eps_11 only
     load = FieldHistory(FieldType.STRAIN, "Strain", eps_history)
-    result = StrainDriver().run(PythonNumericalIntegrator(pe_model), load)
+    result = StrainDriver(PythonNumericalIntegrator(pe_model)).run(load)
     # sigma_33 (index 2) must be non-zero due to plane-strain lateral constraint
     assert np.any(np.abs(result.stress[:, 2]) > 1.0), \
         f"sigma_33 unexpectedly near zero: {result.stress[:, 2]}"

--- a/tests/integration/test_stress_driver.py
+++ b/tests/integration/test_stress_driver.py
@@ -47,7 +47,7 @@ def test_elastic_strain_matches_compliance(model_3d):
     stress_history = np.zeros((N, 6))
     stress_history[:, 0] = np.linspace(0.0, 0.5 * sigma_y0, N)
 
-    result = StressDriver().run(PythonNumericalIntegrator(model_3d), stress_load(stress_history))
+    result = StressDriver(PythonNumericalIntegrator(model_3d)).run(stress_load(stress_history))
 
     C = np.array(model_3d.elastic_stiffness())
     S = np.linalg.inv(C)
@@ -72,7 +72,7 @@ def test_uniaxial_stress_3d_lateral_strains_negative(model_3d):
     stress_history = np.zeros((N, 6))
     stress_history[:, 0] = np.linspace(0.0, 1.5 * sigma_y0, N)
 
-    result = StressDriver().run(PythonNumericalIntegrator(model_3d), stress_load(stress_history))
+    result = StressDriver(PythonNumericalIntegrator(model_3d)).run(stress_load(stress_history))
 
     assert np.all(result.strain[1:, 1] <= 0.0), "ε22 should be non-positive"
     assert np.all(result.strain[1:, 2] <= 0.0), "ε33 should be non-positive"
@@ -85,7 +85,7 @@ def test_uniaxial_stress_3d_off_diagonal_stress_near_zero(model_3d):
     stress_history = np.zeros((N, 6))
     stress_history[:, 0] = np.linspace(0.0, 1.5 * sigma_y0, N)
 
-    result = StressDriver().run(PythonNumericalIntegrator(model_3d), stress_load(stress_history))
+    result = StressDriver(PythonNumericalIntegrator(model_3d)).run(stress_load(stress_history))
 
     np.testing.assert_allclose(
         result.stress[:, 1:], 0.0, atol=1e-6,
@@ -100,7 +100,7 @@ def test_uniaxial_stress_3d_sigma11_matches_target(model_3d):
     stress_history = np.zeros((N, 6))
     stress_history[:, 0] = np.linspace(0.0, 1.5 * sigma_y0, N)
 
-    result = StressDriver().run(PythonNumericalIntegrator(model_3d), stress_load(stress_history))
+    result = StressDriver(PythonNumericalIntegrator(model_3d)).run(stress_load(stress_history))
 
     np.testing.assert_allclose(
         result.stress[:, 0], stress_history[:, 0], atol=1e-8,
@@ -114,7 +114,7 @@ def test_output_shapes(model_3d):
     stress_history = np.zeros((N, 6))
     stress_history[:, 0] = np.linspace(0, 200.0, N)
 
-    result = StressDriver().run(PythonNumericalIntegrator(model_3d), stress_load(stress_history))
+    result = StressDriver(PythonNumericalIntegrator(model_3d)).run(stress_load(stress_history))
 
     assert result.stress.shape == (N, 6)
     assert result.strain.shape == (N, 6)
@@ -129,7 +129,7 @@ def test_state_not_collected_by_default(model_3d):
     stress_history = np.zeros((5, 6))
     stress_history[:, 0] = np.linspace(0, 200.0, 5)
 
-    result = StressDriver().run(PythonNumericalIntegrator(model_3d), stress_load(stress_history))
+    result = StressDriver(PythonNumericalIntegrator(model_3d)).run(stress_load(stress_history))
 
     assert set(result.fields.keys()) == {"Stress", "Strain"}
 
@@ -141,8 +141,7 @@ def test_state_ep_collected_when_requested(model_3d):
     stress_history = np.zeros((N, 6))
     stress_history[:, 0] = np.linspace(0.0, 1.5 * sigma_y0, N)
 
-    result = StressDriver().run(
-        PythonNumericalIntegrator(model_3d),
+    result = StressDriver(PythonNumericalIntegrator(model_3d)).run(
         stress_load(stress_history),
         collect_state={"ep": FieldType.STRAIN},
     )
@@ -163,8 +162,7 @@ def test_strain_driver_collect_state(model_3d):
     strain_history = np.zeros((N, 6))
     strain_history[:, 0] = np.linspace(0.0, 3 * sigma_y0 / E, N)
 
-    result = StrainDriver().run(
-        PythonNumericalIntegrator(model_3d),
+    result = StrainDriver(PythonNumericalIntegrator(model_3d)).run(
         FieldHistory(FieldType.STRAIN, "Strain", strain_history),
         collect_state={"ep": FieldType.STRAIN},
     )
@@ -194,14 +192,14 @@ def test_consistency_with_strain_driver_1d(model_1d):
     eps_history_1d = np.linspace(0.0, 3 * eps_yield, N)
 
     # Step 1: strain → stress
-    result_strain = StrainDriver().run(
-        PythonNumericalIntegrator(model_1d), strain_load(eps_history_1d)
+    result_strain = StrainDriver(PythonNumericalIntegrator(model_1d)).run(
+        strain_load(eps_history_1d)
     )
     sigma_history_2d = result_strain.stress  # (N, 1)
 
     # Step 2: stress → strain via StressDriver
-    result_stress = StressDriver().run(
-        PythonNumericalIntegrator(model_1d), stress_load(sigma_history_2d)
+    result_stress = StressDriver(PythonNumericalIntegrator(model_1d)).run(
+        stress_load(sigma_history_2d)
     )
     recovered_strain = result_stress.strain[:, 0]
 
@@ -216,21 +214,14 @@ def test_consistency_with_strain_driver_1d(model_1d):
 # ---------------------------------------------------------------------------
 
 def test_convergence_failure_raises(model_3d):
-    """Insufficient iterations for a plastic step must raise RuntimeError.
-
-    With max_iter=1 and a target stress in the plastic regime, the elastic
-    compliance initial guess produces stress_trial == sigma_target, which the
-    plastic corrector projects back to the yield surface.  The corrected strain
-    is never re-evaluated within the single allowed iteration, so the outer NR
-    cannot reach the target and must raise RuntimeError.
-    """
+    """Insufficient iterations for a plastic step must raise RuntimeError."""
     sigma_y0 = model_3d.sigma_y0
     stress_history = np.zeros((1, 6))
     stress_history[0, 0] = 1.5 * sigma_y0
 
-    driver = StressDriver(max_iter=1)
+    driver = StressDriver(PythonNumericalIntegrator(model_3d), max_iter=1)
     with pytest.raises(RuntimeError, match="NR did not converge"):
-        driver.run(PythonNumericalIntegrator(model_3d), stress_load(stress_history))
+        driver.run(stress_load(stress_history))
 
 
 def test_strain_driver_general_shape(model):
@@ -239,13 +230,13 @@ def test_strain_driver_general_shape(model):
     strain6 = np.zeros((N, 6))
     strain6[:, 0] = np.linspace(0.0, 5e-3, N)
     load = FieldHistory(FieldType.STRAIN, "Strain", strain6)
-    result = StrainDriver().run(PythonNumericalIntegrator(model), load)
+    result = StrainDriver(PythonNumericalIntegrator(model)).run(load)
     assert result.stress.shape == (N, 6)
     assert result.stress[-1, 0] > model.sigma_y0
 
 
 # ---------------------------------------------------------------------------
-# StressDriver method argument
+# StressDriver integrator types
 # ---------------------------------------------------------------------------
 
 @pytest.mark.parametrize("IntegratorCls", [PythonNumericalIntegrator, PythonAnalyticalIntegrator])
@@ -256,7 +247,7 @@ def test_stress_driver_integrator_types(model_3d, IntegratorCls):
     stress_history = np.zeros((N, 6))
     stress_history[:, 0] = np.linspace(0.0, 1.5 * sigma_y0, N)
 
-    result = StressDriver().run(IntegratorCls(model_3d), stress_load(stress_history))
+    result = StressDriver(IntegratorCls(model_3d)).run(stress_load(stress_history))
 
     assert len(result.step_results) == N
     from manforge.core.stress_update import StressUpdateResult

--- a/tests/slow/test_fitting.py
+++ b/tests/slow/test_fitting.py
@@ -25,16 +25,16 @@ pytestmark = pytest.mark.slow
 # ---------------------------------------------------------------------------
 
 @pytest.fixture
-def driver():
-    return StrainDriver()
+def driver_factory():
+    return lambda integrator: StrainDriver(integrator)
 
 
 @pytest.fixture
-def synthetic_data(model, driver):
+def synthetic_data(model, driver_factory):
     """Uniaxial strain history and synthetic stress response (σ11 only)."""
     strain = np.linspace(0.0, 5e-3, 40)
     load = FieldHistory(FieldType.STRAIN, "Strain", strain)
-    result = driver.run(PythonIntegrator(model), load)
+    result = driver_factory(PythonIntegrator(model)).run(load)
     return {"strain": strain, "stress": result.stress[:, 0]}
 
 
@@ -42,7 +42,7 @@ def synthetic_data(model, driver):
 # Structure test
 # ---------------------------------------------------------------------------
 
-def test_fit_result_structure(model, driver, synthetic_data):
+def test_fit_result_structure(model, driver_factory, synthetic_data):
     """FitResult has all required fields with correct types."""
     fit_config = {
         "sigma_y0": (220.0, (50.0, 600.0)),
@@ -50,7 +50,7 @@ def test_fit_result_structure(model, driver, synthetic_data):
     }
     fixed = {"E": model.E, "nu": model.nu}
 
-    result = fit_params(model, driver, synthetic_data, fit_config,
+    result = fit_params(model, driver_factory, synthetic_data, fit_config,
                         fixed_params=fixed, method="L-BFGS-B")
 
     assert isinstance(result, FitResult)
@@ -69,7 +69,7 @@ def test_fit_result_structure(model, driver, synthetic_data):
 # Convergence test — L-BFGS-B
 # ---------------------------------------------------------------------------
 
-def test_fit_uniaxial_synthetic(model, driver, synthetic_data):
+def test_fit_uniaxial_synthetic(model, driver_factory, synthetic_data):
     """L-BFGS-B recovers sigma_y0 and H within 10% of true values."""
     fit_config = {
         "sigma_y0": (220.0, (50.0, 600.0)),
@@ -77,7 +77,7 @@ def test_fit_uniaxial_synthetic(model, driver, synthetic_data):
     }
     fixed = {"E": model.E, "nu": model.nu}
 
-    result = fit_params(model, driver, synthetic_data, fit_config,
+    result = fit_params(model, driver_factory, synthetic_data, fit_config,
                         fixed_params=fixed, method="L-BFGS-B")
 
     assert result.residual < 1.0, f"Residual too large: {result.residual:.3e}"
@@ -89,7 +89,7 @@ def test_fit_uniaxial_synthetic(model, driver, synthetic_data):
 # Convergence test — Nelder-Mead
 # ---------------------------------------------------------------------------
 
-def test_fit_nelder_mead(model, driver, synthetic_data):
+def test_fit_nelder_mead(model, driver_factory, synthetic_data):
     """Nelder-Mead also converges to true parameters."""
     fit_config = {
         "sigma_y0": (220.0, (None, None)),
@@ -97,7 +97,7 @@ def test_fit_nelder_mead(model, driver, synthetic_data):
     }
     fixed = {"E": model.E, "nu": model.nu}
 
-    result = fit_params(model, driver, synthetic_data, fit_config,
+    result = fit_params(model, driver_factory, synthetic_data, fit_config,
                         fixed_params=fixed, method="Nelder-Mead")
 
     assert result.residual < 1.0
@@ -108,7 +108,7 @@ def test_fit_nelder_mead(model, driver, synthetic_data):
 # History populated for gradient-based methods
 # ---------------------------------------------------------------------------
 
-def test_fit_history_populated(model, driver, synthetic_data):
+def test_fit_history_populated(model, driver_factory, synthetic_data):
     """History list is non-empty after L-BFGS-B run."""
     fit_config = {
         "sigma_y0": (220.0, (50.0, 600.0)),
@@ -116,11 +116,9 @@ def test_fit_history_populated(model, driver, synthetic_data):
     }
     fixed = {"E": model.E, "nu": model.nu}
 
-    result = fit_params(model, driver, synthetic_data, fit_config,
+    result = fit_params(model, driver_factory, synthetic_data, fit_config,
                         fixed_params=fixed, method="L-BFGS-B")
 
     assert len(result.history) > 0
     assert "sigma_y0" in result.history[0]
     assert "H" in result.history[0]
-
-

--- a/tests/unit/test_case_result_base_converged.py
+++ b/tests/unit/test_case_result_base_converged.py
@@ -5,7 +5,6 @@ import pytest
 import manforge  # noqa: F401
 from manforge.models.j2_isotropic import J2Isotropic3D
 from manforge.simulation import (
-    StrainDriver,
     PythonNumericalIntegrator,
     PythonAnalyticalIntegrator,
 )
@@ -60,7 +59,7 @@ class TestCounterAggregation:
         cc = StressUpdateCrosscheck(py_a, py_b)
         history = generate_strain_history(model)
         load = FieldHistory(FieldType.STRAIN, "eps", history)
-        result = cc.run(StrainDriver(), load)
+        result = cc.run(load)
         assert result.n_a_nonconverged == 0
         assert result.n_b_nonconverged == 0
 

--- a/tests/unit/test_crosscheck_case_result_trajectory.py
+++ b/tests/unit/test_crosscheck_case_result_trajectory.py
@@ -5,7 +5,6 @@ import pytest
 import manforge  # noqa: F401
 from manforge.models.j2_isotropic import J2Isotropic3D
 from manforge.simulation import (
-    StrainDriver,
     PythonNumericalIntegrator,
     PythonAnalyticalIntegrator,
 )
@@ -30,7 +29,7 @@ class TestCrosscheckTrajectory:
         cc = StressUpdateCrosscheck(py_int_a, py_int_b)
         history = generate_strain_history(model)
         load = FieldHistory(FieldType.STRAIN, "eps", history)
-        result = cc.run(StrainDriver(), load)
+        result = cc.run(load)
 
         assert result.passed
         for cr in result.cases:
@@ -47,7 +46,7 @@ class TestCrosscheckTrajectory:
         cc = StressUpdateCrosscheck(py_int_a, py_int_b)
         history = generate_strain_history(model)
         load = FieldHistory(FieldType.STRAIN, "eps", history)
-        result = cc.run(StrainDriver(), load)
+        result = cc.run(load)
 
         plastic_cases = [cr for cr in result.cases
                          if cr.py_dlambda is not None and cr.py_dlambda > 0]
@@ -65,7 +64,7 @@ class TestCrosscheckTrajectory:
         elastic_strain[0, 0] = 1e-6
         elastic_strain[1, 0] = 2e-6
         load = FieldHistory(FieldType.STRAIN, "eps", elastic_strain)
-        for cr in cc.iter_run(StrainDriver(), load):
+        for cr in cc.iter_run(load):
             assert cr.a_converged is True
 
 


### PR DESCRIPTION
## Summary

Part 1 (#41) で Integrator の class-identity 化は完了したが、**Integrator を受け取るタイミングの不整合**が残っていた:

| クラス | 変更前 | 変更後 |
|---|---|---|
| `StrainDriver` | `run(integrator, load)` | `__init__(integrator)` + `run(load)` |
| `StressDriver` | `run(integrator, load)` | `__init__(integrator, *, max_iter, tol)` + `run(load)` |
| `StressUpdateCrosscheck` | `run(driver, load)` | `run(load)` (driver を内部自動選択) |
| `fit_params` | `driver=StrainDriver()` | `driver_factory=lambda i: StrainDriver(i)` |

## 変更内容

- **`DriverBase.__init__(integrator)`** を新設。`iter_run` / `run` から `integrator` 引数を削除。`_check_integrator` を init の 1 箇所に集約。
- **`StressDriver(integrator, *, max_iter, tol)`** — `max_iter` / `tol` を keyword-only に格上げ。
- **`StressUpdateCrosscheck.iter_run(load)`** — `driver` 引数を削除。`load.type` から `StrainDriver` / `StressDriver` を内部自動選択 (`_driver_for`)。`stress_driver_kwargs` kwarg で `StressDriver` パラメータを渡せる。
- **`fit_params` / `build_objective`** — `driver` → `driver_factory: Callable[[StressIntegrator], DriverBase]` に変更。
- 全呼び出しサイト (tests / examples / benchmarks / README) を新 API に機械的置換。

## Migration guide

```python
# Before
result = StrainDriver().run(integrator, load)
for step in StressDriver(max_iter=30).iter_run(integrator, load): ...
cc = StressUpdateCrosscheck(a, b)
result = cc.run(StrainDriver(), load)
fit_params(model, driver=StrainDriver(), exp_data=..., ...)

# After
result = StrainDriver(integrator).run(load)
for step in StressDriver(integrator, max_iter=30).iter_run(load): ...
cc = StressUpdateCrosscheck(a, b)
result = cc.run(load)
fit_params(model, driver_factory=lambda i: StrainDriver(i), exp_data=..., ...)
```

## Test plan

- [x] `make test-unit` — 237 passed
- [x] `make test-integration` — 197 passed
- [x] `make test-slow` — 34 passed
- [x] `make test-fortran` — 42 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)