### PR TITLE
refactor: hardening_type を廃し implicit_state_names / implicit_stress API に移行

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,11 +50,20 @@ manforge is a framework for validating Fortran UMAT (Abaqus user material) const
 
 **1. Material model layer** — `src/manforge/core/material.py`
 
-`MaterialModel` is the internal ABC. Users subclass one of the stress-state base classes and implement the required material-physics methods based on `hardening_type`:
+`MaterialModel` is the internal ABC. Users subclass one of the stress-state base classes and implement the required material-physics methods. Two class-level attributes control the NR unknown set:
+
+- `implicit_state_names: list[str] = []` — names of state variables treated as independent NR unknowns (must be a subset of `state_names`). Default `[]` → all states are explicit.
+- `implicit_stress: bool = False` — if `True`, σ is also included as an independent NR unknown (gives the fully-coupled vector NR). Default `False` → σ is derived from Δλ via the consistency condition each iteration.
+
+Required methods depend on which states are explicit vs implicit:
 - `elastic_stiffness()` → (ntens, ntens) Voigt stiffness tensor (always required)
 - `yield_function(stress, state)` → scalar (≤0 = elastic) (always required)
-- For **reduced** hardening (`hardening_type = "reduced"`, default): `update_state(dlambda, stress, state)` → updated state dict `q_{n+1}`. State is substituted into the residual each NR iteration; scalar NR on Δλ only (1D reduced system).
-- For **augmented** hardening (`hardening_type = "augmented"`): `state_residual(state_new, dlambda, stress, state_n)` → residual dict (zero at convergence). State is an independent unknown; full (ntens+1+n_state) vector NR (augmented system). The two are related by `state_residual = q_{n+1} − update_state(...)`, and the base class provides `state_residual` automatically from `update_state`.
+- `update_state(dlambda, stress, state)` → dict with only the **explicit** state keys (`state_names − implicit_state_names`). Required whenever any state is explicit. Scalar NR on Δλ when `implicit_state_names = []` and `implicit_stress = False`.
+- `state_residual(state_new, dlambda, stress, state_n)` → dict with only the **implicit** state keys (`implicit_state_names`). Required whenever any state is implicit. Vector NR on `[Δλ] + [q_implicit]` (or `[σ, Δλ, q_implicit]` if `implicit_stress=True`).
+
+The base class provides a default `state_residual = q_{n+1} − update_state(...)` so models that have a closed-form explicit update can opt into implicit NR without rewriting the physics. Both methods may coexist for mixed (partial-implicit) models; each returns only its own keys.
+
+`hardening_type` is no longer used and raises `TypeError` with a migration hint if declared.
 
 Material parameters are passed at construction time (`model = J2Isotropic3D(E=210000.0, nu=0.3, sigma_y0=250.0, H=1000.0)`) and stored as instance attributes (`self.E`, `self.nu`, etc.). The `params` property auto-generates a dict from `param_names` for internal use.
 
@@ -75,13 +84,13 @@ The reference implementation is `src/manforge/models/j2_isotropic.py` (J2Isotrop
 
 - `stress_update.py`: Two-level API:
   - `stress_update(model, deps, stress_n, state_n, method="auto")` → `StressUpdateResult` — full constitutive integration (elastic trial → yield check → return mapping → consistent tangent). Equivalent to one UMAT call.
-  - `return_mapping(model, stress_trial, C, state_n, method="auto")` → `ReturnMappingResult` — plastic correction only (closest point projection). Dispatches on `model.hardening_type`: `"reduced"` → scalar NR on Δλ; `"augmented"` → (ntens+1+n_state) vector NR (max 50 iter, tol=1e-10).
+  - `return_mapping(model, stress_trial, C, state_n, method="auto")` → `ReturnMappingResult` — plastic correction only (closest point projection). NR path selected by `model.implicit_state_names` and `model.implicit_stress`: scalar NR on Δλ when both are empty/False; vector NR on `[Δλ, q_implicit]` or `[σ, Δλ, q_implicit]` otherwise (max 50 iter, tol=1e-10).
   - `method` values: `"auto"` (use `user_defined_return_mapping` if present, else `"numerical_newton"`), `"numerical_newton"` (framework NR), `"user_defined"` (requires model to implement `user_defined_return_mapping`).
   - `ReturnMappingResult` fields: `stress`, `state`, `dlambda`, `n_iterations`, `residual_history`.
   - `StressUpdateResult` fields: `return_mapping` (None for elastic), `ddsdde`, `stress_trial`, `is_plastic`. Convenience properties `stress`, `state`, `dlambda`, `n_iterations`, `residual_history` delegate to `return_mapping` (or elastic defaults).
-- `jacobian.py`: `JacobianBlocks` dataclass and `ad_jacobian_blocks(model, result, state_n)` — computes the residual Jacobian at the converged point via `jax.jacobian` and decomposes it into named blocks (`dstress_dsigma`, `dyield_dsigma`, `dstate_dstate`, etc.). For augmented models, state blocks are keyed by variable name (e.g. `jac.dstate_dsigma["alpha"]`). Accepts both `StressUpdateResult` and `ReturnMappingResult`. Used for step-by-step verification of analytical derivatives.
-- `tangent.py`: Consistent tangent via implicit differentiation — reduced models use (ntens+1)×(ntens+1) system; augmented models use (ntens+1+n_state) system (does NOT differentiate through NR iterations)
-- `residual.py`: Residual builders for both paths: `make_reduced_residual` (reduced) and `make_augmented_residual` (augmented), plus `select_residual_builder` dispatch
+- `jacobian.py`: `JacobianBlocks` dataclass and `ad_jacobian_blocks(model, result, state_n)` — computes the residual Jacobian at the converged point and decomposes it into named blocks (`dstress_dsigma`, `dyield_dsigma`, `dstate_dstate`, etc.). State blocks are keyed by variable name (e.g. `jac.dstate_dsigma["alpha"]`); only implicit states appear in `dstate_*` fields. Accepts both `StressUpdateResult` and `ReturnMappingResult`. Used for step-by-step verification of analytical derivatives.
+- `tangent.py`: Consistent tangent via implicit differentiation — always uses the `[σ, Δλ, q_implicit]` linear system regardless of `implicit_stress` (size ntens+1+n_implicit). Does NOT differentiate through NR iterations.
+- `residual.py`: Two residual builders: `make_nr_residual(model, stress_trial, state_n)` → `(fn, meta, unflatten)` for the NR phase (σ included only when `implicit_stress=True`); `make_tangent_residual(model, stress_trial, state_n)` → `(fn, n_implicit, unflatten)` for the tangent/Jacobian phase (σ always included).
 
 JAX autodiff computes yield function gradients and the Hessian needed for the tangent. Float64 is enabled globally in `src/manforge/__init__.py`.
 

--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ src/manforge/
 │   ├── stress_state.py    # StressState (SOLID_3D / PLANE_STRAIN / PLANE_STRESS / UNIAXIAL_1D)
 │   ├── material.py        # MaterialModel ABC + MaterialModel3D/PS/1D
 │   ├── stress_update.py   # ReturnMappingResult / StressUpdateResult — 戻り値 dataclass
-│   ├── solver.py          # _reduced_nr / _augmented_nr
+│   ├── solver.py          # _numerical_newton (scalar / vector NR を自動選択)
 │   ├── tangent.py         # consistent tangent (implicit differentiation)
-│   ├── residual.py        # make_reduced_residual / make_augmented_residual
+│   ├── residual.py        # make_nr_residual / make_tangent_residual
 │   └── jacobian.py        # JacobianBlocks — AD ヤコビアンブロック分解
 ├── autodiff/
 │   ├── backend.py         # autograd バックエンド設定
@@ -136,12 +136,15 @@ src/manforge/
 | `MaterialModelPS` | `PLANE_STRESS` | 3 |
 | `MaterialModel1D` | `UNIAXIAL_1D` | 1 |
 
-必須メソッドは `hardening_type` によって異なる:
+必須メソッドは `implicit_state_names` と `implicit_stress` の設定によって異なる:
 
-| `hardening_type` | 必須メソッド | 省略可能メソッド |
-|-----------------|-------------|----------------|
-| `"reduced"` (デフォルト) | `yield_function`, `update_state` | `elastic_stiffness` |
-| `"augmented"` | `yield_function`, `state_residual` | `elastic_stiffness` |
+| 設定 | 必須メソッド | NR 未知数 |
+|-----|-------------|----------|
+| `implicit_state_names = []` (デフォルト) | `yield_function`, `update_state` | スカラー Δλ |
+| `implicit_state_names = [全 state]`, `implicit_stress = True` | `yield_function`, `state_residual` | `[σ, Δλ, q]` |
+| 部分的 implicit (一部 state のみ) | `yield_function`, `update_state`, `state_residual` の両方 | `[Δλ, q_implicit]` |
+
+`update_state` は **陽更新 state のみ** (`state_names − implicit_state_names`) のキーを返す。`state_residual` は **陰 state のみ** (`implicit_state_names`) のキーを返す。`hardening_type` は廃止 (宣言すると `TypeError`)。
 
 `elastic_stiffness(self, state=None)` は `MaterialModel3D` / `MaterialModelPS` / `MaterialModel1D` 基底クラスに等方性デフォルト実装が用意されており、`self.E` と `self.nu` を持つモデルなら実装不要。状態依存の弾性剛性 (損傷塑性など) を持つモデルのみ override する。
 
@@ -273,9 +276,9 @@ print(result.params, result.residual)
 
 ## Adding a New Model
 
-### Reduced template (J2-like)
+### Explicit-state template (J2-like)
 
-`hardening_type = "reduced"` (デフォルト) の場合、状態更新を closed-form で `update_state` に記述する。NR はスカラー Δλ のみ解く。
+デフォルト (`implicit_state_names = []`) では、状態更新を closed-form で `update_state` に記述する。NR はスカラー Δλ のみ解く。
 
 ```python
 import autograd.numpy as anp
@@ -321,16 +324,17 @@ model_1d = J2Isotropic1D(E=210_000.0, nu=0.3, sigma_y0=250.0, H=1_000.0)
 | `PLANE_STRESS` | 3 | CPS4 / シェル |
 | `UNIAXIAL_1D` | 1 | 1D トラス / フィッティング用 |
 
-### Augmented template (Ohno-Wang-like)
+### Implicit-state template (Ohno-Wang-like)
 
-`update_state` が closed-form で解けない場合 (後方 Euler 離散化に状態変数が非線形に現れる場合)、`hardening_type = "augmented"` を宣言して `state_residual` を実装する。NR は (ntens+1+n_state) の拡張残差系を解く。
+`update_state` が closed-form で解けない場合 (後方 Euler 離散化に状態変数が非線形に現れる場合)、`implicit_state_names` にその state 名を列挙して `state_residual` を実装する。NR の未知数ベクトルは `[Δλ, q_implicit]` (+ `implicit_stress=True` にすると σ も含まれる)。
 
 ```python
 import autograd.numpy as anp
 from manforge.core.material import MaterialModel3D
 
 class MyImplicitModel(MaterialModel3D):
-    hardening_type = "augmented"
+    implicit_state_names = ["alpha", "ep"]   # 全 state が陰 → update_state 不要
+    implicit_stress = True                   # σ も NR 未知数に含める
     param_names = ["E", "nu", "sigma_y0", "C_k", "gamma"]
     state_names = ["alpha", "ep"]
 
@@ -347,7 +351,7 @@ class MyImplicitModel(MaterialModel3D):
         return self._vonmises(xi) - self.sigma_y0
 
     def state_residual(self, state_new, dlambda, stress, state_n):
-        """後方 Euler 残差。収束時にゼロになる dict を返す。"""
+        """後方 Euler 残差。implicit_state_names のキーのみ返す。収束時にゼロ。"""
         # ...モデル固有の残差を定義...
         R_alpha = ...         # shape (ntens,)
         R_ep = state_new["ep"] - state_n["ep"] - dlambda
@@ -366,10 +370,10 @@ from manforge.models import AFKinematic3D, OWKinematic3D
 from manforge.simulation import StrainDriver, PythonIntegrator
 from manforge.simulation.types import FieldHistory, FieldType
 
-# Armstrong-Frederick (reduced path)
+# Armstrong-Frederick (全 state 陽更新、スカラー NR)
 model_af = AFKinematic3D(E=210_000.0, nu=0.3, sigma_y0=250.0, C_k=8_000.0, gamma=80.0)
 
-# Ohno-Wang 修正 AF (augmented path)
+# Ohno-Wang 修正 AF (全 state 陰、implicit_stress=True、ベクトル NR)
 model_ow = OWKinematic3D(E=210_000.0, nu=0.3, sigma_y0=250.0, C_k=8_000.0, gamma=0.05)
 
 strain_history = np.zeros((150, 6))

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ src/manforge/
 ├── models/
 │   ├── j2_isotropic.py    # J2 等方硬化 (参照実装)
 │   ├── af_kinematic.py    # Armstrong-Frederick 移動硬化
-│   └── ow_kinematic.py    # Ohno-Wang 修正 AF (augmented path の参照実装)
+│   └── ow_kinematic.py    # Ohno-Wang 修正 AF (implicit_state_names の参照実装)
 ├── simulation/
 │   ├── types.py           # FieldType / FieldHistory / DriverResult
 │   ├── driver.py          # StrainDriver / StressDriver
@@ -448,7 +448,7 @@ print(jac.dstress_dsigma)   # shape (ntens, ntens)
 print(jac.full)             # フラットな全体行列
 ```
 
-augmented モデル (例: Ohno-Wang) では状態変数名をキーとするブロックも取得できる:
+implicit_state_names を持つモデル (例: Ohno-Wang) では状態変数名をキーとするブロックも取得できる:
 
 ```python
 jac.dstate_dsigma["alpha"]        # ∂R_alpha/∂σ,  shape (ntens, ntens)

--- a/benchmarks/bench_autodiff.py
+++ b/benchmarks/bench_autodiff.py
@@ -2,7 +2,7 @@
 
 3 scenarios:
   1. driver_step   – StrainDriver, J2Isotropic3D, N=40 steps
-  2. augmented_nr  – OWKinematic3D, 200 small-increment steps (augmented NR)
+  2. vector_nr     – OWKinematic3D, 200 small-increment steps (implicit_state_names)
   3. fd_tangent    – check_tangent for J2Isotropic3D (1 + 12 stress_update calls)
 
 Run:
@@ -76,10 +76,10 @@ def _make_driver_step():
 
 
 # ---------------------------------------------------------------------------
-# scenario 2: augmented NR  (OW 3D, 200 increments)
+# scenario 2: vector NR  (OW 3D, 200 increments, implicit_state_names=["alpha","ep"])
 # ---------------------------------------------------------------------------
 
-def _make_augmented_nr():
+def _make_vector_nr():
     import numpy as np
     from manforge.models.ow_kinematic import OWKinematic3D
     from manforge.simulation.integrator import PythonIntegrator
@@ -135,7 +135,7 @@ def _make_fd_tangent():
 
 SCENARIOS = [
     ("driver_step",   _make_driver_step),
-    ("augmented_nr",  _make_augmented_nr),
+    ("vector_nr",     _make_vector_nr),
     ("fd_tangent",    _make_fd_tangent),
 ]
 

--- a/src/manforge/core/jacobian.py
+++ b/src/manforge/core/jacobian.py
@@ -8,12 +8,17 @@ import autograd
 import autograd.numpy as anp
 import numpy as np
 
-from manforge.core.residual import _flatten_state
+from manforge.core.residual import make_tangent_residual, _flatten_state
 
 
 @dataclass
 class JacobianBlocks:
-    """Named blocks of the return-mapping residual Jacobian at the converged point."""
+    """Named blocks of the return-mapping residual Jacobian at the converged point.
+
+    The Jacobian is computed from the tangent residual system where σ is
+    always an independent variable.  Explicit-state keys (not in
+    ``model.implicit_state_names``) do not appear in ``dstate_*`` fields.
+    """
 
     dstress_dsigma: anp.ndarray
     dstress_ddlambda: anp.ndarray
@@ -54,63 +59,42 @@ def ad_jacobian_blocks(
                 "to ad_jacobian_blocks(). Use stress_update() instead, or pass "
                 "stress_trial=... explicitly."
             )
+
     ntens = model.ntens
+    implicit_keys = sorted(model.implicit_state_names)
+    implicit_state = {k: state[k] for k in implicit_keys}
+    flat_impl, _ = _flatten_state(implicit_state)
+    n_implicit = len(flat_impl)
 
-    _blocks_fn = (
-        _jacobian_blocks_augmented
-        if model.hardening_type == "augmented"
-        else _jacobian_blocks_reduced
-    )
-    return _blocks_fn(model, stress, state, dlambda, stress_trial, state_n, ntens)
+    residual_fn, _, _ = make_tangent_residual(model, stress_trial, state_n)
 
-
-def _jacobian_blocks_reduced(
-    model, stress, state, dlambda, stress_trial, state_n, ntens
-):
-    from manforge.core.residual import make_reduced_residual
-
-    residual_fn = make_reduced_residual(model, stress_trial, state_n)
-    x_conv = anp.concatenate([anp.array(stress), anp.array([float(dlambda)])])
-    J = autograd.jacobian(residual_fn)(x_conv)
-
-    return JacobianBlocks(
-        dstress_dsigma=J[:ntens, :ntens],
-        dstress_ddlambda=J[:ntens, ntens],
-        dyield_dsigma=J[ntens, :ntens],
-        dyield_ddlambda=J[ntens, ntens],
-        dstress_dstate=None,
-        dyield_dstate=None,
-        dstate_dsigma=None,
-        dstate_ddlambda=None,
-        dstate_dstate=None,
-        full=J,
-    )
-
-
-def _jacobian_blocks_augmented(
-    model, stress, state, dlambda, stress_trial, state_n, ntens
-):
-    from manforge.core.residual import make_augmented_residual
-
-    residual_fn, n_state, unflatten_fn = make_augmented_residual(
-        model, stress_trial, state_n
-    )
-
-    flat_state, _ = _flatten_state(state)
     x_conv = anp.concatenate([
         anp.array(stress),
         anp.array([float(dlambda)]),
-        flat_state,
+        flat_impl,
     ])
     J = autograd.jacobian(residual_fn)(x_conv)
-
-    state_keys = sorted(state.keys())
-    slices = _build_state_slices(state, state_keys)
 
     dstress_dsigma   = J[:ntens, :ntens]
     dstress_ddlambda = J[:ntens, ntens]
     dyield_dsigma    = J[ntens, :ntens]
     dyield_ddlambda  = J[ntens, ntens]
+
+    if n_implicit == 0:
+        return JacobianBlocks(
+            dstress_dsigma=dstress_dsigma,
+            dstress_ddlambda=dstress_ddlambda,
+            dyield_dsigma=dyield_dsigma,
+            dyield_ddlambda=dyield_ddlambda,
+            dstress_dstate=None,
+            dyield_dstate=None,
+            dstate_dsigma=None,
+            dstate_ddlambda=None,
+            dstate_dstate=None,
+            full=J,
+        )
+
+    slices = _build_state_slices(implicit_state, implicit_keys)
 
     dstress_dstate: dict = {}
     dyield_dstate:  dict = {}

--- a/src/manforge/core/material.py
+++ b/src/manforge/core/material.py
@@ -24,6 +24,16 @@ class MaterialModel(ABC):
         Names of internal state variables (keys in ``state`` dicts).
     stress_state : StressState
         Dimensionality descriptor (default: ``SOLID_3D``, 6-component 3D).
+    implicit_state_names : list[str]
+        State variable names that are treated as independent NR unknowns
+        (implicit/hidden variables).  Must be a subset of ``state_names``.
+        State variables *not* listed here are updated explicitly via
+        :meth:`update_state` at every NR iteration.  Default: ``[]`` (all
+        states are explicit — scalar NR on Δλ only).
+    implicit_stress : bool
+        If ``True``, σ is also included as an independent NR unknown (in
+        addition to Δλ and any implicit states).  Default: ``False``
+        (σ is computed from σ_trial, Δλ, and q at every iteration).
     ntens : int
         Read-only property; returns ``self.stress_state.ntens``.
     """
@@ -31,7 +41,8 @@ class MaterialModel(ABC):
     param_names: list[str]
     state_names: list[str]
     stress_state: StressState = SOLID_3D
-    hardening_type: str = "reduced"  # "reduced" or "augmented"
+    implicit_state_names: list[str] = []
+    implicit_stress: bool = False
 
     @property
     def params(self) -> dict:
@@ -40,20 +51,25 @@ class MaterialModel(ABC):
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
-        # Skip intermediate abstract classes (MaterialModel3D, MaterialModelPS, etc.)
-        # that have not yet implemented yield_function.
+        # Skip intermediate abstract classes that have not yet implemented yield_function.
         if cls.yield_function is MaterialModel.yield_function:
             return
-        ht = cls.hardening_type
-        if ht not in ("reduced", "augmented"):
+        # Reject legacy hardening_type attribute.
+        if "hardening_type" in cls.__dict__:
+            _val = cls.__dict__["hardening_type"]
             _hint = ""
-            if ht in ("explicit", "implicit"):
-                _hint = f" (renamed to '{'reduced' if ht == 'explicit' else 'augmented'}' — update hardening_type on {cls.__name__})"
+            if _val == "reduced":
+                _hint = " — remove hardening_type; implicit_state_names=[] is the default"
+            elif _val == "augmented":
+                _hint = (
+                    " — remove hardening_type; set implicit_state_names=<your state_names>"
+                    " (and implicit_stress=True if σ should be an NR unknown)"
+                )
             raise TypeError(
-                f"{cls.__name__}: hardening_type must be 'reduced' or 'augmented', "
-                f"got {ht!r}{_hint}"
+                f"{cls.__name__}: hardening_type has been removed. "
+                f"Use implicit_state_names and implicit_stress instead.{_hint}"
             )
-        # Detect old method names (removed in this version) and guide migration.
+        # Detect renamed methods and guide migration.
         if "hardening_increment" in cls.__dict__:
             raise TypeError(
                 f"{cls.__name__}: hardening_increment() has been renamed to "
@@ -64,15 +80,26 @@ class MaterialModel(ABC):
                 f"{cls.__name__}: hardening_residual() has been renamed to "
                 "state_residual() — rename the method on your subclass"
             )
-        if ht == "reduced" and cls.update_state is MaterialModel.update_state:
+        implicit = set(cls.implicit_state_names)
+        all_states = set(cls.state_names)
+        unknown = implicit - all_states
+        if unknown:
             raise TypeError(
-                f"{cls.__name__}: reduced hardening models must implement "
-                "update_state()"
+                f"{cls.__name__}: implicit_state_names contains names not in "
+                f"state_names: {sorted(unknown)}"
             )
-        if ht == "augmented" and cls.state_residual is MaterialModel.state_residual:
+        explicit = all_states - implicit
+        needs_update = bool(explicit)
+        needs_residual = bool(implicit)
+        if needs_update and cls.update_state is MaterialModel.update_state:
             raise TypeError(
-                f"{cls.__name__}: augmented hardening models must implement "
-                "state_residual()"
+                f"{cls.__name__}: explicit states {sorted(explicit)} require "
+                "update_state() to be implemented"
+            )
+        if needs_residual and cls.state_residual is MaterialModel.state_residual:
+            raise TypeError(
+                f"{cls.__name__}: implicit states {sorted(implicit)} require "
+                "state_residual() to be implemented"
             )
         from manforge.verification.fortran_registry import collect_bindings
         cls._fortran_bindings = collect_bindings(cls)
@@ -143,18 +170,17 @@ class MaterialModel(ABC):
     ) -> dict:
         """Return updated state variables after a plastic increment.
 
-        Closed-form update rule: given (Δλ, σ, q_n), computes q_{n+1}
-        directly.  Required for reduced hardening models
-        (``hardening_type='reduced'``).
+        Closed-form (explicit) update rule: given (Δλ, σ, q_n), returns
+        q_{n+1} directly.  Required for all state variables *not* listed in
+        :attr:`implicit_state_names`.  Only the keys for explicit states need
+        to be returned; extra keys raise ``ValueError`` at residual-build time.
 
         The companion residual form is :meth:`state_residual`, related by::
 
             state_residual(q_{n+1}, Δλ, σ, q_n) = q_{n+1} - update_state(Δλ, σ, q_n)
 
-        The base class provides a default ``state_residual`` derived from this
-        method, so reduced models only need to implement ``update_state``.
-        Augmented models that cannot express q_{n+1} in closed form must
-        instead override :meth:`state_residual` directly.
+        The base class provides a default ``state_residual`` from this method,
+        so models where all states are explicit only need ``update_state``.
 
         Parameters
         ----------
@@ -162,24 +188,23 @@ class MaterialModel(ABC):
             Plastic multiplier increment Δλ ≥ 0.
         stress : anp.ndarray, shape (ntens,)
             Current stress within the NR iteration (Voigt notation).
-            Models that depend only on dlambda (e.g. isotropic hardening)
-            may ignore this argument.
         state : dict
             State at the beginning of the increment.
 
         Returns
         -------
         dict
-            Updated state ``q_{n+1}``.
+            Updated explicit-state dict ``{k: q_{n+1}[k] for k in explicit_keys}``.
 
         Raises
         ------
         NotImplementedError
-            If not overridden on a reduced model.
+            If not overridden when explicit states exist.
         """
         raise NotImplementedError(
             f"{type(self).__name__}.update_state() is not implemented. "
-            "Reduced models (hardening_type='reduced') must override this method."
+            "Models with explicit states (not in implicit_state_names) must "
+            "implement update_state()."
         )
 
     def state_residual(
@@ -189,25 +214,26 @@ class MaterialModel(ABC):
         stress: anp.ndarray,
         state_n: dict,
     ) -> dict:
-        """Residual of the state evolution equations.
+        """Residual of the implicit state evolution equations.
 
-        Defines R_h(q_{n+1}, Δλ, σ, q_n) = 0 for use in the augmented
-        residual system where state variables are independent unknowns.
+        Defines R_h(q_{n+1}, Δλ, σ, q_n) = 0 for state variables listed in
+        :attr:`implicit_state_names`.  Only those keys should appear in the
+        returned dict; extra or missing keys raise ``ValueError`` at
+        residual-build time.
 
         The relationship to the closed-form update rule is::
 
             state_residual(q_{n+1}, Δλ, σ, q_n) = q_{n+1} - update_state(Δλ, σ, q_n)
 
-        The default implementation derives ``state_residual`` automatically from
-        :meth:`update_state`.  Override this method directly to define implicit
-        hardening laws where ``state_new`` cannot be expressed in closed form as
-        a function of ``(dlambda, stress, state_n)`` — this is the ``augmented``
-        path.
+        The default implementation derives the residual automatically from
+        :meth:`update_state` (valid when all states can be expressed in closed
+        form).  Override this method directly when ``state_new`` cannot be
+        computed in closed form from ``(dlambda, stress, state_n)``.
 
         Parameters
         ----------
         state_new : dict
-            Proposed state at step n+1 (independent unknown).
+            Proposed implicit-state values at step n+1 (NR unknowns).
         dlambda : anp.ndarray, scalar
             Plastic multiplier increment Δλ.
         stress : anp.ndarray, shape (ntens,)
@@ -218,8 +244,7 @@ class MaterialModel(ABC):
         Returns
         -------
         dict
-            Residual dict with same keys and shapes as ``state_new``.
-            Zero at convergence.
+            Residual dict keyed by :attr:`implicit_state_names`.  Zero at convergence.
         """
         state_explicit = self.update_state(dlambda, stress, state_n)
         return {k: state_new[k] - state_explicit[k] for k in state_new}

--- a/src/manforge/core/residual.py
+++ b/src/manforge/core/residual.py
@@ -6,7 +6,7 @@ import numpy as np
 
 
 # ---------------------------------------------------------------------------
-# State flatten / unflatten helpers (replaces jax.flatten_util.ravel_pytree)
+# State flatten / unflatten helpers
 # ---------------------------------------------------------------------------
 
 def _flatten_state(state: dict):
@@ -19,12 +19,10 @@ def _flatten_state(state: dict):
              safe to inspect outside of autograd's tracing context.
     """
     keys = sorted(state.keys())
-    # Use np.asarray for shape inspection only (no gradient needed for shape).
     shapes = [(k, np.asarray(state[k]).shape) for k in keys]
     parts = []
     for k, shp in shapes:
         v = state[k]
-        # Wrap scalar box values in a 1-element array so concatenate works.
         parts.append(anp.reshape(v, (-1,)) if shp else anp.atleast_1d(v))
     vec = anp.concatenate(parts) if parts else anp.zeros(0)
     return vec, shapes
@@ -43,58 +41,204 @@ def _unflatten_state(vec, shapes: list) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# Key-consistency validation helpers (called at first NR evaluation)
+# ---------------------------------------------------------------------------
+
+def _check_update_state_keys(model_name, returned: dict, expected_keys: set):
+    actual = set(returned.keys())
+    if actual != expected_keys:
+        extra = actual - expected_keys
+        missing = expected_keys - actual
+        parts = []
+        if extra:
+            parts.append(f"unexpected keys: {sorted(extra)}")
+        if missing:
+            parts.append(f"missing keys: {sorted(missing)}")
+        raise ValueError(
+            f"{model_name}.update_state() returned wrong keys "
+            f"({'; '.join(parts)}). Expected: {sorted(expected_keys)}"
+        )
+
+
+def _check_state_residual_keys(model_name, returned: dict, expected_keys: set):
+    actual = set(returned.keys())
+    if actual != expected_keys:
+        extra = actual - expected_keys
+        missing = expected_keys - actual
+        parts = []
+        if extra:
+            parts.append(f"unexpected keys: {sorted(extra)}")
+        if missing:
+            parts.append(f"missing keys: {sorted(missing)}")
+        raise ValueError(
+            f"{model_name}.state_residual() returned wrong keys "
+            f"({'; '.join(parts)}). Expected: {sorted(expected_keys)}"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Residual builders
 # ---------------------------------------------------------------------------
 
-def make_reduced_residual(model, stress_trial, state_n):
-    """Build the residual function for reduced-system models."""
+def make_nr_residual(model, stress_trial, state_n):
+    """Build the NR residual function.
+
+    Unknown vector layout::
+
+        x_NR = [σ (ntens)]?          if model.implicit_stress
+             + [Δλ (1)]
+             + [q_implicit (n_imp)]?  if model.implicit_state_names
+
+    Returns
+    -------
+    residual_fn : callable(x) -> R
+    unknowns_meta : dict
+        Keys: ``implicit_stress`` (bool), ``ntens`` (int),
+        ``n_implicit`` (int), ``implicit_shapes`` (list).
+    unflatten_implicit : callable(flat) -> dict
+    """
     ntens = model.ntens
+    implicit_keys = sorted(model.implicit_state_names)
+    explicit_keys = set(model.state_names) - set(implicit_keys)
+    do_implicit_stress = model.implicit_stress
+    model_name = type(model).__name__
+
+    implicit_state_n = {k: state_n[k] for k in implicit_keys}
+    flat_impl_n, implicit_shapes = _flatten_state(implicit_state_n)
+    n_implicit = len(flat_impl_n)
+
+    def unflatten_implicit(flat):
+        return _unflatten_state(flat, implicit_shapes)
+
+    unknowns_meta = {
+        "implicit_stress": do_implicit_stress,
+        "ntens": ntens,
+        "n_implicit": n_implicit,
+        "implicit_shapes": implicit_shapes,
+    }
+
+    # Index positions in x.
+    if do_implicit_stress:
+        _sig_sl = slice(0, ntens)
+        _dl_idx = ntens
+        _q_sl = slice(ntens + 1, ntens + 1 + n_implicit)
+    else:
+        _sig_sl = None
+        _dl_idx = 0
+        _q_sl = slice(1, 1 + n_implicit)
 
     def residual_fn(x):
-        sig = x[:ntens]
-        dl = x[ntens]
-        st = model.update_state(dl, sig, state_n)
-        C_new = model.elastic_stiffness(st)
-        n = autograd.grad(lambda s: model.yield_function(s, st))(sig)
-        R_stress = sig - stress_trial + dl * (C_new @ n)
-        R_yield = model.yield_function(sig, st)
-        return anp.concatenate([R_stress, anp.atleast_1d(R_yield)])
+        dlambda = x[_dl_idx]
 
-    return residual_fn
+        if n_implicit > 0:
+            q_imp = unflatten_implicit(x[_q_sl])
+        else:
+            q_imp = {}
+
+        if do_implicit_stress:
+            sig = x[_sig_sl]
+            # Compute explicit states from update_state using current sig.
+            if explicit_keys:
+                q_exp = model.update_state(dlambda, sig, state_n)
+                _check_update_state_keys(model_name, q_exp, explicit_keys)
+                q_full = {**q_imp, **q_exp}
+            else:
+                q_full = q_imp
+        else:
+            # σ is derived via one fixed-point step from σ_trial using current q.
+            if explicit_keys:
+                # Approximate explicit states using state_n (they are re-evaluated
+                # after σ is determined inside the full solver iteration).
+                q_exp_approx = {k: state_n[k] for k in explicit_keys}
+                q_full_approx = {**q_imp, **q_exp_approx}
+            else:
+                q_full_approx = q_imp if q_imp else dict(state_n)
+            C_approx = model.elastic_stiffness(q_full_approx)
+            n_approx = autograd.grad(
+                lambda s: model.yield_function(s, q_full_approx)
+            )(anp.array(stress_trial))
+            sig = anp.array(stress_trial) - dlambda * (C_approx @ n_approx)
+            if explicit_keys:
+                q_exp = model.update_state(dlambda, sig, state_n)
+                _check_update_state_keys(model_name, q_exp, explicit_keys)
+                q_full = {**q_imp, **q_exp}
+            else:
+                q_full = q_imp if q_imp else {}
+
+        C = model.elastic_stiffness(q_full)
+        n = autograd.grad(lambda s: model.yield_function(s, q_full))(sig)
+        R_yield = model.yield_function(sig, q_full)
+
+        parts = []
+        if do_implicit_stress:
+            R_stress = sig - anp.array(stress_trial) + dlambda * (C @ n)
+            parts.append(R_stress)
+        parts.append(anp.atleast_1d(R_yield))
+        if n_implicit > 0:
+            R_state_dict = model.state_residual(q_imp, dlambda, sig, state_n)
+            _check_state_residual_keys(model_name, R_state_dict, set(implicit_keys))
+            R_state_flat, _ = _flatten_state(R_state_dict)
+            parts.append(R_state_flat)
+
+        return anp.concatenate(parts)
+
+    return residual_fn, unknowns_meta, unflatten_implicit
 
 
-def make_augmented_residual(model, stress_trial, state_n):
-    """Build the augmented residual function for implicit-state models."""
+def make_tangent_residual(model, stress_trial, state_n):
+    """Build the tangent/Jacobian residual function.
+
+    σ is always an independent variable.  Unknown vector layout::
+
+        x_tan = [σ (ntens)] + [Δλ (1)] + [q_implicit (n_imp)]?
+
+    Returns
+    -------
+    residual_fn : callable(x) -> R  of size ntens + 1 + n_implicit
+    n_implicit : int
+    unflatten_implicit : callable(flat) -> dict
+    """
     ntens = model.ntens
+    implicit_keys = sorted(model.implicit_state_names)
+    explicit_keys = set(model.state_names) - set(implicit_keys)
+    model_name = type(model).__name__
 
-    _, shapes = _flatten_state(state_n)
-    n_state = sum(int(np.prod(shp)) if shp else 1 for _, shp in shapes)
+    implicit_state_n = {k: state_n[k] for k in implicit_keys}
+    _, implicit_shapes = _flatten_state(implicit_state_n)
+    n_implicit = sum(int(np.prod(shp)) if shp else 1 for _, shp in implicit_shapes)
 
-    def unflatten_fn(q_flat):
-        return _unflatten_state(q_flat, shapes)
+    def unflatten_implicit(flat):
+        return _unflatten_state(flat, implicit_shapes)
 
     def residual_fn(x):
         sig = x[:ntens]
         dlambda = x[ntens]
-        q_flat = x[ntens + 1:]
-        state_new = unflatten_fn(q_flat)
 
-        C_new = model.elastic_stiffness(state_new)
-        n = autograd.grad(lambda s: model.yield_function(s, state_new))(sig)
+        if n_implicit > 0:
+            q_imp = unflatten_implicit(x[ntens + 1:])
+        else:
+            q_imp = {}
 
-        R_stress = sig - stress_trial + dlambda * (C_new @ n)
-        R_yield = model.yield_function(sig, state_new)
+        if explicit_keys:
+            q_exp = model.update_state(dlambda, sig, state_n)
+            _check_update_state_keys(model_name, q_exp, explicit_keys)
+            q_full = {**q_imp, **q_exp}
+        else:
+            q_full = q_imp
 
-        R_state_dict = model.state_residual(state_new, dlambda, sig, state_n)
-        R_state_flat, _ = _flatten_state(R_state_dict)
+        C = model.elastic_stiffness(q_full)
+        n = autograd.grad(lambda s: model.yield_function(s, q_full))(sig)
 
-        return anp.concatenate([R_stress, anp.atleast_1d(R_yield), R_state_flat])
+        R_stress = sig - anp.array(stress_trial) + dlambda * (C @ n)
+        R_yield = model.yield_function(sig, q_full)
 
-    return residual_fn, n_state, unflatten_fn
+        parts = [R_stress, anp.atleast_1d(R_yield)]
+        if n_implicit > 0:
+            R_state_dict = model.state_residual(q_imp, dlambda, sig, state_n)
+            _check_state_residual_keys(model_name, R_state_dict, set(implicit_keys))
+            R_state_flat, _ = _flatten_state(R_state_dict)
+            parts.append(R_state_flat)
 
+        return anp.concatenate(parts)
 
-def select_residual_builder(model):
-    """Return the appropriate residual builder for *model*."""
-    if model.hardening_type == "augmented":
-        return make_augmented_residual
-    return make_reduced_residual
+    return residual_fn, n_implicit, unflatten_implicit

--- a/src/manforge/core/solver.py
+++ b/src/manforge/core/solver.py
@@ -1,27 +1,52 @@
-"""Newton-Raphson solvers for return-mapping systems."""
+"""Newton-Raphson solver for return-mapping systems."""
 
 import autograd
 import autograd.numpy as anp
 import numpy as np
 
 from manforge.core.residual import (
-    make_augmented_residual,
-    make_reduced_residual,
+    make_nr_residual,
     _flatten_state,
 )
 
 
-def _reduced_nr(model, stress_trial, state_n, max_iter, tol,
-                raise_on_nonconverged=True):
-    """Newton-Raphson solver for the reduced (ntens+1) residual system.
+def _numerical_newton(model, stress_trial, state_n, max_iter, tol,
+                      raise_on_nonconverged=True):
+    """Unified Newton-Raphson solver for return mapping.
+
+    Dispatches automatically based on ``model.implicit_state_names`` and
+    ``model.implicit_stress``:
+
+    * ``implicit_state_names=[]``, ``implicit_stress=False``  →  scalar NR on Δλ
+      (uses ``autograd.grad`` for efficiency)
+    * otherwise  →  vector NR on ``[σ?] + [Δλ] + [q_implicit?]``
+      (uses ``autograd.jacobian`` + ``np.linalg.solve``)
 
     Returns
     -------
     tuple
         ``(stress, state_new, dlambda, n_iterations, residual_history, converged)``
     """
-    ntens = model.ntens
+    residual_fn, unknowns_meta, unflatten_implicit = make_nr_residual(
+        model, stress_trial, state_n
+    )
+    do_implicit_stress = unknowns_meta["implicit_stress"]
+    n_implicit = unknowns_meta["n_implicit"]
+    scalar_nr = (not do_implicit_stress) and (n_implicit == 0)
 
+    if scalar_nr:
+        return _scalar_nr(
+            model, stress_trial, state_n, max_iter, tol, raise_on_nonconverged,
+        )
+    else:
+        return _vector_nr(
+            model, stress_trial, state_n, residual_fn, unknowns_meta,
+            unflatten_implicit, max_iter, tol, raise_on_nonconverged,
+        )
+
+
+def _scalar_nr(model, stress_trial, state_n, max_iter, tol, raise_on_nonconverged):
+    """Scalar NR on Δλ (implicit_state_names=[], implicit_stress=False)."""
     dlambda = anp.array(0.0)
     stress = anp.array(stress_trial)
     state_new = state_n
@@ -34,7 +59,7 @@ def _reduced_nr(model, stress_trial, state_n, max_iter, tol,
         state_new = model.update_state(dlambda, stress, state_n)
         C_new = model.elastic_stiffness(state_new)
         n = autograd.grad(lambda s: model.yield_function(s, state_new))(stress)
-        stress = stress_trial - dlambda * (C_new @ n)
+        stress = anp.array(stress_trial) - dlambda * (C_new @ n)
         state_new = model.update_state(dlambda, stress, state_n)
         f = model.yield_function(stress, state_new)
         residual_history.append(float(np.abs(float(f))))
@@ -45,7 +70,7 @@ def _reduced_nr(model, stress_trial, state_n, max_iter, tol,
         def _f_residual(dl, _stress=stress):
             st = model.update_state(dl, _stress, state_n)
             nn = autograd.grad(lambda s: model.yield_function(s, st))(_stress)
-            s_upd = stress_trial - dl * (model.elastic_stiffness(st) @ nn)
+            s_upd = anp.array(stress_trial) - dl * (model.elastic_stiffness(st) @ nn)
             return model.yield_function(s_upd, st)
 
         dfddl = autograd.grad(_f_residual)(dlambda)
@@ -54,63 +79,83 @@ def _reduced_nr(model, stress_trial, state_n, max_iter, tol,
 
     if raise_on_nonconverged:
         raise RuntimeError(
-            f"_reduced_nr: NR did not converge in {max_iter} iterations "
+            f"_scalar_nr: NR did not converge in {max_iter} iterations "
             f"(|f| = {float(np.abs(float(f))):.3e}, tol = {tol:.3e})"
         )
-
     return stress, state_new, dlambda, n_iterations, residual_history, False
 
 
-def _augmented_nr(model, stress_trial, state_n, max_iter, tol,
-                  raise_on_nonconverged=True):
-    """Newton-Raphson solver for the augmented (ntens+1+n_state) residual system.
+def _vector_nr(model, stress_trial, state_n, residual_fn, unknowns_meta,
+               unflatten_implicit, max_iter, tol, raise_on_nonconverged):
+    """Vector NR on [σ?] + [Δλ] + [q_implicit?]."""
+    ntens = unknowns_meta["ntens"]
+    do_implicit_stress = unknowns_meta["implicit_stress"]
+    n_implicit = unknowns_meta["n_implicit"]
+    implicit_keys = sorted(model.implicit_state_names)
+    explicit_keys = set(model.state_names) - set(implicit_keys)
 
-    Returns
-    -------
-    tuple
-        ``(stress, state_new, dlambda, n_iterations, residual_history, converged)``
-    """
-    ntens = model.ntens
-    residual_fn, n_state, unflatten_fn = make_augmented_residual(
-        model, stress_trial, state_n
-    )
+    # Build initial guess x.
+    implicit_state_n = {k: state_n[k] for k in implicit_keys}
+    flat_impl_n, _ = _flatten_state(implicit_state_n)
+    parts = []
+    if do_implicit_stress:
+        parts.append(anp.array(stress_trial))
+    parts.append(anp.array([0.0]))  # Δλ
+    if n_implicit > 0:
+        parts.append(flat_impl_n)
+    x = anp.concatenate(parts)
 
-    flat_state_n, _ = _flatten_state(state_n)
-    x = anp.concatenate([anp.array(stress_trial), anp.array([0.0]), flat_state_n])
+    if do_implicit_stress:
+        _dl_idx = ntens
+        _q_sl = slice(ntens + 1, ntens + 1 + n_implicit)
+    else:
+        _dl_idx = 0
+        _q_sl = slice(1, 1 + n_implicit)
 
     residual_history = []
     n_iterations = 0
     R = residual_fn(x)
+    converged = False
+
     for _iteration in range(max_iter):
         R = residual_fn(x)
         res_norm = float(np.linalg.norm(np.array(R)))
         residual_history.append(res_norm)
         if res_norm < tol:
-            stress = x[:ntens]
-            dlambda = float(x[ntens])
-            state_new = unflatten_fn(x[ntens + 1:])
-            return (stress, state_new, anp.array(dlambda),
-                    n_iterations, residual_history, True)
+            converged = True
+            break
         J = autograd.jacobian(residual_fn)(x)
         dx = np.linalg.solve(np.array(J), np.array(R))
         x = x - anp.array(dx)
         n_iterations += 1
 
-    if raise_on_nonconverged:
+    if not converged and raise_on_nonconverged:
         raise RuntimeError(
-            f"_augmented_nr: NR did not converge in {max_iter} iterations "
+            f"_vector_nr: NR did not converge in {max_iter} iterations "
             f"(||R||_2 = {float(np.linalg.norm(np.array(R))):.3e}, tol = {tol:.3e})"
         )
 
-    stress = x[:ntens]
-    dlambda = float(x[ntens])
-    state_new = unflatten_fn(x[ntens + 1:])
-    return (stress, state_new, anp.array(dlambda),
-            n_iterations, residual_history, False)
+    # Extract results from x.
+    dlambda_val = x[_dl_idx]
 
+    if do_implicit_stress:
+        stress = x[:ntens]
+    else:
+        q_imp = unflatten_implicit(x[_q_sl]) if n_implicit > 0 else {}
+        if explicit_keys:
+            q_exp = model.update_state(dlambda_val, anp.array(stress_trial), state_n)
+            q_full = {**q_imp, **q_exp}
+        else:
+            q_full = q_imp if q_imp else dict(state_n)
+        C = model.elastic_stiffness(q_full)
+        n_dir = autograd.grad(lambda s: model.yield_function(s, q_full))(anp.array(stress_trial))
+        stress = anp.array(stress_trial) - dlambda_val * (C @ n_dir)
 
-def _select_nr(model):
-    """Return the NR solver function appropriate for *model*."""
-    if model.hardening_type == "augmented":
-        return _augmented_nr
-    return _reduced_nr
+    q_imp = unflatten_implicit(x[_q_sl]) if n_implicit > 0 else {}
+    if explicit_keys:
+        q_exp = model.update_state(dlambda_val, stress, state_n)
+        state_new = {**q_imp, **q_exp}
+    else:
+        state_new = q_imp if q_imp else dict(state_n)
+
+    return stress, state_new, anp.array(dlambda_val), n_iterations, residual_history, converged

--- a/src/manforge/core/tangent.py
+++ b/src/manforge/core/tangent.py
@@ -4,64 +4,59 @@ import autograd
 import autograd.numpy as anp
 import numpy as np
 
-from manforge.core.residual import (
-    make_augmented_residual,
-    make_reduced_residual,
-    _flatten_state,
-)
+from manforge.core.residual import make_tangent_residual, _flatten_state
 
 
 def consistent_tangent(model, stress, state, dlambda, stress_n, state_n):
-    """Compute the consistent (algorithmic) tangent dσ_{n+1}/dΔε (reduced path)."""
+    """Compute the consistent (algorithmic) tangent dσ_{n+1}/dΔε.
+
+    σ is always included as an independent variable in the linear system,
+    regardless of ``model.implicit_stress``.  The linear system solved is::
+
+        A · dx/dε = rhs
+        A = ∂R/∂x  (ntens + 1 + n_implicit) × (ntens + 1 + n_implicit)
+        rhs[:,j] = [C_n[:,j], 0, ..., 0]
+        dσ/dε = dx[:ntens, :]
+
+    Parameters
+    ----------
+    model : MaterialModel
+    stress : array, shape (ntens,)
+        Converged stress σ_{n+1}.
+    state : dict
+        Converged state at step n+1.
+    dlambda : scalar
+        Converged Δλ.
+    stress_n : array
+        Stress at increment start (unused, kept for API compatibility).
+    state_n : dict
+        State at increment start.
+
+    Returns
+    -------
+    anp.ndarray, shape (ntens, ntens)
+    """
     ntens = model.ntens
     C_n = model.elastic_stiffness(state_n)
     C_conv = model.elastic_stiffness(state)
 
     n_conv = autograd.grad(lambda s: model.yield_function(s, state))(stress)
-    # Reconstruct stress_trial from the converged state equation:
-    # stress = stress_trial - dlambda * C(state_new) @ n  →  stress_trial = stress + dlambda * C_conv @ n
     stress_trial = stress + float(dlambda) * (C_conv @ n_conv)
 
-    residual_fn = make_reduced_residual(model, stress_trial, state_n)
+    residual_fn, n_implicit, _ = make_tangent_residual(model, stress_trial, state_n)
 
-    x_conv = anp.concatenate([anp.array(stress), anp.array([float(dlambda)])])
-    A = autograd.jacobian(residual_fn)(x_conv)  # (ntens+1, ntens+1)
+    implicit_keys = sorted(model.implicit_state_names)
+    implicit_state = {k: state[k] for k in implicit_keys}
+    flat_impl, _ = _flatten_state(implicit_state)
 
-    rhs = np.vstack([np.array(C_n), np.zeros((1, ntens))])  # (ntens+1, ntens)
-    dxde = np.linalg.solve(np.array(A), rhs)                # (ntens+1, ntens)
-
-    return anp.array(dxde[:ntens, :])
-
-
-def augmented_consistent_tangent(model, stress, state, dlambda, stress_n, state_n):
-    """Consistent tangent for implicit-state models (augmented residual system)."""
-    ntens = model.ntens
-    C_n = model.elastic_stiffness(state_n)
-    C_conv = model.elastic_stiffness(state)
-
-    n_conv = autograd.grad(lambda s: model.yield_function(s, state))(stress)
-    stress_trial = stress + float(dlambda) * (C_conv @ n_conv)
-
-    residual_fn, n_state, _ = make_augmented_residual(model, stress_trial, state_n)
-
-    flat_state, _ = _flatten_state(state)
     x_conv = anp.concatenate([
         anp.array(stress),
         anp.array([float(dlambda)]),
-        flat_state,
+        flat_impl,
     ])
 
     A = autograd.jacobian(residual_fn)(x_conv)
-
-    total = ntens + 1 + n_state
-    rhs = np.vstack([np.array(C_n), np.zeros((1 + n_state, ntens))])  # (total, ntens)
-    dxde = np.linalg.solve(np.array(A), rhs)                        # (total, ntens)
+    rhs = np.vstack([np.array(C_n), np.zeros((1 + n_implicit, ntens))])
+    dxde = np.linalg.solve(np.array(A), rhs)
 
     return anp.array(dxde[:ntens, :])
-
-
-def _select_tangent(model):
-    """Return the consistent-tangent function appropriate for *model*."""
-    if model.hardening_type == "augmented":
-        return augmented_consistent_tangent
-    return consistent_tangent

--- a/src/manforge/models/ow_kinematic.py
+++ b/src/manforge/models/ow_kinematic.py
@@ -45,8 +45,9 @@ Rearranged as a residual (the form used by ``state_residual``):
     R_α = α_{n+1} − α_n − C_k Δλ n̂ + γ Δλ ‖α_{n+1}‖ α_{n+1} = 0
 
 Because ‖α_{n+1}‖ appears nonlinearly, this cannot be solved for α_{n+1} in
-closed form.  Setting ``hardening_type = 'augmented'`` activates the augmented
-Newton-Raphson path and the augmented consistent tangent automatically.
+closed form.  Setting ``implicit_state_names = state_names`` and
+``implicit_stress = True`` activates the vector Newton-Raphson path and
+the correct consistent tangent automatically.
 
 Saturation backstress
 ---------------------
@@ -74,7 +75,7 @@ Notes
   (same limit as standard AF).
 * The plastic increment is always solved via the augmented NR using
   ``state_residual``.  No ``update_state`` is defined because
-  ``hardening_type = 'augmented'`` does not require one.
+  ``implicit_state_names`` does not require one.
 """
 
 import autograd.numpy as anp
@@ -87,7 +88,7 @@ class OWKinematic3D(MaterialModel3D):
     """J2 + Ohno-Wang kinematic hardening for full-rank stress states.
 
     Inherits operator methods from :class:`~manforge.core.material.MaterialModel3D`.
-    Uses the augmented residual path (``hardening_type = 'augmented'``) because the
+    Uses the vector NR path (``implicit_state_names = state_names``) because the
     backward-Euler discretisation of the Ohno-Wang evolution equation is genuinely
     implicit.
 
@@ -108,7 +109,8 @@ class OWKinematic3D(MaterialModel3D):
         Dynamic recovery parameter (Ohno-Wang nonlinearity).
     """
 
-    hardening_type = "augmented"
+    implicit_state_names = ["alpha", "ep"]
+    implicit_stress = True
     param_names = ["E", "nu", "sigma_y0", "C_k", "gamma"]
     state_names = ["alpha", "ep"]
 
@@ -142,9 +144,8 @@ class OWKinematic3D(MaterialModel3D):
         ``σ − α_{n+1}`` for full backward-Euler consistency with the flow
         direction used in the stress residual equation.
 
-        Required because ``hardening_type = 'augmented'``, which activates the
-        augmented (ntens+1+n_state) Newton-Raphson solver and the augmented
-        consistent tangent automatically.
+        Required because ``implicit_state_names = state_names``, which activates
+        the vector Newton-Raphson solver and the correct consistent tangent.
         """
         alpha_new = state_new["alpha"]
 
@@ -173,7 +174,7 @@ class OWKinematicPS(MaterialModelPS):
     :class:`~manforge.core.material.MaterialModelPS` (including the
     missing-component correction in ``_vonmises``).
 
-    Uses the augmented residual path (``hardening_type = 'augmented'``).
+    Uses the vector NR path (``implicit_state_names = state_names``).
 
     Parameters
     ----------
@@ -192,7 +193,8 @@ class OWKinematicPS(MaterialModelPS):
         Dynamic recovery parameter (Ohno-Wang nonlinearity).
     """
 
-    hardening_type = "augmented"
+    implicit_state_names = ["alpha", "ep"]
+    implicit_stress = True
     param_names = ["E", "nu", "sigma_y0", "C_k", "gamma"]
     state_names = ["alpha", "ep"]
 
@@ -241,7 +243,7 @@ class OWKinematic1D(MaterialModel1D):
     Inherits operator methods from
     :class:`~manforge.core.material.MaterialModel1D`.
 
-    Uses the augmented residual path (``hardening_type = 'augmented'``).
+    Uses the vector NR path (``implicit_state_names = state_names``).
 
     Parameters
     ----------
@@ -259,7 +261,8 @@ class OWKinematic1D(MaterialModel1D):
         Dynamic recovery parameter (Ohno-Wang nonlinearity).
     """
 
-    hardening_type = "augmented"
+    implicit_state_names = ["alpha", "ep"]
+    implicit_stress = True
     param_names = ["E", "nu", "sigma_y0", "C_k", "gamma"]
     state_names = ["alpha", "ep"]
 

--- a/src/manforge/simulation/integrator.py
+++ b/src/manforge/simulation/integrator.py
@@ -41,8 +41,8 @@ import numpy as np
 
 from manforge.core.stress_update import ReturnMappingResult, StressUpdateResult
 from manforge.core.stress_state import StressState, SOLID_3D
-from manforge.core.solver import _select_nr
-from manforge.core.tangent import _select_tangent
+from manforge.core.solver import _numerical_newton
+from manforge.core.tangent import consistent_tangent
 
 
 # ---------------------------------------------------------------------------
@@ -164,8 +164,7 @@ class _PythonIntegratorBase:
         if rm is not None:
             return rm
 
-        nr = _select_nr(self._model)
-        stress, state_new, dlambda, n_iter, res_hist, converged = nr(
+        stress, state_new, dlambda, n_iter, res_hist, converged = _numerical_newton(
             self._model, stress_trial, state_n,
             self._max_iter, self._tol, self._raise_on_nonconverged,
         )
@@ -200,8 +199,7 @@ class _PythonIntegratorBase:
 
         ddsdde = self._try_user_tangent(rm, stress_n, state_n, C_n)
         if ddsdde is None:
-            tangent_fn = _select_tangent(self._model)
-            ddsdde = tangent_fn(
+            ddsdde = consistent_tangent(
                 self._model, rm.stress, rm.state, rm.dlambda, stress_n, state_n
             )
 

--- a/tests/fixtures/implicit_models.py
+++ b/tests/fixtures/implicit_models.py
@@ -1,7 +1,7 @@
-"""AF kinematic hardening models recast as augmented (implicit) residual systems.
+"""AF kinematic hardening models recast as implicit residual systems.
 
-These are test doubles used to validate the augmented NR machinery. Mathematically
-identical to the corresponding reduced-path models at convergence.
+These are test doubles used to validate the vector NR machinery. Mathematically
+identical to the corresponding explicit-path models at convergence.
 
 The explicit update for alpha is:
     alpha_new = (alpha_n + C_k * dlambda * n_hat) / (1 + gamma * dlambda)
@@ -20,7 +20,8 @@ from manforge.core.stress_state import PLANE_STRAIN
 class _AFKinematicImplicit3D(AFKinematic3D):
     """AF kinematic 3D model with hardening expressed as an implicit residual."""
 
-    hardening_type = "augmented"
+    implicit_state_names = ["alpha", "ep"]
+    implicit_stress = True
 
     def state_residual(self, state_new, dlambda, stress, state_n):
         alpha_n = state_n["alpha"]
@@ -38,7 +39,8 @@ class _AFKinematicImplicit3D(AFKinematic3D):
 class _AFKinematicImplicitPS(AFKinematicPS):
     """Plane-stress variant of the implicit AF model."""
 
-    hardening_type = "augmented"
+    implicit_state_names = ["alpha", "ep"]
+    implicit_stress = True
 
     def state_residual(self, state_new, dlambda, stress, state_n):
         alpha_n = state_n["alpha"]
@@ -56,7 +58,8 @@ class _AFKinematicImplicitPS(AFKinematicPS):
 class _AFKinematicImplicitPE(AFKinematic3D):
     """Plane-strain variant of the implicit AF model (uses MaterialModel3D with PLANE_STRAIN)."""
 
-    hardening_type = "augmented"
+    implicit_state_names = ["alpha", "ep"]
+    implicit_stress = True
 
     def __init__(self):
         super().__init__(stress_state=PLANE_STRAIN,

--- a/tests/integration/test_af_specific.py
+++ b/tests/integration/test_af_specific.py
@@ -2,7 +2,7 @@ import numpy as np
 """AF (Armstrong-Frederick) model-specific tests.
 
 Covers physics unique to the AF model:
-- hardening_type == "reduced" for all variants
+- implicit_state_names == [] (all states explicit) for all variants
 - gamma=0 gives purely linear kinematic backstress (positive axial component)
 """
 
@@ -14,19 +14,19 @@ from manforge.simulation.integrator import PythonIntegrator
 
 
 # ---------------------------------------------------------------------------
-# hardening_type detection
+# API detection: all AF states are explicit (no implicit_state_names)
 # ---------------------------------------------------------------------------
 
-def test_hardening_type_af3d():
-    assert AFKinematic3D(E=210000.0, nu=0.3, sigma_y0=250.0, C_k=10000.0, gamma=100.0).hardening_type == "reduced"
+def test_implicit_state_names_af3d():
+    assert AFKinematic3D(E=210000.0, nu=0.3, sigma_y0=250.0, C_k=10000.0, gamma=100.0).implicit_state_names == []
 
 
-def test_hardening_type_afps():
-    assert AFKinematicPS(E=210000.0, nu=0.3, sigma_y0=250.0, C_k=10000.0, gamma=100.0).hardening_type == "reduced"
+def test_implicit_state_names_afps():
+    assert AFKinematicPS(E=210000.0, nu=0.3, sigma_y0=250.0, C_k=10000.0, gamma=100.0).implicit_state_names == []
 
 
-def test_hardening_type_af1d():
-    assert AFKinematic1D(E=210000.0, nu=0.3, sigma_y0=250.0, C_k=10000.0, gamma=100.0).hardening_type == "reduced"
+def test_implicit_state_names_af1d():
+    assert AFKinematic1D(E=210000.0, nu=0.3, sigma_y0=250.0, C_k=10000.0, gamma=100.0).implicit_state_names == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_augmented_residual.py
+++ b/tests/integration/test_augmented_residual.py
@@ -1,16 +1,16 @@
-"""Tests for the augmented (ntens+1+n_state) residual system.
+"""Tests for the implicit-state (ntens+1+n_state) residual system.
 
-The augmented system treats state variables as independent unknowns, enabling
-models with implicit hardening laws where state_new cannot be expressed in
-closed form as a function of (dlambda, stress, state_n).
+The implicit-state system treats state variables as independent NR unknowns,
+enabling models with implicit hardening laws where state_new cannot be
+expressed in closed form as a function of (dlambda, stress, state_n).
 
 Key verifications
 -----------------
-- hardening_type detection via class variable
-- Augmented NR produces the same converged solution as the reduced NR path
-  (validated by recasting the AF model as an augmented model whose residual
-  equations are algebraically identical to the reduced update)
-- FD tangent vs AD tangent agreement for the augmented path
+- implicit_state_names / implicit_stress API detection via class variable
+- Implicit NR produces the same converged solution as the explicit NR path
+  (validated by recasting the AF model as an implicit model whose residual
+  equations are algebraically identical to the explicit update)
+- FD tangent vs AD tangent agreement for the implicit path
 - Yield surface consistency after plastic steps
 - Correct dimensionality handling (3D, PLANE_STRAIN, PLANE_STRESS)
 """
@@ -50,23 +50,28 @@ def implicit_ps_model():
 
 
 # ---------------------------------------------------------------------------
-# hardening_type detection
+# API detection: explicit vs implicit state names
 # ---------------------------------------------------------------------------
 
-def test_hardening_type_j2_is_reduced(model):
-    assert model.hardening_type == "reduced"
+def test_j2_has_no_implicit_states(model):
+    assert model.implicit_state_names == []
+    assert model.implicit_stress is False
 
 
-def test_hardening_type_af_is_reduced():
-    assert AFKinematic3D(E=210000.0, nu=0.3, sigma_y0=250.0, C_k=10000.0, gamma=100.0).hardening_type == "reduced"
+def test_af_has_no_implicit_states():
+    m = AFKinematic3D(E=210000.0, nu=0.3, sigma_y0=250.0, C_k=10000.0, gamma=100.0)
+    assert m.implicit_state_names == []
+    assert m.implicit_stress is False
 
 
-def test_hardening_type_augmented_af_is_augmented(implicit_model):
-    assert implicit_model.hardening_type == "augmented"
+def test_implicit_af_has_implicit_states(implicit_model):
+    assert implicit_model.implicit_state_names == ["alpha", "ep"]
+    assert implicit_model.implicit_stress is True
 
 
-def test_hardening_type_augmented_ps_is_augmented(implicit_ps_model):
-    assert implicit_ps_model.hardening_type == "augmented"
+def test_implicit_ps_has_implicit_states(implicit_ps_model):
+    assert implicit_ps_model.implicit_state_names == ["alpha", "ep"]
+    assert implicit_ps_model.implicit_stress is True
 
 
 # ---------------------------------------------------------------------------
@@ -272,8 +277,10 @@ def test_augmented_tangent_matches_reduced_3d(af_model, implicit_model, deps_vec
 # PLANE_STRAIN stress state
 # ---------------------------------------------------------------------------
 
-def test_hardening_type_augmented_pe_is_augmented():
-    assert _AFKinematicImplicitPE().hardening_type == "augmented"
+def test_implicit_pe_has_implicit_states():
+    m = _AFKinematicImplicitPE()
+    assert m.implicit_state_names == ["alpha", "ep"]
+    assert m.implicit_stress is True
 
 
 def test_augmented_yield_consistency_plane_strain():

--- a/tests/integration/test_ow_specific.py
+++ b/tests/integration/test_ow_specific.py
@@ -1,7 +1,7 @@
 """OW (Ohno-Wang) model-specific tests.
 
 These tests cover physics unique to the OW model:
-- hardening_type == "augmented" for all variants
+- implicit_state_names == ["alpha", "ep"] and implicit_stress == True for all variants
 - Backstress saturation: ‖α‖_vm → √(C_k / γ)  under monotonic loading
 - gamma=0 limit gives physically correct OW-to-Prager reduction
 - OW approaches AF for small plastic strains (near linear regime)
@@ -18,19 +18,25 @@ from manforge.simulation.integrator import PythonIntegrator
 
 
 # ---------------------------------------------------------------------------
-# hardening_type detection
+# API detection: all OW states are implicit, σ included in NR
 # ---------------------------------------------------------------------------
 
-def test_hardening_type_ow3d():
-    assert OWKinematic3D(E=210000.0, nu=0.3, sigma_y0=250.0, C_k=10000.0, gamma=1.0).hardening_type == "augmented"
+def test_implicit_state_names_ow3d():
+    m = OWKinematic3D(E=210000.0, nu=0.3, sigma_y0=250.0, C_k=10000.0, gamma=1.0)
+    assert m.implicit_state_names == ["alpha", "ep"]
+    assert m.implicit_stress is True
 
 
-def test_hardening_type_owps():
-    assert OWKinematicPS(E=210000.0, nu=0.3, sigma_y0=250.0, C_k=10000.0, gamma=1.0).hardening_type == "augmented"
+def test_implicit_state_names_owps():
+    m = OWKinematicPS(E=210000.0, nu=0.3, sigma_y0=250.0, C_k=10000.0, gamma=1.0)
+    assert m.implicit_state_names == ["alpha", "ep"]
+    assert m.implicit_stress is True
 
 
-def test_hardening_type_ow1d():
-    assert OWKinematic1D(E=210000.0, nu=0.3, sigma_y0=250.0, C_k=10000.0, gamma=1.0).hardening_type == "augmented"
+def test_implicit_state_names_ow1d():
+    m = OWKinematic1D(E=210000.0, nu=0.3, sigma_y0=250.0, C_k=10000.0, gamma=1.0)
+    assert m.implicit_state_names == ["alpha", "ep"]
+    assert m.implicit_stress is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_partial_implicit.py
+++ b/tests/integration/test_partial_implicit.py
@@ -1,0 +1,257 @@
+"""Tests for partial-implicit state declarations.
+
+Validates that mixing explicit and implicit state variables works correctly:
+- A model with only some states in implicit_state_names converges to the
+  same solution as the fully-explicit or fully-implicit counterpart.
+- implicit_stress=False (σ eliminated from NR) converges to the same
+  solution as implicit_stress=True (σ as independent NR unknown).
+
+Uses AF kinematic hardening as the reference because its state_residual has
+a known closed-form solution, so all three paths must agree at convergence.
+"""
+
+import pytest
+import numpy as np
+import autograd.numpy as anp
+
+from manforge.models.af_kinematic import AFKinematic3D
+from manforge.simulation.integrator import PythonIntegrator
+from manforge.verification.fd_check import check_tangent
+
+
+# ---------------------------------------------------------------------------
+# Partial-implicit model: alpha is implicit, ep is explicit
+# ---------------------------------------------------------------------------
+
+class _AFAlphaImplicit(AFKinematic3D):
+    """AF 3D with only alpha declared as an implicit state (ep remains explicit).
+
+    update_state returns only the explicit key (ep).
+    state_residual returns only the implicit key (alpha).
+    """
+
+    implicit_state_names = ["alpha"]
+    implicit_stress = False
+
+    def update_state(self, dlambda, stress, state_n):
+        return {"ep": state_n["ep"] + dlambda}
+
+    def state_residual(self, state_new, dlambda, stress, state_n):
+        alpha_n = state_n["alpha"]
+        xi = stress - alpha_n
+        s_xi = self._dev(xi)
+        vm_safe = self._vonmises(xi)
+        n_hat = s_xi / vm_safe
+        scale = 1.0 + self.gamma * dlambda
+        R_alpha = state_new["alpha"] * scale - alpha_n - self.C_k * dlambda * n_hat
+        return {"alpha": R_alpha}
+
+
+# ---------------------------------------------------------------------------
+# Partial-implicit with implicit_stress=True: α implicit, ep explicit, σ in NR
+# ---------------------------------------------------------------------------
+
+class _AFAlphaImplicitStress(AFKinematic3D):
+    """AF 3D with alpha implicit and σ as an independent NR unknown."""
+
+    implicit_state_names = ["alpha"]
+    implicit_stress = True
+
+    def update_state(self, dlambda, stress, state_n):
+        return {"ep": state_n["ep"] + dlambda}
+
+    def state_residual(self, state_new, dlambda, stress, state_n):
+        alpha_n = state_n["alpha"]
+        xi = stress - alpha_n
+        s_xi = self._dev(xi)
+        vm_safe = self._vonmises(xi)
+        n_hat = s_xi / vm_safe
+        scale = 1.0 + self.gamma * dlambda
+        R_alpha = state_new["alpha"] * scale - alpha_n - self.C_k * dlambda * n_hat
+        return {"alpha": R_alpha}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_PARAMS = dict(E=210000.0, nu=0.3, sigma_y0=250.0, C_k=10000.0, gamma=100.0)
+
+
+@pytest.fixture
+def explicit_model():
+    return AFKinematic3D(**_PARAMS)
+
+
+@pytest.fixture
+def partial_model():
+    return _AFAlphaImplicit(**_PARAMS)
+
+
+@pytest.fixture
+def partial_stress_model():
+    return _AFAlphaImplicitStress(**_PARAMS)
+
+
+# ---------------------------------------------------------------------------
+# API checks
+# ---------------------------------------------------------------------------
+
+def test_partial_implicit_api():
+    m = _AFAlphaImplicit(**_PARAMS)
+    assert m.implicit_state_names == ["alpha"]
+    assert m.implicit_stress is False
+
+
+def test_partial_implicit_stress_api():
+    m = _AFAlphaImplicitStress(**_PARAMS)
+    assert m.implicit_state_names == ["alpha"]
+    assert m.implicit_stress is True
+
+
+# ---------------------------------------------------------------------------
+# Stress and state match between all three paths
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("deps_vec", [
+    [2e-3, 0.0, 0.0, 0.0, 0.0, 0.0],
+    [2e-3, -1e-3, -1e-3, 0.0, 0.0, 0.0],
+    [0.0, 0.0, 0.0, 2e-3, 0.0, 0.0],
+])
+def test_partial_implicit_stress_matches_explicit(explicit_model, partial_model, deps_vec):
+    """Partial-implicit path must produce the same stress as the fully-explicit path."""
+    deps = anp.array(deps_vec)
+    stress0 = anp.zeros(6)
+    state0 = explicit_model.initial_state()
+
+    stress_exp = PythonIntegrator(explicit_model).stress_update(deps, stress0, state0).stress
+    stress_imp = PythonIntegrator(partial_model).stress_update(deps, stress0, state0).stress
+
+    np.testing.assert_allclose(
+        np.array(stress_imp), np.array(stress_exp), atol=1e-7,
+        err_msg=f"Partial-implicit stress differs from explicit for deps={deps_vec}"
+    )
+
+
+@pytest.mark.parametrize("deps_vec", [
+    [2e-3, 0.0, 0.0, 0.0, 0.0, 0.0],
+    [2e-3, -1e-3, -1e-3, 0.0, 0.0, 0.0],
+    [0.0, 0.0, 0.0, 2e-3, 0.0, 0.0],
+])
+def test_partial_implicit_state_matches_explicit(explicit_model, partial_model, deps_vec):
+    """Partial-implicit state (alpha, ep) must match the fully-explicit path."""
+    deps = anp.array(deps_vec)
+    stress0 = anp.zeros(6)
+    state0 = explicit_model.initial_state()
+
+    state_exp = PythonIntegrator(explicit_model).stress_update(deps, stress0, state0).state
+    state_imp = PythonIntegrator(partial_model).stress_update(deps, stress0, state0).state
+
+    np.testing.assert_allclose(
+        np.array(state_imp["alpha"]), np.array(state_exp["alpha"]), atol=1e-7,
+    )
+    np.testing.assert_allclose(float(state_imp["ep"]), float(state_exp["ep"]), atol=1e-10)
+
+
+@pytest.mark.parametrize("deps_vec", [
+    [2e-3, 0.0, 0.0, 0.0, 0.0, 0.0],
+    [2e-3, -1e-3, -1e-3, 0.0, 0.0, 0.0],
+])
+def test_implicit_stress_flag_matches_no_flag(partial_model, partial_stress_model, deps_vec):
+    """implicit_stress=True must converge to the same result as implicit_stress=False."""
+    deps = anp.array(deps_vec)
+    stress0 = anp.zeros(6)
+    state0 = partial_model.initial_state()
+
+    r_no_flag = PythonIntegrator(partial_model).stress_update(deps, stress0, state0)
+    r_flag = PythonIntegrator(partial_stress_model).stress_update(deps, stress0, state0)
+
+    np.testing.assert_allclose(
+        np.array(r_flag.stress), np.array(r_no_flag.stress), atol=1e-7,
+        err_msg=f"implicit_stress=True stress differs for deps={deps_vec}"
+    )
+    np.testing.assert_allclose(
+        np.array(r_flag.state["alpha"]), np.array(r_no_flag.state["alpha"]), atol=1e-7,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Yield surface consistency
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("deps_vec", [
+    [2e-3, 0.0, 0.0, 0.0, 0.0, 0.0],
+    [0.0, 0.0, 0.0, 2e-3, 0.0, 0.0],
+])
+def test_partial_implicit_yield_consistency(partial_model, deps_vec):
+    """After a plastic step, stress must lie on the yield surface."""
+    state0 = partial_model.initial_state()
+    deps = anp.array(deps_vec)
+
+    _r = PythonIntegrator(partial_model).stress_update(deps, anp.zeros(6), state0)
+    f = partial_model.yield_function(_r.stress, _r.state)
+    assert abs(float(f)) < 1e-8, f"Yield not satisfied: f = {float(f):.3e}"
+
+
+# ---------------------------------------------------------------------------
+# FD tangent check
+# ---------------------------------------------------------------------------
+
+@pytest.mark.slow
+@pytest.mark.parametrize("deps_vec", [
+    [2e-3, 0.0, 0.0, 0.0, 0.0, 0.0],
+    [0.0, 0.0, 0.0, 2e-3, 0.0, 0.0],
+])
+def test_partial_implicit_fd_tangent(partial_model, deps_vec):
+    """Consistent tangent must match FD for the partial-implicit model."""
+    state0 = partial_model.initial_state()
+    result = check_tangent(
+        PythonIntegrator(partial_model),
+        anp.zeros(6),
+        state0,
+        anp.array(deps_vec),
+    )
+    assert result.passed, (
+        f"FD tangent check failed: max_rel_err = {result.max_rel_err:.3e}"
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("deps_vec", [
+    [2e-3, 0.0, 0.0, 0.0, 0.0, 0.0],
+])
+def test_partial_implicit_stress_fd_tangent(partial_stress_model, deps_vec):
+    """Consistent tangent must match FD for partial-implicit with implicit_stress=True."""
+    state0 = partial_stress_model.initial_state()
+    result = check_tangent(
+        PythonIntegrator(partial_stress_model),
+        anp.zeros(6),
+        state0,
+        anp.array(deps_vec),
+    )
+    assert result.passed, (
+        f"FD tangent check failed (implicit_stress): max_rel_err = {result.max_rel_err:.3e}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tangent agreement between paths
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("deps_vec", [
+    [2e-3, 0.0, 0.0, 0.0, 0.0, 0.0],
+    [2e-3, -1e-3, -1e-3, 0.0, 0.0, 0.0],
+])
+def test_partial_implicit_tangent_matches_explicit(explicit_model, partial_model, deps_vec):
+    """Consistent tangent from partial-implicit path must match explicit path."""
+    deps = anp.array(deps_vec)
+    stress0 = anp.zeros(6)
+    state0 = explicit_model.initial_state()
+
+    ddsdde_exp = PythonIntegrator(explicit_model).stress_update(deps, stress0, state0).ddsdde
+    ddsdde_imp = PythonIntegrator(partial_model).stress_update(deps, stress0, state0).ddsdde
+
+    np.testing.assert_allclose(
+        np.array(ddsdde_imp), np.array(ddsdde_exp), atol=1e-6,
+        err_msg=f"Partial-implicit tangent differs from explicit for deps={deps_vec}"
+    )

--- a/tests/unit/test_material_bases.py
+++ b/tests/unit/test_material_bases.py
@@ -510,12 +510,13 @@ def test_1d_I_dev_projects_to_deviatoric():
 # __init_subclass__ validation
 # ---------------------------------------------------------------------------
 
-def test_reduced_without_update_state_raises():
-    """Reduced model that does not implement update_state must raise TypeError."""
+def test_explicit_state_without_update_state_raises():
+    """Model with explicit states (implicit_state_names=[]) must implement update_state."""
     with pytest.raises(TypeError, match="update_state"):
         class Bad(MaterialModel3D):
             param_names = []
-            state_names = []
+            state_names = ["ep"]
+            implicit_state_names = []
 
             def elastic_stiffness(self, state=None):
                 pass
@@ -524,9 +525,24 @@ def test_reduced_without_update_state_raises():
                 pass
 
 
-def test_augmented_without_state_residual_raises():
-    """Augmented model that does not implement state_residual must raise TypeError."""
+def test_implicit_state_without_state_residual_raises():
+    """Model with implicit states must implement state_residual."""
     with pytest.raises(TypeError, match="state_residual"):
+        class Bad(MaterialModel3D):
+            param_names = []
+            state_names = ["alpha"]
+            implicit_state_names = ["alpha"]
+
+            def elastic_stiffness(self, state=None):
+                pass
+
+            def yield_function(self, stress, state):
+                pass
+
+
+def test_hardening_type_attribute_raises():
+    """Declaring hardening_type must raise TypeError with migration hint."""
+    with pytest.raises(TypeError, match="hardening_type has been removed"):
         class Bad(MaterialModel3D):
             hardening_type = "augmented"
             param_names = []
@@ -538,14 +554,17 @@ def test_augmented_without_state_residual_raises():
             def yield_function(self, stress, state):
                 pass
 
+            def state_residual(self, state_new, dlambda, stress, state_n):
+                return {}
 
-def test_invalid_hardening_type_raises():
-    """Unknown hardening_type value must raise TypeError."""
-    with pytest.raises(TypeError, match="hardening_type"):
+
+def test_hardening_type_reduced_hint():
+    """hardening_type='reduced' gives hint to remove the attribute."""
+    with pytest.raises(TypeError, match="implicit_state_names=\\[\\] is the default"):
         class Bad(MaterialModel3D):
-            hardening_type = "mixed"
+            hardening_type = "reduced"
             param_names = []
-            state_names = []
+            state_names = ["ep"]
 
             def elastic_stiffness(self, state=None):
                 pass
@@ -554,29 +573,82 @@ def test_invalid_hardening_type_raises():
                 pass
 
             def update_state(self, dlambda, stress, state):
-                return {}
+                return {"ep": state["ep"] + dlambda}
 
 
-def test_augmented_with_both_methods_allowed():
-    """Augmented model may optionally define update_state as well."""
-    class OKImplicit(MaterialModel3D):
-        hardening_type = "augmented"
+def test_implicit_state_names_not_in_state_names_raises():
+    """implicit_state_names containing unknown keys must raise TypeError."""
+    with pytest.raises(TypeError, match="not in state_names"):
+        class Bad(MaterialModel3D):
+            param_names = []
+            state_names = ["ep"]
+            implicit_state_names = ["alpha"]  # "alpha" not in state_names
+
+            def elastic_stiffness(self, state=None):
+                pass
+
+            def yield_function(self, stress, state):
+                pass
+
+            def state_residual(self, state_new, dlambda, stress, state_n):
+                return {"alpha": anp.array(0.0)}
+
+
+def test_mixed_implicit_explicit_requires_both_methods():
+    """Partial implicit (some explicit, some implicit) requires both methods."""
+    class OK(MaterialModel3D):
         param_names = []
-        state_names = []
+        state_names = ["alpha", "ep"]
+        implicit_state_names = ["alpha"]  # ep is explicit
 
-        def elastic_stiffness(self):
+        def elastic_stiffness(self, state=None):
             pass
 
         def yield_function(self, stress, state):
             pass
 
         def update_state(self, dlambda, stress, state):
-            return {}
+            return {"ep": state["ep"] + dlambda}
 
         def state_residual(self, state_new, dlambda, stress, state_n):
-            return {}
+            return {"alpha": state_new["alpha"] - state_n["alpha"]}
 
-    assert OKImplicit().hardening_type == "augmented"
+    assert OK.implicit_state_names == ["alpha"]
+    assert OK.implicit_stress is False
+
+
+def test_all_implicit_states_no_update_state_needed():
+    """Model with all states implicit does not need update_state."""
+    class OKImplicit(MaterialModel3D):
+        param_names = []
+        state_names = ["alpha", "ep"]
+        implicit_state_names = ["alpha", "ep"]
+
+        def elastic_stiffness(self, state=None):
+            pass
+
+        def yield_function(self, stress, state):
+            pass
+
+        def state_residual(self, state_new, dlambda, stress, state_n):
+            return {"alpha": anp.array(0.0), "ep": anp.array(0.0)}
+
+    assert set(OKImplicit.implicit_state_names) == {"alpha", "ep"}
+
+
+def test_no_state_names_no_methods_needed():
+    """Model with empty state_names needs neither update_state nor state_residual."""
+    class OKStateless(MaterialModel3D):
+        param_names = []
+        state_names = []
+
+        def elastic_stiffness(self, state=None):
+            pass
+
+        def yield_function(self, stress, state):
+            pass
+
+    assert OKStateless.implicit_state_names == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `MaterialModel.hardening_type: "reduced" | "augmented"` を廃止し、NR 未知数集合をユーザーが state ごとに宣言できる API に置き換え
  - `implicit_state_names: list[str] = []` — NR 未知数に昇格する state 名のリスト
  - `implicit_stress: bool = False` — σ を NR 未知数に含めるかどうか
- **NR フェーズとタンジェントフェーズを分離**: NR では `implicit_stress` に従って σ を消去 or 独立扱い; タンジェントでは常に σ を含む線形系を使用 (DDSDDE の正確性は不変)
- 部分 implicit (一部 state のみ陰) が自然に表現可能になった

## 主な変更

| ファイル | 変更内容 |
|---|---|
| `core/material.py` | `hardening_type` 削除、`implicit_state_names` / `implicit_stress` 追加、`__init_subclass__` バリデーション刷新 |
| `core/residual.py` | `make_reduced_residual` / `make_augmented_residual` → `make_nr_residual` / `make_tangent_residual` に統合 |
| `core/solver.py` | `_reduced_nr` / `_augmented_nr` → `_numerical_newton` 一本化 |
| `core/tangent.py` | `augmented_consistent_tangent` / `_select_tangent` を削除し単一関数に統合 |
| `core/jacobian.py` | reduced/augmented 分岐を削除 |
| `models/ow_kinematic.py` | `hardening_type="augmented"` → `implicit_state_names=state_names, implicit_stress=True` |
| `tests/integration/test_partial_implicit.py` | **新規**: 部分 implicit・`implicit_stress` フラグの一致検証・FD タンジェントチェック |

## Test plan

- [x] `make test` — 440 passed (fast suite)
- [x] `make test-slow` — 37 passed (FD tangent, backstress saturation 含む)
- [x] `make test-fortran` — 4 failures は main ブランチ起点で既存 (本 PR の変更と無関係)
- [x] 新規 `test_partial_implicit.py` — 17 passed (partial implicit の全ケース)

🤖 Generated with [Claude Code](https://claude.com/claude-code)