### PR TITLE
refactor: State.__getattr__ を削除しドット記法を廃止 (#50)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ class MyModel(MaterialModel3D):
 
 `__init_subclass__` derives `cls.state_names`, `cls.implicit_state_names`, and `cls.state_fields` from the MRO. Subclass can override a parent field (e.g. `Explicit` → `Implicit`) by re-declaring it.
 
-User methods are unified on `State` arguments — stress is accessed via `state["stress"]` (or `state.stress`) like any other state:
+User methods are unified on `State` arguments — stress is accessed via `state["stress"]` like any other state:
 
 - `yield_function(self, state)` → scalar (≤0 = elastic). **Must be implemented.** Old 2-arg signature `yield_function(self, stress, state)` raises `TypeError`.
 - `update_state(self, dlambda, state_n, state_trial)` → `list[StateUpdate]` with only the **explicit** state keys (excluding stress, unless user declares `stress = Explicit` and wants custom update). Required whenever any non-stress state is `Explicit`. Old signature `update_state(self, dlambda, stress, state)` raises `TypeError`.
@@ -150,7 +150,7 @@ For 3D solid elements, stress/strain vectors are 6-component: `[11, 22, 33, 12, 
 
 ### State variables
 
-State is `dict[str, anp.ndarray]` at the framework boundary (solver inputs/outputs, `ReturnMappingResult.state`, driver results). Inside `update_state` / `state_residual` the framework may also pass a `State` dict-wrapper (from `manforge.core.state`) that provides attribute-style access (`state.alpha` equivalent to `state["alpha"]`) while preserving the dict internally for autograd compatibility. `State` is immutable — assignment raises `AttributeError`.
+State is `dict[str, anp.ndarray]` at the framework boundary (solver inputs/outputs, `ReturnMappingResult.state`, driver results). Inside `update_state` / `state_residual` the framework passes a `State` dict-wrapper (from `manforge.core.state`) that preserves declaration-order field metadata while supporting bracket access (`state["alpha"]`) with autograd compatibility. Use bracket notation consistently — dot access (`state.alpha`) is not supported.
 
 ### Fortran UMAT
 

--- a/src/manforge/core/material.py
+++ b/src/manforge/core/material.py
@@ -33,9 +33,10 @@ class MaterialModel(ABC):
     Declare ``stress = Implicit(shape=NTENS)`` to include σ as an NR unknown
     (replaces the removed ``implicit_stress = True`` flag).
 
-    User methods receive a ``State`` object for all state arguments (including
-    ``state.stress``).  The ``stress`` argument has been removed from
-    ``yield_function``, ``update_state``, and ``state_residual``.
+    User methods receive a ``State`` dict-wrapper for all state arguments.
+    Access state variables with bracket notation: ``state["stress"]``.
+    The ``stress`` argument has been removed from ``yield_function``,
+    ``update_state``, and ``state_residual``.
 
     Required methods depend on which states are explicit vs implicit:
 
@@ -166,9 +167,9 @@ class MaterialModel(ABC):
             if len(params) >= 3 and params[1] == "stress" and params[2] == "state":
                 raise TypeError(
                     f"{cls.__name__}: yield_function(self, stress, state) is no longer accepted. "
-                    "Update to yield_function(self, state) and access stress via state.stress:\n"
+                    "Update to yield_function(self, state) and access stress via state[\"stress\"]:\n"
                     "    def yield_function(self, state):\n"
-                    "        xi = state.stress - state.alpha\n"
+                    "        xi = state[\"stress\"] - state[\"alpha\"]\n"
                     "        return self._vonmises(xi) - self.sigma_y0"
                 )
         # Reject old update_state(self, dlambda, stress, state) signature.
@@ -180,7 +181,7 @@ class MaterialModel(ABC):
                     f"{cls.__name__}: update_state(self, dlambda, stress, state) is no longer accepted. "
                     "Update to update_state(self, dlambda, state_n, state_trial):\n"
                     "    def update_state(self, dlambda, state_n, state_trial):\n"
-                    "        stress = state_trial.stress\n"
+                    "        stress = state_trial[\"stress\"]\n"
                     "        ..."
                 )
         # Reject old state_residual(self, state_new, dlambda, stress, state_n) signature.
@@ -193,7 +194,7 @@ class MaterialModel(ABC):
                     "is no longer accepted. Update to state_residual(self, state_new, dlambda, "
                     "state_n, state_trial):\n"
                     "    def state_residual(self, state_new, dlambda, state_n, state_trial):\n"
-                    "        stress = state_new.stress\n"
+                    "        stress = state_new[\"stress\"]\n"
                     "        ..."
                 )
         # Collect StateField descriptors from MRO and derive state_names / implicit_state_names.
@@ -275,7 +276,7 @@ class MaterialModel(ABC):
         Parameters
         ----------
         state : State or dict
-            Current state including ``state.stress`` (Voigt notation) and all
+            Current state including ``state["stress"]`` (Voigt notation) and all
             internal state variables.
 
         Returns
@@ -306,7 +307,7 @@ class MaterialModel(ABC):
         state_n : State or dict
             State at the beginning of the increment.
         state_trial : State or dict
-            Trial state (``state_trial.stress`` is the elastic trial stress).
+            Trial state (``state_trial["stress"]`` is the elastic trial stress).
 
         Returns
         -------
@@ -347,7 +348,7 @@ class MaterialModel(ABC):
         state_n : State or dict
             State at the beginning of the increment.
         state_trial : State or dict
-            Trial state (``state_trial.stress`` is the elastic trial stress).
+            Trial state (``state_trial["stress"]`` is the elastic trial stress).
 
         Returns
         -------
@@ -493,8 +494,7 @@ class MaterialModel(ABC):
         dlambda : scalar
             Plastic multiplier increment Δλ.
         state_trial : State or dict
-            Trial state; ``state_trial["stress"]`` is the fixed elastic
-            predictor σ_trial.
+            Trial state; ``state_trial["stress"]`` is the fixed elastic predictor σ_trial.
 
         Returns
         -------
@@ -534,8 +534,7 @@ class MaterialModel(ABC):
         state_n : State or dict
             State at the beginning of the increment (unused by default).
         state_trial : State or dict
-            Trial state; ``state_trial["stress"]`` is the framework-pre-computed
-            associative σ iterate.
+            Trial state; ``state_trial["stress"]`` is the framework-pre-computed associative σ iterate.
 
         Returns
         -------

--- a/src/manforge/core/state.py
+++ b/src/manforge/core/state.py
@@ -21,7 +21,8 @@ by ``MaterialModel.__init_subclass__`` if the user does not declare it.  When
 declared as ``Implicit``, σ is included as an NR unknown.  The ``implicit_stress``
 flag has been removed — use ``stress = Implicit(shape=NTENS)`` instead.
 
-User methods receive and return ``State`` objects that include ``state.stress``.
+User methods receive state arguments as :class:`State` dict-wrappers.
+Access state variables with bracket notation: ``state["stress"]``, ``state["alpha"]``.
 
 Returning residuals / updates
 ------------------------------
@@ -39,8 +40,8 @@ or ``StateUpdate`` (explicit), giving a concise return idiom::
 The framework validates the returned list at the call boundary via
 ``_validate_state_items``.
 
-``State`` is a thin, immutable dict-wrapper with ``__getattr__`` access.
-It is created at ``make_state`` call boundaries so that autograd traces
+``State`` is a thin dict-wrapper that carries field-ordering metadata.
+It is created at ``_wrap_state`` call boundaries so that autograd traces
 through the raw dict values unchanged.
 """
 
@@ -326,15 +327,17 @@ def collect_state_fields(cls) -> dict[str, StateField]:
 # ---------------------------------------------------------------------------
 
 class State:
-    """Immutable dict-wrapper providing attribute-style access to state variables.
+    """Dict-wrapper carrying field-ordering metadata for state variables.
 
-    Wraps the internal ``dict[str, array]`` so that user code can write
-    ``state.alpha`` instead of ``state["alpha"]``.  The internal dict is
-    preserved unchanged, so autograd traces through the raw array values
-    without modification.
+    Wraps the internal ``dict[str, array]`` and preserves declaration-order
+    field names in ``_fields``.  The internal dict is preserved unchanged so
+    autograd traces through the raw array values without modification.
 
-    ``State`` objects are created at the ``make_state`` call boundary and
-    are never mutated.
+    Access state variables with bracket notation: ``state["stress"]``,
+    ``state["alpha"]``.  Attribute-style dot access is not supported.
+
+    ``State`` objects are created at ``_wrap_state`` call boundaries and
+    are never mutated by the framework.
     """
 
     __slots__ = ("_data", "_fields")
@@ -342,14 +345,6 @@ class State:
     def __init__(self, data: dict, fields: tuple):
         object.__setattr__(self, "_data", data)
         object.__setattr__(self, "_fields", fields)
-
-    def __getattr__(self, name: str):
-        try:
-            return self._data[name]
-        except KeyError:
-            raise AttributeError(
-                f"State has no field {name!r}. Available: {list(self._fields)}"
-            )
 
     def __getitem__(self, key: str):
         return self._data[key]
@@ -372,9 +367,6 @@ class State:
     def as_dict(self) -> dict:
         """Return the underlying dict (no copy — values are shared)."""
         return self._data
-
-    def __setattr__(self, name, value):
-        raise AttributeError("State is immutable")
 
     def __repr__(self):
         return f"State({self._data!r})"

--- a/src/manforge/models/af_kinematic.py
+++ b/src/manforge/models/af_kinematic.py
@@ -15,7 +15,7 @@ ep    : equivalent plastic strain (scalar, ≥ 0)
 
 Yield function
 --------------
-f(state) = σ_vm(state.stress − state.alpha) − σ_y0
+f(state) = σ_vm(state["stress"] − state["alpha"]) − σ_y0
 
 where σ_vm is the von Mises equivalent stress of the *relative* stress.
 

--- a/src/manforge/models/j2_isotropic.py
+++ b/src/manforge/models/j2_isotropic.py
@@ -13,7 +13,7 @@ ep : equivalent plastic strain (scalar, ≥ 0)
 
 Yield function
 --------------
-f(state) = σ_vm(state.stress) - (σ_y0 + H * ep)
+f(state) = σ_vm(state["stress"]) - (σ_y0 + H * ep)
 
 where σ_vm is the von Mises equivalent stress.
 

--- a/src/manforge/models/ow_kinematic.py
+++ b/src/manforge/models/ow_kinematic.py
@@ -21,7 +21,7 @@ ep    : equivalent plastic strain (scalar, ≥ 0)
 
 Yield function
 --------------
-f(state) = σ_vm(state.stress − state.alpha) − σ_y0
+f(state) = σ_vm(state["stress"] − state["alpha"]) − σ_y0
 
 Ohno-Wang backstress evolution
 -------------------------------

--- a/tests/unit/test_state_fields.py
+++ b/tests/unit/test_state_fields.py
@@ -307,27 +307,10 @@ def test_validate_state_items_extra_raises():
 # State wrapper
 # ---------------------------------------------------------------------------
 
-def test_state_getattr():
-    s = State({"alpha": np.zeros(6), "ep": np.array(0.0)}, ("alpha", "ep"))
-    assert np.allclose(s.alpha, np.zeros(6))
-    assert float(s.ep) == 0.0
-
-
 def test_state_getitem():
-    s = State({"ep": np.array(1.0)}, ("ep",))
+    s = State({"alpha": np.zeros(6), "ep": np.array(1.0)}, ("alpha", "ep"))
+    assert np.allclose(s["alpha"], np.zeros(6))
     assert float(s["ep"]) == 1.0
-
-
-def test_state_getattr_missing_raises_attribute_error():
-    s = State({"ep": np.array(0.0)}, ("ep",))
-    with pytest.raises(AttributeError, match="no field 'alpha'"):
-        _ = s.alpha
-
-
-def test_state_is_immutable():
-    s = State({"ep": np.array(0.0)}, ("ep",))
-    with pytest.raises(AttributeError):
-        s.ep = np.array(1.0)
 
 
 def test_state_as_dict_returns_same_object():
@@ -351,7 +334,7 @@ def test_state_identity_no_copy():
     arr = np.zeros(6)
     data = {"alpha": arr}
     s = State(data, ("alpha",))
-    assert s.alpha is arr
+    assert s["alpha"] is arr
 
 
 # ---------------------------------------------------------------------------
@@ -389,8 +372,8 @@ def test_make_state_all_keys_required():
     model = _AlphaEP(SOLID_3D)
     s = model.make_state(stress=np.zeros(6), alpha=np.zeros(6), ep=np.array(0.0))
     assert isinstance(s, State)
-    assert np.allclose(s.alpha, np.zeros(6))
-    assert np.allclose(s.stress, np.zeros(6))
+    assert np.allclose(s["alpha"], np.zeros(6))
+    assert np.allclose(s["stress"], np.zeros(6))
 
 
 def test_make_state_missing_raises():


### PR DESCRIPTION
## Summary

- **`State.__getattr__` / `__setattr__` を削除**: `state.alpha` 形式のドット記法を廃止。`state["alpha"]` ブラケット記法のみをサポート。
- **一貫性の回復**: ドット記法は user method 境界 (`yield_function` / `update_state` / `state_residual`) 内でのみ有効だった一方、`ReturnMappingResult.state`, `initial_state()`, driver の持ち回り state, `user_defined_*` 引数など framework の大半は plain dict のまま。両記法が混在する状態を解消。
- **安全性の分離確認**: 返却の安全性は `StateField.__call__` + `StateResidual`/`StateUpdate` + `_validate_state_items` で独立に担保されており、ドット化は安全性向上に寄与していなかった。
- **`State` 型は存続**: `_wrap_state` / `_state_with_stress` / `isinstance(state, State)` 分岐を保持。`_fields` による宣言順メタデータ保持・`make_state` のキー検証は引き続き有効。

## Changes

| ファイル | 変更内容 |
|---|---|
| `src/manforge/core/state.py` | `__getattr__` / `__setattr__` 削除、module docstring / `State` class docstring 更新 |
| `src/manforge/core/material.py` | migration error hint と docstring のドット例示を bracket に統一 |
| `src/manforge/models/j2_isotropic.py` | module docstring 物理式 `state.stress` → `state["stress"]` |
| `src/manforge/models/af_kinematic.py` | 同上 `state.stress − state.alpha` → bracket |
| `src/manforge/models/ow_kinematic.py` | 同上 |
| `CLAUDE.md` | State 説明を「ドット非サポート」に書き換え |
| `tests/unit/test_state_fields.py` | `test_state_getattr` / `test_state_getattr_missing_raises_attribute_error` / `test_state_is_immutable` 削除、他 2 件を bracket 記法に書き換え |

## Test plan

- [x] `make test` — 501 tests pass (504 − 3 削除テスト)
- [x] `grep -rn 'state\.\(stress\|alpha\|ep\)' src/ tests/ CLAUDE.md` — 0 hits (引用説明文のみ)
- [x] `grep -n '__getattr__\|__setattr__' src/manforge/core/state.py` — `object.__setattr__` (slot 初期化) のみ残存

🤖 Generated with [Claude Code](https://claude.com/claude-code)