### PR TITLE
feat: state_residual に self.dlambda(R) で Δλ 行残差を上書きできる API を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ src/manforge/
 | 一部 state が `Implicit` (σ は Explicit) | `yield_function`, `update_state`, `state_residual` の両方 | `[Δλ, q_implicit]` |
 | 全 state が `Implicit`、`stress = Implicit` | `yield_function`, `state_residual` | `[σ, Δλ, q]` |
 
-`update_state` は **陽更新 state のみ** のキーを返す。`state_residual` は **陰 state のみ** のキーを返し、`self.stress(R_stress)` を含めると σ 残差をカスタム指定できる。`hardening_type` と `implicit_stress` は廃止 (宣言すると `TypeError`)。全メソッドは `state["stress"]` 経由で応力にアクセスする (旧 2 引数シグネチャは `TypeError`)。
+`update_state` は **陽更新 state のみ** のキーを返す。`state_residual` は **陰 state のみ** のキーを返し、`self.stress(R_stress)` を含めると σ 残差をカスタム指定できる。さらに `self.dlambda(R_dl)` を含めると Δλ 行の残差を差し替えられる (粘塑性 Perzyna 型など)。省略時は `yield_function(state) = 0` がデフォルト。`hardening_type` と `implicit_stress` は廃止 (宣言すると `TypeError`)。全メソッドは `state["stress"]` 経由で応力にアクセスする (旧 2 引数シグネチャは `TypeError`)。
 
 `elastic_stiffness(self, state=None)` は `MaterialModel3D` / `MaterialModelPS` / `MaterialModel1D` 基底クラスに等方性デフォルト実装が用意されており、`self.E` と `self.nu` を持つモデルなら実装不要。状態依存の弾性剛性 (損傷塑性など) を持つモデルのみ override する。
 
@@ -359,6 +359,21 @@ class MyImplicitModel(MaterialModel3D):
 ```
 
 参照実装: `src/manforge/models/ow_kinematic.py`
+
+#### Δλ 行残差のカスタム指定 (粘塑性・非標準 consistency condition)
+
+`state_residual` に `self.dlambda(R_dl)` を含めると NR 残差の Δλ 行を差し替えられる。省略時は `yield_function(state) = 0` (標準弾塑性)。
+
+```python
+def state_residual(self, state_new, dlambda, state_n, state_trial):
+    # Perzyna 型粘塑性: f − η·Δλ/Δt = 0
+    f = self.yield_function(state_new)
+    R_dl = f - self.eta * dlambda / self.dt
+    R_alpha = ...
+    return [self.dlambda(R_dl), self.alpha(R_alpha)]
+```
+
+`self.dlambda(R_dl)` は scalar-NR / vector NR / consistent tangent の全経路で機能する。`update_state` で使うと `TypeError`、リスト内に 2 個含めると `ValueError`。
 
 ### Kinematic / backstress (AF・OW の既製クラス)
 

--- a/src/manforge/core/__init__.py
+++ b/src/manforge/core/__init__.py
@@ -1,4 +1,4 @@
-from manforge.core.state import Implicit, Explicit, State, NTENS, StateResidual, StateUpdate
+from manforge.core.state import Implicit, Explicit, State, NTENS, StateResidual, StateUpdate, DlambdaResidual
 from manforge.core.stress_state import (
     StressState,
     SOLID_3D,
@@ -16,6 +16,7 @@ __all__ = [
     "NTENS",
     "StateResidual",
     "StateUpdate",
+    "DlambdaResidual",
     "StressState",
     "SOLID_3D",
     "PLANE_STRAIN",

--- a/src/manforge/core/material.py
+++ b/src/manforge/core/material.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 import autograd.numpy as anp
 
 from manforge.autodiff.operators import identity_voigt
-from manforge.core.state import StateField, State, collect_state_fields, _make, NTENS
+from manforge.core.state import StateField, State, collect_state_fields, _make, NTENS, DLAMBDA_FIELD
 from manforge.core.stress_state import SOLID_3D, PLANE_STRESS, UNIAXIAL_1D, StressState
 from manforge.utils.smooth import smooth_sqrt
 
@@ -77,6 +77,11 @@ class MaterialModel(ABC):
     state_fields: dict[str, StateField] = {}
     state_names: list[str] = []
     implicit_state_names: list[str] = []
+
+    # Framework-provided pseudo-field for the Δλ NR unknown.  Users can
+    # optionally return self.dlambda(R_dl) from state_residual to override
+    # the default R_dλ = yield_function(state).
+    dlambda = DLAMBDA_FIELD
 
     @property
     def params(self) -> dict:

--- a/src/manforge/core/residual.py
+++ b/src/manforge/core/residual.py
@@ -5,7 +5,8 @@ import autograd.numpy as anp
 import numpy as np
 
 from manforge.core.state import (
-    StateResidual, StateUpdate, State, _validate_state_items, _state_with_stress,
+    StateResidual, StateUpdate, DlambdaResidual, State,
+    _validate_state_items, _state_with_stress,
 )
 
 
@@ -127,6 +128,12 @@ def _call_update_state(model, dlambda, state_n_dict, state_trial_dict,
     expected_all = (expected_explicit_keys | {"stress"}) if require_stress else expected_explicit_keys
     if isinstance(returned, list):
         for item in returned:
+            if isinstance(item, DlambdaResidual):
+                raise TypeError(
+                    f"{model_name}.update_state: self.dlambda(...) is not allowed in "
+                    "update_state (Δλ has no explicit update rule). "
+                    "Use state_residual to override the Δλ residual instead."
+                )
             if not isinstance(item, StateUpdate):
                 raise TypeError(
                     f"{model_name}.update_state: every item must be StateUpdate, "
@@ -179,10 +186,18 @@ def _call_update_state(model, dlambda, state_n_dict, state_trial_dict,
 
 def _call_state_residual(model, state_new_dict, dlambda, state_n_dict, state_trial_dict,
                           expected_implicit_keys, model_name):
-    """Call model.state_residual(state_new, dlambda, state_n, state_trial) → dict.
+    """Call model.state_residual(state_new, dlambda, state_n, state_trial).
 
     *expected_implicit_keys* must NOT include "stress".  The returned dict
     MUST include "stress" when stress is Implicit so the framework can use it.
+
+    Returns
+    -------
+    tuple
+        ``(state_dict, r_dlambda_or_None)`` where *state_dict* maps implicit
+        field names to residual values and *r_dlambda_or_None* is the scalar
+        Δλ-row override if ``self.dlambda(R)`` was included in the list, else
+        ``None`` (framework falls back to ``model.yield_function(state)``).
     """
     state_new = _wrap_state(state_new_dict, model)
     state_n = _wrap_state(state_n_dict, model)
@@ -192,13 +207,26 @@ def _call_state_residual(model, state_new_dict, dlambda, state_n_dict, state_tri
     do_implicit_stress = stress_field.kind == "implicit"
     expected_all = (expected_implicit_keys | {"stress"}) if do_implicit_stress else expected_implicit_keys
     if isinstance(returned, list):
+        # Partition DlambdaResidual items from StateResidual items
+        state_items = []
+        dl_items = []
         for item in returned:
-            if not isinstance(item, StateResidual):
+            if isinstance(item, DlambdaResidual):
+                dl_items.append(item)
+            elif isinstance(item, StateResidual):
+                state_items.append(item)
+            else:
                 raise TypeError(
-                    f"{model_name}.state_residual: every item must be StateResidual, "
+                    f"{model_name}.state_residual: every item must be StateResidual "
+                    f"or DlambdaResidual (self.dlambda(R)), "
                     f"got {type(item).__name__}"
                 )
-        actual_keys = {item.name for item in returned}
+        if len(dl_items) > 1:
+            raise ValueError(
+                f"{model_name}.state_residual: duplicate self.dlambda(...) entries"
+            )
+        r_dl = dl_items[0].value if dl_items else None
+        actual_keys = {item.name for item in state_items}
         if actual_keys != expected_all:
             extra = actual_keys - expected_all
             missing = expected_all - actual_keys
@@ -216,7 +244,7 @@ def _call_state_residual(model, state_new_dict, dlambda, state_n_dict, state_tri
                 f"{model_name}.state_residual() returned wrong keys "
                 f"({'; '.join(parts)}). Expected: {sorted(expected_all)}"
             )
-        return {item.name: item.value for item in returned}
+        return {item.name: item.value for item in state_items}, r_dl
     if isinstance(returned, dict):
         actual_keys = set(returned.keys())
         if actual_keys != expected_all:
@@ -235,10 +263,11 @@ def _call_state_residual(model, state_new_dict, dlambda, state_n_dict, state_tri
                 f"{model_name}.state_residual() returned wrong keys "
                 f"({'; '.join(parts)}). Expected: {sorted(expected_all)}"
             )
-        return returned
+        return returned, None
     raise TypeError(
         f"{model_name}.state_residual must return a list of StateResidual "
-        f"(use `self.<field>(value)`) or a dict, got {type(returned).__name__}"
+        f"(use `self.<field>(value)`, optionally `self.dlambda(R)`) or a dict, "
+        f"got {type(returned).__name__}"
     )
 
 
@@ -270,10 +299,14 @@ def make_nr_residual(model, stress_trial, state_n):
         ``n_implicit`` (int), ``implicit_shapes`` (list).
     unflatten_implicit : callable(flat) -> dict
     """
+    from manforge.core.material import MaterialModel as _MaterialModel
     ntens = model.ntens
     stress_field = model.state_fields["stress"]
     do_implicit_stress = (stress_field.kind == "implicit")
     model_name = type(model).__name__
+    user_has_state_residual = (
+        type(model).state_residual is not _MaterialModel.state_residual
+    )
 
     # Keys excluding "stress"
     implicit_keys_non_stress = sorted([k for k in model.implicit_state_names if k != "stress"])
@@ -354,11 +387,12 @@ def make_nr_residual(model, stress_trial, state_n):
                 sig = sig_approx
 
         q_full_state = _wrap_state(q_full, model)
-        R_yield = model.yield_function(q_full_state)
 
-        parts = [anp.atleast_1d(R_yield)]
+        # Collect optional R_dl override and implicit-state residuals from state_residual
+        r_dl_override = None
+        R_state_dict = {}
 
-        if n_implicit > 0:
+        if user_has_state_residual:
             state_trial_for_residual = dict(state_n)
             if do_implicit_stress:
                 # When stress is Implicit, state_trial["stress"] must be the fixed
@@ -369,22 +403,27 @@ def make_nr_residual(model, stress_trial, state_n):
                 # When stress is Explicit, pass the current derived stress as the trial
                 # so that user's state_residual can access it (e.g. AF flow direction).
                 state_trial_for_residual["stress"] = q_full.get("stress", anp.array(stress_trial))
-            R_state_dict = _call_state_residual(
+            R_state_dict, r_dl_override = _call_state_residual(
                 model, q_full, dlambda, state_n, state_trial_for_residual,
                 set(implicit_keys_non_stress), model_name
             )
-            if do_implicit_stress:
-                # stress MUST be in R_state_dict (enforced by _call_state_residual)
-                parts.insert(0, R_state_dict["stress"])
-            R_state_non_stress = {k: v for k, v in R_state_dict.items() if k != "stress"}
-            if R_state_non_stress:
-                R_state_flat, _ = _flatten_state(R_state_non_stress)
-                parts.append(R_state_flat)
         elif do_implicit_stress:
             raise ValueError(
-                f"{model_name}: stress is Implicit but there are no implicit states "
-                "to call state_residual() on — this should not happen."
+                f"{model_name}: stress is Implicit but state_residual() is not implemented "
+                "— this should not happen."
             )
+
+        # Δλ row: user override if provided, else yield_function default
+        R_dl = r_dl_override if r_dl_override is not None else model.yield_function(q_full_state)
+        parts = [anp.atleast_1d(R_dl)]
+
+        if do_implicit_stress:
+            # stress MUST be in R_state_dict (enforced by _call_state_residual)
+            parts.insert(0, R_state_dict["stress"])
+        R_state_non_stress = {k: v for k, v in R_state_dict.items() if k != "stress"}
+        if R_state_non_stress:
+            R_state_flat, _ = _flatten_state(R_state_non_stress)
+            parts.append(R_state_flat)
 
         return anp.concatenate(parts)
 
@@ -404,6 +443,7 @@ def make_tangent_residual(model, stress_trial, state_n):
     n_implicit : int
     unflatten_implicit : callable(flat) -> dict
     """
+    from manforge.core.material import MaterialModel as _MaterialModel
     ntens = model.ntens
     stress_field = model.state_fields["stress"]
     do_implicit_stress = (stress_field.kind == "implicit")
@@ -413,6 +453,9 @@ def make_tangent_residual(model, stress_trial, state_n):
         if k != "stress" and k not in model.implicit_state_names
     )
     model_name = type(model).__name__
+    user_has_state_residual = (
+        type(model).state_residual is not _MaterialModel.state_residual
+    )
 
     implicit_state_n = {k: state_n[k] for k in implicit_keys_non_stress}
     _, implicit_shapes = _flatten_state(implicit_state_n)
@@ -445,9 +488,11 @@ def make_tangent_residual(model, stress_trial, state_n):
         q_full_state = _wrap_state(q_full, model)
         stress_trial_arr = anp.array(stress_trial)
 
-        R_yield = model.yield_function(q_full_state)
+        # Collect optional R_dl override and implicit-state residuals from state_residual
+        r_dl_override = None
+        R_state_dict = {}
 
-        if n_implicit > 0:
+        if user_has_state_residual:
             state_trial_for_residual = dict(state_n)
             if do_implicit_stress:
                 # When stress is Implicit, state_trial["stress"] must be the fixed elastic
@@ -458,22 +503,24 @@ def make_tangent_residual(model, stress_trial, state_n):
                 # When stress is Explicit, pass the tangent variable sig as the trial
                 # so that user's state_residual captures ∂R_state/∂σ correctly.
                 state_trial_for_residual["stress"] = sig
-            R_state_dict = _call_state_residual(
+            R_state_dict, r_dl_override = _call_state_residual(
                 model, q_full, dlambda, state_n, state_trial_for_residual,
                 set(implicit_keys_non_stress), model_name
             )
-            # stress MUST be in R_state_dict for Implicit stress (enforced by _call_state_residual)
-            R_stress = R_state_dict["stress"] if do_implicit_stress else (
-                model._default_stress_residual(sig, dlambda, q_full_state, stress_trial_arr)
-            )
-            R_state_non_stress = {k: v for k, v in R_state_dict.items() if k != "stress"}
-            parts = [R_stress, anp.atleast_1d(R_yield)]
-            if R_state_non_stress:
-                R_state_flat, _ = _flatten_state(R_state_non_stress)
-                parts.append(R_state_flat)
-        else:
-            R_stress = model._default_stress_residual(sig, dlambda, q_full_state, stress_trial_arr)
-            parts = [R_stress, anp.atleast_1d(R_yield)]
+
+        # Δλ row: user override if provided, else yield_function default
+        R_dl = r_dl_override if r_dl_override is not None else model.yield_function(q_full_state)
+
+        # Stress residual row
+        R_stress = R_state_dict["stress"] if do_implicit_stress else (
+            model._default_stress_residual(sig, dlambda, q_full_state, stress_trial_arr)
+        )
+
+        R_state_non_stress = {k: v for k, v in R_state_dict.items() if k != "stress"}
+        parts = [R_stress, anp.atleast_1d(R_dl)]
+        if R_state_non_stress:
+            R_state_flat, _ = _flatten_state(R_state_non_stress)
+            parts.append(R_state_flat)
 
         return anp.concatenate(parts)
 

--- a/src/manforge/core/solver.py
+++ b/src/manforge/core/solver.py
@@ -10,6 +10,7 @@ from manforge.core.residual import (
     _normalise_update,
     _wrap_state,
     _call_update_state,
+    _call_state_residual,
     _state_with_stress,
 )
 from manforge.core.state import _state_with_stress as _state_with_stress_fn
@@ -52,6 +53,7 @@ def _numerical_newton(model, stress_trial, state_n, max_iter, tol,
 
 def _scalar_nr(model, stress_trial, state_n, max_iter, tol, raise_on_nonconverged):
     """Scalar NR on Δλ (stress=Explicit, no implicit non-stress states)."""
+    from manforge.core.material import MaterialModel as _MaterialModel
     dlambda = anp.array(0.0)
     stress = anp.array(stress_trial)
     state_new = state_n
@@ -65,6 +67,22 @@ def _scalar_nr(model, stress_trial, state_n, max_iter, tol, raise_on_nonconverge
         k for k in model.state_names
         if k != "stress" and k not in model.implicit_state_names
     )
+    user_has_state_residual = (
+        type(model).state_residual is not _MaterialModel.state_residual
+    )
+
+    def _eval_R_dl(dl, state_new_dict):
+        """Return R_dl: user override if present, else yield_function."""
+        if user_has_state_residual:
+            # state_trial["stress"] = current stress for the Explicit case
+            trial_dict = dict(state_new_dict)
+            _, r_dl = _call_state_residual(
+                model, state_new_dict, dl, state_n, trial_dict,
+                set(), model_name  # no implicit non-stress keys in scalar-NR
+            )
+            if r_dl is not None:
+                return r_dl
+        return model.yield_function(_wrap_state(state_new_dict, model))
 
     for _iteration in range(max_iter):
         # Update explicit non-stress states
@@ -103,8 +121,7 @@ def _scalar_nr(model, stress_trial, state_n, max_iter, tol, raise_on_nonconverge
         else:
             state_new = {"stress": stress}
 
-        state_new_state = _wrap_state(state_new, model)
-        f = model.yield_function(state_new_state)
+        f = _eval_R_dl(dlambda, state_new)
         residual_history.append(float(np.abs(float(f))))
 
         if abs(float(f)) < tol:
@@ -127,7 +144,7 @@ def _scalar_nr(model, stress_trial, state_n, max_iter, tol, raise_on_nonconverge
             )(_stress)
             s_upd = anp.array(stress_trial) - dl * (model.elastic_stiffness(st_state) @ nn)
             st2 = {"stress": s_upd, **{k: v for k, v in st.items() if k != "stress"}}
-            return model.yield_function(_wrap_state(st2, model))
+            return _eval_R_dl(dl, st2)
 
         dfddl = autograd.grad(_f_residual)(dlambda)
         dlambda = dlambda - f / dfddl

--- a/src/manforge/core/state.py
+++ b/src/manforge/core/state.py
@@ -225,6 +225,52 @@ class StateUpdate:
 
 
 # ---------------------------------------------------------------------------
+# DlambdaResidual / DlambdaField — optional Δλ row override
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class DlambdaResidual:
+    """Optional override for the Δλ row of the NR residual.
+
+    Produced by ``self.dlambda(R)`` inside ``state_residual``.  If present in
+    the returned list, the framework uses this as the Δλ row instead of the
+    default ``model.yield_function(state) = 0``.
+
+    Use this to implement viscoplasticity (Perzyna), non-standard consistency
+    conditions, or any model where the equation determining Δλ differs from the
+    yield surface.
+    """
+
+    value: Any
+
+
+class DlambdaField:
+    """Framework-provided pseudo-field for the Δλ NR unknown.
+
+    Not a :class:`StateField` — does not appear in ``state_fields`` /
+    ``state_names`` / ``implicit_state_names``.  A single stateless singleton
+    ``DLAMBDA_FIELD`` is attached to :class:`~manforge.core.material.MaterialModel`
+    as the class attribute ``dlambda`` so that users can write
+    ``self.dlambda(R_dl)`` inside ``state_residual``.
+
+    Example::
+
+        def state_residual(self, state_new, dlambda, state_n, state_trial):
+            f = self.yield_function(state_new)
+            R_dl = f - self.eta * dlambda / self.dt   # Perzyna
+            return [self.dlambda(R_dl), self.alpha(R_alpha)]
+    """
+
+    __slots__ = ()
+
+    def __call__(self, value) -> DlambdaResidual:
+        return DlambdaResidual(value=value)
+
+
+DLAMBDA_FIELD = DlambdaField()
+
+
+# ---------------------------------------------------------------------------
 # Boundary validator
 # ---------------------------------------------------------------------------
 

--- a/tests/integration/test_dlambda_override.py
+++ b/tests/integration/test_dlambda_override.py
@@ -1,0 +1,307 @@
+"""Integration tests for self.dlambda(R) — user-overridable Δλ residual.
+
+Covers three paths:
+1. Scalar-NR with dlambda override (stress=Explicit, no Implicit state)
+2. Vector-NR with dlambda override (alpha=Implicit)
+3. Vector-NR fallback: omitting self.dlambda uses yield_function default
+
+All tests verify that the override path produces correct physics by comparing
+against either the default path or analytically expected results.
+"""
+
+import numpy as np
+import pytest
+import autograd.numpy as anp
+
+from manforge.core.material import MaterialModel3D
+from manforge.core.state import Implicit, Explicit, NTENS
+from manforge.core.stress_state import SOLID_3D
+from manforge.simulation.integrator import PythonIntegrator
+
+
+def stress_update(model, deps, stress_n, state_n):
+    return PythonIntegrator(model).stress_update(deps, stress_n, state_n)
+
+
+# ---------------------------------------------------------------------------
+# Shared elastic constants (steel-like)
+# ---------------------------------------------------------------------------
+
+_E = 210000.0
+_NU = 0.3
+_SIGMA_Y0 = 250.0
+_H = 1000.0          # isotropic hardening
+_H_K = 5000.0        # kinematic hardening stiffness
+
+_LAM = _E * _NU / ((1.0 + _NU) * (1.0 - 2.0 * _NU))
+_MU = _E / (2.0 * (1.0 + _NU))
+
+
+# ---------------------------------------------------------------------------
+# Model 1: scalar-NR, dlambda override ≡ yield_function (identity check)
+# ---------------------------------------------------------------------------
+
+class _J2ScalarWithDlambdaOverride(MaterialModel3D):
+    """J2 without hardening.  state_residual returns self.dlambda(yield_function)
+    which is semantically identical to the default.  Used to verify that the
+    scalar-NR path produces the same result whether the override is present or not.
+    """
+    param_names = ["E", "nu", "sigma_y0"]
+    stress = Explicit(shape=NTENS, doc="stress")
+    ep = Explicit(shape=(), doc="ep")
+
+    def __init__(self, *, E, nu, sigma_y0):
+        super().__init__()
+        self.E = E
+        self.nu = nu
+        self.sigma_y0 = sigma_y0
+
+    def elastic_stiffness(self, state=None):
+        return self.isotropic_C(_LAM, _MU)
+
+    def yield_function(self, state):
+        return self._vonmises(state["stress"]) - self.sigma_y0
+
+    def update_state(self, dlambda, state_n, state_trial):
+        ep_new = state_n["ep"] + dlambda
+        stress_new = self.default_stress_update(dlambda, state_n, state_trial)
+        return [self.ep(ep_new), self.stress(stress_new)]
+
+    def state_residual(self, state_new, dlambda, state_n, state_trial):
+        # Explicit override that is mathematically identical to the default
+        return [self.dlambda(self.yield_function(state_new))]
+
+
+class _J2ScalarDefault(MaterialModel3D):
+    """Same model without the dlambda override — uses default yield_function path."""
+    param_names = ["E", "nu", "sigma_y0"]
+    stress = Explicit(shape=NTENS, doc="stress")
+    ep = Explicit(shape=(), doc="ep")
+
+    def __init__(self, *, E, nu, sigma_y0):
+        super().__init__()
+        self.E = E
+        self.nu = nu
+        self.sigma_y0 = sigma_y0
+
+    def elastic_stiffness(self, state=None):
+        return self.isotropic_C(_LAM, _MU)
+
+    def yield_function(self, state):
+        return self._vonmises(state["stress"]) - self.sigma_y0
+
+    def update_state(self, dlambda, state_n, state_trial):
+        ep_new = state_n["ep"] + dlambda
+        stress_new = self.default_stress_update(dlambda, state_n, state_trial)
+        return [self.ep(ep_new), self.stress(stress_new)]
+
+
+def _plastic_strain_increment():
+    """Return a uniaxial strain increment that causes yielding."""
+    return anp.array([2e-3, 0.0, 0.0, 0.0, 0.0, 0.0])
+
+
+@pytest.fixture
+def scalar_with_override():
+    return _J2ScalarWithDlambdaOverride(E=_E, nu=_NU, sigma_y0=_SIGMA_Y0)
+
+
+@pytest.fixture
+def scalar_default():
+    return _J2ScalarDefault(E=_E, nu=_NU, sigma_y0=_SIGMA_Y0)
+
+
+def test_scalar_nr_dlambda_override_matches_default(scalar_with_override, scalar_default):
+    """Scalar-NR: self.dlambda(yield_function) override gives same result as default."""
+    deps = _plastic_strain_increment()
+    state_n_ovr = scalar_with_override.initial_state()
+    state_n_def = scalar_default.initial_state()
+
+    r_ovr = stress_update(scalar_with_override, deps, anp.zeros(6), state_n_ovr)
+    r_def = stress_update(scalar_default, deps, anp.zeros(6), state_n_def)
+
+    np.testing.assert_allclose(
+        np.asarray(r_ovr.stress), np.asarray(r_def.stress), atol=1e-10,
+        err_msg="stress differs between dlambda-override and default paths"
+    )
+    np.testing.assert_allclose(
+        float(r_ovr.dlambda), float(r_def.dlambda), atol=1e-10,
+        err_msg="dlambda differs between dlambda-override and default paths"
+    )
+    np.testing.assert_allclose(
+        float(r_ovr.state["ep"]), float(r_def.state["ep"]), atol=1e-10,
+        err_msg="ep differs between dlambda-override and default paths"
+    )
+
+
+def test_scalar_nr_dlambda_override_is_plastic(scalar_with_override):
+    """Confirm the scalar-NR override step actually enters the plastic domain."""
+    deps = _plastic_strain_increment()
+    state_n = scalar_with_override.initial_state()
+    r = stress_update(scalar_with_override, deps, anp.zeros(6), state_n)
+    assert r.is_plastic, "expected plastic step"
+    assert float(r.dlambda) > 0.0
+
+
+# ---------------------------------------------------------------------------
+# Model 2: vector-NR, kinematic hardening, Perzyna-like dlambda override
+# ---------------------------------------------------------------------------
+
+class _KinematicWithDlambdaOverride(MaterialModel3D):
+    """Kinematic hardening (AF).  state_residual returns self.dlambda(R_dl)
+    where R_dl = f − c·Δλ  with  c = 0.0  (reduces to standard plasticity).
+
+    Setting c → 0 means the Perzyna term vanishes and results must match the
+    purely rate-independent model without the dlambda override.
+    """
+    param_names = ["E", "nu", "sigma_y0", "H_k", "c"]
+    alpha = Implicit(shape=NTENS, doc="backstress")
+
+    def __init__(self, *, E, nu, sigma_y0, H_k, c=0.0):
+        super().__init__()
+        self.E = E
+        self.nu = nu
+        self.sigma_y0 = sigma_y0
+        self.H_k = H_k
+        self.c = c
+
+    def elastic_stiffness(self, state=None):
+        return self.isotropic_C(_LAM, _MU)
+
+    def yield_function(self, state):
+        xi = state["stress"] - state["alpha"]
+        return self._vonmises(xi) - self.sigma_y0
+
+    def state_residual(self, state_new, dlambda, state_n, state_trial):
+        xi_new = state_new["stress"] - state_new["alpha"]
+        f_new = self._vonmises(xi_new) - self.sigma_y0
+        # flow direction n = df/dσ at current iterate
+        import autograd
+        from manforge.core.state import _state_with_stress
+        n = autograd.grad(
+            lambda s: self.yield_function(_state_with_stress(state_new, s))
+        )(state_new["stress"])
+        # Armstrong-Frederick backstress evolution
+        R_alpha = (state_new["alpha"] - state_n["alpha"]
+                   - dlambda * (self.H_k * n - 0.0 * state_n["alpha"]))
+        # Perzyna-like consistency: f − c·Δλ = 0  (c=0 → standard)
+        R_dl = f_new - self.c * dlambda
+        return [self.alpha(R_alpha), self.dlambda(R_dl)]
+
+
+class _KinematicDefault(MaterialModel3D):
+    """Same AF model without dlambda override (uses yield_function default)."""
+    param_names = ["E", "nu", "sigma_y0", "H_k"]
+    alpha = Implicit(shape=NTENS, doc="backstress")
+
+    def __init__(self, *, E, nu, sigma_y0, H_k):
+        super().__init__()
+        self.E = E
+        self.nu = nu
+        self.sigma_y0 = sigma_y0
+        self.H_k = H_k
+
+    def elastic_stiffness(self, state=None):
+        return self.isotropic_C(_LAM, _MU)
+
+    def yield_function(self, state):
+        xi = state["stress"] - state["alpha"]
+        return self._vonmises(xi) - self.sigma_y0
+
+    def state_residual(self, state_new, dlambda, state_n, state_trial):
+        import autograd
+        from manforge.core.state import _state_with_stress
+        n = autograd.grad(
+            lambda s: self.yield_function(_state_with_stress(state_new, s))
+        )(state_new["stress"])
+        R_alpha = (state_new["alpha"] - state_n["alpha"]
+                   - dlambda * (self.H_k * n - 0.0 * state_n["alpha"]))
+        return [self.alpha(R_alpha)]
+
+
+@pytest.fixture
+def kin_with_override():
+    return _KinematicWithDlambdaOverride(E=_E, nu=_NU, sigma_y0=_SIGMA_Y0, H_k=_H_K, c=0.0)
+
+
+@pytest.fixture
+def kin_default():
+    return _KinematicDefault(E=_E, nu=_NU, sigma_y0=_SIGMA_Y0, H_k=_H_K)
+
+
+def test_vector_nr_dlambda_override_c0_matches_default(kin_with_override, kin_default):
+    """Vector-NR: Perzyna c=0 override gives same result as no-override."""
+    deps = _plastic_strain_increment()
+    state_n_ovr = kin_with_override.initial_state()
+    state_n_def = kin_default.initial_state()
+
+    r_ovr = stress_update(kin_with_override, deps, anp.zeros(6), state_n_ovr)
+    r_def = stress_update(kin_default, deps, anp.zeros(6), state_n_def)
+
+    np.testing.assert_allclose(
+        np.asarray(r_ovr.stress), np.asarray(r_def.stress), atol=1e-8,
+        err_msg="stress differs: c=0 override vs no-override"
+    )
+    np.testing.assert_allclose(
+        float(r_ovr.dlambda), float(r_def.dlambda), atol=1e-8,
+        err_msg="dlambda differs: c=0 override vs no-override"
+    )
+    np.testing.assert_allclose(
+        np.asarray(r_ovr.state["alpha"]), np.asarray(r_def.state["alpha"]), atol=1e-8,
+        err_msg="alpha differs: c=0 override vs no-override"
+    )
+
+
+def test_vector_nr_dlambda_override_converges(kin_with_override):
+    """Verify the Perzyna override path converges in NR."""
+    deps = _plastic_strain_increment()
+    state_n = kin_with_override.initial_state()
+    r = stress_update(kin_with_override, deps, anp.zeros(6), state_n)
+    assert r.is_plastic
+    assert r.return_mapping is not None
+    assert r.return_mapping.n_iterations < 50
+    # Residual history should decrease monotonically (or at least end small)
+    hist = r.return_mapping.residual_history
+    assert hist[-1] < 1e-8, f"NR residual did not converge: {hist[-1]:.3e}"
+
+
+def test_vector_nr_omit_dlambda_fallback_matches_default(kin_with_override, kin_default):
+    """Omitting self.dlambda in state_residual falls back to yield_function."""
+    # kin_default has no self.dlambda — this test is redundant but explicit
+    deps = _plastic_strain_increment()
+    state_n_ovr = kin_with_override.initial_state()
+    state_n_def = kin_default.initial_state()
+
+    r_ovr_c0 = stress_update(kin_with_override, deps, anp.zeros(6), state_n_ovr)
+    r_def = stress_update(kin_default, deps, anp.zeros(6), state_n_def)
+
+    # c=0 case with override should match the no-override default
+    np.testing.assert_allclose(
+        np.asarray(r_ovr_c0.stress), np.asarray(r_def.stress), atol=1e-8
+    )
+
+
+# ---------------------------------------------------------------------------
+# Model 3: consistent tangent still works with dlambda override
+# ---------------------------------------------------------------------------
+
+def test_scalar_nr_tangent_is_finite(scalar_with_override):
+    """Consistent tangent must be finite and non-zero when dlambda is overridden."""
+    deps = _plastic_strain_increment()
+    state_n = scalar_with_override.initial_state()
+    r = stress_update(scalar_with_override, deps, anp.zeros(6), state_n)
+    assert r.is_plastic
+    ddsdde = np.asarray(r.ddsdde)
+    assert np.all(np.isfinite(ddsdde)), "tangent contains inf/nan"
+    assert np.linalg.norm(ddsdde) > 0.0, "tangent is zero"
+
+
+def test_vector_nr_tangent_is_finite(kin_with_override):
+    """Consistent tangent with Perzyna override is finite and non-zero."""
+    deps = _plastic_strain_increment()
+    state_n = kin_with_override.initial_state()
+    r = stress_update(kin_with_override, deps, anp.zeros(6), state_n)
+    assert r.is_plastic
+    ddsdde = np.asarray(r.ddsdde)
+    assert np.all(np.isfinite(ddsdde)), "tangent contains inf/nan"
+    assert np.linalg.norm(ddsdde) > 0.0, "tangent is zero"

--- a/tests/unit/test_dlambda_validation.py
+++ b/tests/unit/test_dlambda_validation.py
@@ -1,0 +1,248 @@
+"""Validation tests for self.dlambda(R) API: error paths and boundary checks."""
+
+import pytest
+import autograd.numpy as anp
+
+from manforge.core.state import (
+    Implicit, Explicit, NTENS,
+    DlambdaResidual, DlambdaField, DLAMBDA_FIELD,
+    StateResidual, StateUpdate,
+)
+from manforge.core.material import MaterialModel3D, MaterialModel1D
+
+
+# ---------------------------------------------------------------------------
+# Minimal models for validation tests
+# ---------------------------------------------------------------------------
+
+_LAM = 115384.0
+_MU = 76923.0
+
+
+class _NoStateModel(MaterialModel3D):
+    """No state fields beyond stress (scalar-NR path)."""
+    param_names = ["sigma_y0"]
+
+    def __init__(self, *, sigma_y0):
+        super().__init__()
+        self.sigma_y0 = sigma_y0
+
+    def yield_function(self, state):
+        return self._vonmises(state["stress"]) - self.sigma_y0
+
+    def elastic_stiffness(self, state):
+        return self.isotropic_C(_LAM, _MU)
+
+
+class _DlambdaOnlyModel(MaterialModel3D):
+    """state_residual returns only self.dlambda(R) — no other implicit states."""
+    param_names = ["sigma_y0"]
+
+    def __init__(self, *, sigma_y0):
+        super().__init__()
+        self.sigma_y0 = sigma_y0
+
+    def yield_function(self, state):
+        return self._vonmises(state["stress"]) - self.sigma_y0
+
+    def elastic_stiffness(self, state):
+        return self.isotropic_C(_LAM, _MU)
+
+    def state_residual(self, state_new, dlambda, state_n, state_trial):
+        return [self.dlambda(self.yield_function(state_new))]
+
+
+class _AlphaModel(MaterialModel3D):
+    """Vector-NR: alpha Implicit."""
+    param_names = ["sigma_y0", "H_k"]
+    alpha = Implicit(shape=NTENS, doc="backstress")
+
+    def __init__(self, *, sigma_y0, H_k):
+        super().__init__()
+        self.sigma_y0 = sigma_y0
+        self.H_k = H_k
+
+    def yield_function(self, state):
+        xi = state["stress"] - state["alpha"]
+        return self._vonmises(xi) - self.sigma_y0
+
+    def elastic_stiffness(self, state):
+        return self.isotropic_C(_LAM, _MU)
+
+    def state_residual(self, state_new, dlambda, state_n, state_trial):
+        R_alpha = state_new["alpha"] - state_n["alpha"]
+        return [self.alpha(R_alpha)]
+
+
+class _DuplicateDlambdaModel(MaterialModel3D):
+    """Intentionally returns self.dlambda(...) twice — should error."""
+    param_names = ["sigma_y0"]
+    alpha = Implicit(shape=NTENS, doc="backstress")
+
+    def __init__(self, *, sigma_y0):
+        super().__init__()
+        self.sigma_y0 = sigma_y0
+
+    def yield_function(self, state):
+        return self._vonmises(state["stress"]) - self.sigma_y0
+
+    def elastic_stiffness(self, state):
+        return self.isotropic_C(_LAM, _MU)
+
+    def state_residual(self, state_new, dlambda, state_n, state_trial):
+        R_alpha = state_new["alpha"] - state_n["alpha"]
+        return [
+            self.alpha(R_alpha),
+            self.dlambda(self.yield_function(state_new)),
+            self.dlambda(self.yield_function(state_new)),  # duplicate
+        ]
+
+
+class _BadItemModel(MaterialModel3D):
+    """state_residual returns a non-StateResidual / non-DlambdaResidual item."""
+    param_names = ["sigma_y0"]
+    alpha = Implicit(shape=NTENS, doc="backstress")
+
+    def __init__(self, *, sigma_y0):
+        super().__init__()
+        self.sigma_y0 = sigma_y0
+
+    def yield_function(self, state):
+        return self._vonmises(state["stress"]) - self.sigma_y0
+
+    def elastic_stiffness(self, state):
+        return self.isotropic_C(_LAM, _MU)
+
+    def state_residual(self, state_new, dlambda, state_n, state_trial):
+        return [42]  # wrong type
+
+
+class _DlambdaInUpdateState(MaterialModel3D):
+    """update_state mistakenly returns self.dlambda(R) — should error."""
+    param_names = ["sigma_y0"]
+    ep = Explicit(shape=(), doc="ep")
+
+    def __init__(self, *, sigma_y0):
+        super().__init__()
+        self.sigma_y0 = sigma_y0
+
+    def yield_function(self, state):
+        return self._vonmises(state["stress"]) - self.sigma_y0
+
+    def elastic_stiffness(self, state):
+        return self.isotropic_C(_LAM, _MU)
+
+    def update_state(self, dlambda, state_n, state_trial):
+        return [
+            self.ep(state_n["ep"] + dlambda),
+            self.dlambda(anp.array(0.0)),  # not allowed
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Tests: DlambdaField / DlambdaResidual basics
+# ---------------------------------------------------------------------------
+
+def test_dlambda_field_is_attached_to_model():
+    model = _NoStateModel(sigma_y0=250.0)
+    assert hasattr(model, "dlambda")
+    assert isinstance(model.dlambda, DlambdaField)
+
+
+def test_dlambda_field_call_produces_dlambda_residual():
+    model = _NoStateModel(sigma_y0=250.0)
+    result = model.dlambda(anp.array(1.5))
+    assert isinstance(result, DlambdaResidual)
+    assert float(result.value) == pytest.approx(1.5)
+
+
+def test_dlambda_field_singleton():
+    assert isinstance(DLAMBDA_FIELD, DlambdaField)
+    model_a = _NoStateModel(sigma_y0=250.0)
+    model_b = _AlphaModel(sigma_y0=250.0, H_k=1000.0)
+    assert model_a.dlambda is model_b.dlambda is DLAMBDA_FIELD
+
+
+def test_dlambda_not_in_state_fields():
+    model = _NoStateModel(sigma_y0=250.0)
+    assert "dlambda" not in model.state_fields
+    assert "dlambda" not in model.state_names
+    assert "dlambda" not in model.implicit_state_names
+
+
+# ---------------------------------------------------------------------------
+# Tests: update_state must not accept self.dlambda(R)
+# ---------------------------------------------------------------------------
+
+def test_update_state_rejects_dlambda_residual():
+    model = _DlambdaInUpdateState(sigma_y0=250.0)
+    state_n = model.make_state(stress=anp.zeros(6), ep=anp.array(0.0))
+    stress_trial = anp.zeros(6)
+    import numpy as np
+    from manforge.core.residual import _call_update_state
+    with pytest.raises(TypeError, match="self.dlambda.*not allowed in update_state"):
+        _call_update_state(
+            model, anp.array(0.01), state_n, state_n,
+            {"ep"}, "_DlambdaInUpdateState"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: state_residual duplicate self.dlambda(...) raises ValueError
+# ---------------------------------------------------------------------------
+
+def test_state_residual_duplicate_dlambda_raises():
+    import numpy as np
+    from manforge.core.residual import _call_state_residual
+    model = _DuplicateDlambdaModel(sigma_y0=250.0)
+    state_n = model.make_state(stress=anp.zeros(6), alpha=anp.zeros(6))
+    with pytest.raises(ValueError, match="duplicate self.dlambda"):
+        _call_state_residual(
+            model, dict(state_n), anp.array(0.01), dict(state_n), dict(state_n),
+            {"alpha"}, "_DuplicateDlambdaModel"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: state_residual bad item type raises TypeError
+# ---------------------------------------------------------------------------
+
+def test_state_residual_bad_item_raises():
+    from manforge.core.residual import _call_state_residual
+    model = _BadItemModel(sigma_y0=250.0)
+    state_n = model.make_state(stress=anp.zeros(6), alpha=anp.zeros(6))
+    with pytest.raises(TypeError, match="StateResidual.*DlambdaResidual"):
+        _call_state_residual(
+            model, dict(state_n), anp.array(0.01), dict(state_n), dict(state_n),
+            {"alpha"}, "_BadItemModel"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: _call_state_residual returns (dict, r_dl) correctly
+# ---------------------------------------------------------------------------
+
+def test_call_state_residual_with_dlambda_override():
+    from manforge.core.residual import _call_state_residual
+    model = _DlambdaOnlyModel(sigma_y0=250.0)
+    state_n = model.make_state(stress=anp.zeros(6))
+    state_dict = dict(state_n)
+    result_dict, r_dl = _call_state_residual(
+        model, state_dict, anp.array(0.0), state_dict, state_dict,
+        set(), "_DlambdaOnlyModel"
+    )
+    assert result_dict == {}
+    assert r_dl is not None
+
+
+def test_call_state_residual_without_dlambda_returns_none():
+    from manforge.core.residual import _call_state_residual
+    model = _AlphaModel(sigma_y0=250.0, H_k=1000.0)
+    state_n = model.make_state(stress=anp.zeros(6), alpha=anp.zeros(6))
+    state_dict = dict(state_n)
+    result_dict, r_dl = _call_state_residual(
+        model, state_dict, anp.array(0.0), state_dict, state_dict,
+        {"alpha"}, "_AlphaModel"
+    )
+    assert "alpha" in result_dict
+    assert r_dl is None


### PR DESCRIPTION
## Summary

- `state_residual` の戻り値に `self.dlambda(R_dl)` を混ぜることで、NR 残差の Δλ 行をユーザーが差し替えられるようにした
- 省略時は従来通り `yield_function(state) = 0` にフォールバック（後方互換）
- scalar-NR / vector NR / consistent tangent の全経路で動作

## 動機

従来、NR 残差ベクトルの Δλ 行は `model.yield_function(state) = 0` としてハードコードされており、粘塑性 (Perzyna 型: `R_dl = f − η·Δλ/Δt`) など Δλ を決める式が yield function と異なるモデルを実装できなかった。

## 使い方

```python
def state_residual(self, state_new, dlambda, state_n, state_trial):
    f = self.yield_function(state_new)
    R_dl = f - self.eta * dlambda / self.dt   # Perzyna 型
    return [self.dlambda(R_dl), self.alpha(R_alpha)]
```

## 実装詳細

### 新規 API (`state.py`)
- `DlambdaResidual` — `self.dlambda(R)` が返すラッパークラス
- `DlambdaField` / `DLAMBDA_FIELD` — `MaterialModel.dlambda` に attach する pseudo-field
- `dlambda` は `state_fields` / `state_names` / `implicit_state_names` に含まれない

### 変更ファイル
| ファイル | 変更内容 |
|---|---|
| `core/state.py` | `DlambdaResidual`, `DlambdaField`, `DLAMBDA_FIELD` 追加 |
| `core/material.py` | `MaterialModel.dlambda = DLAMBDA_FIELD` を class 属性として追加 |
| `core/residual.py` | `_call_state_residual` 戻り値を `(dict, r_dl_or_None)` に変更; `_call_update_state` に拒否ガード追加; `make_nr_residual` / `make_tangent_residual` に R_dl フォールバック |
| `core/solver.py` | `_scalar_nr` に `_eval_R_dl` ヘルパーを追加 |
| `core/__init__.py` | `DlambdaResidual` をエクスポート |

### バリデーション
- `update_state` で `self.dlambda(...)` を返す → `TypeError`
- `state_residual` で `self.dlambda(...)` を 2 回返す → `ValueError`
- `StateResidual` / `DlambdaResidual` 以外の item → `TypeError`

## Test plan

- [x] `tests/unit/test_dlambda_validation.py` — field attaches, 型エラー, 重複エラー, `_call_state_residual` 戻り値 (9件)
- [x] `tests/integration/test_dlambda_override.py` — scalar-NR identity 確認, c=0 Perzyna 収束確認, fallback 確認, tangent 有限確認 (7件)
- [x] 既存 501件のテストが全て通過 (合計 517件 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)