### PR TITLE
refactor: ResidualLayout 導入・JacobianBlocks 改名・state_residual kwarg 統一

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,23 +73,22 @@ class MyModel(MaterialModel3D):
 User methods are unified on `State` arguments — stress is accessed via `state["stress"]` like any other state:
 
 - `yield_function(self, state)` → scalar (≤0 = elastic). **Must be implemented.**
-- `update_state(self, dlambda, state_n, state_trial)` → `list[StateUpdate]` with only the **explicit** state keys (excluding stress, unless user declares `stress = Explicit` and wants custom update). Required whenever any non-stress state is `Explicit`.
-- `state_residual(self, state_new, dlambda, state_n, state_trial)` → `list[StateResidual]` with the **implicit** state keys. May optionally include a `self.stress(R_stress)` item to override the default associative R_stress. Required whenever any state is `Implicit`.
+- `update_state(self, dlambda, state_n, state_trial)` → `list[StateUpdate]` with only the **explicit non-stress** state keys. Do **not** return `stress` — the framework drives σ via the NR system. Required whenever any non-stress state is `Explicit`.
+- `state_residual(self, state_new, dlambda, state_n, state_trial, *, stress_trial)` → `list[StateResidual]` with the **implicit** state keys. May optionally include a `self.stress(R_stress)` item to provide the stress residual when `stress = Implicit`. Required whenever any state is `Implicit`.
 
-`state_trial["stress"]` semantics in these methods:
-- When `stress = Implicit`: `state_trial["stress"]` is the **fixed elastic trial stress** (used to write `R_stress = σ − σ_trial + ...`).
-- When `stress = Explicit`: `state_trial["stress"]` is the **current stress iterate** (used by models like AF kinematic to evaluate the flow direction at the current state).
+`state_trial["stress"]` semantics: always the **current σ NR iterate** (same in both `update_state` and `state_residual`). The fixed elastic predictor σ_trial = σ_n + C Δε is provided as the keyword argument `stress_trial` to `state_residual`. Use `self.default_stress_residual(state_new, dlambda, stress_trial)` to compute the associative R_stress.
 
 Use `StateField.__call__` to wrap return values (produces `StateResidual` or `StateUpdate` depending on field kind):
 
 ```python
-def state_residual(self, state_new, dlambda, state_n, state_trial):
+def state_residual(self, state_new, dlambda, state_n, state_trial, *, stress_trial):
+    R_stress = self.default_stress_residual(state_new, dlambda, stress_trial)
     ...
-    return [self.alpha(R_alpha), self.ep(R_ep)]   # list of StateResidual
+    return [self.stress(R_stress), self.alpha(R_alpha), self.ep(R_ep)]   # list of StateResidual
 
 def update_state(self, dlambda, state_n, state_trial):
     ...
-    return [self.alpha(alpha_new), self.ep(ep_new)]  # list of StateUpdate
+    return [self.alpha(alpha_new), self.ep(ep_new)]  # list of StateUpdate (no stress)
 ```
 
 The framework validates the list at the boundary: wrong kind (`StateResidual` where `StateUpdate` expected), duplicate names, missing or extra fields all raise `TypeError` / `ValueError` immediately.
@@ -121,20 +120,21 @@ The reference implementation is `src/manforge/models/j2_isotropic.py` (J2Isotrop
   - `ReturnMappingResult` fields: `stress`, `state`, `dlambda`, `n_iterations`, `residual_history`, `converged`.
   - `StressUpdateResult` fields: `return_mapping` (None for elastic), `ddsdde`, `stress_trial`, `is_plastic`. Convenience properties `stress`, `state`, `dlambda`, `n_iterations`, `residual_history` delegate to `return_mapping` (or elastic defaults).
   - Both are importable via `from manforge.core import ReturnMappingResult, StressUpdateResult`.
-- `jacobian.py`: `JacobianBlocks` dataclass and `ad_jacobian_blocks(model, result, state_n)` — computes the residual Jacobian at the converged point and decomposes it into named blocks (`dstress_dsigma`, `dyield_dsigma`, `dstate_dstate`, etc.). State blocks are keyed by variable name (e.g. `jac.dstate_dsigma["alpha"]`); only implicit states appear in `dstate_*` fields. Accepts both `StressUpdateResult` and `ReturnMappingResult`. Used for step-by-step verification of analytical derivatives.
-- `residual.py`: Two residual builders: `make_nr_residual(model, stress_trial, state_n)` → `(fn, meta, unflatten)` for the NR phase (σ included only when stress is Implicit); `make_tangent_residual(model, stress_trial, state_n)` → `(fn, n_implicit, unflatten)` for the tangent/Jacobian phase (σ always included).
+- (no `jacobian.py` or `residual.py` in `core/` — these live in `simulation/` and `verification/` respectively)
 
 autograd computes yield function gradients and the Hessian needed for the tangent. Float64 is enabled globally in `src/manforge/__init__.py`.
 
 **3. Application layer**
 
 - `simulation/integrator/` (package): `_PythonIntegratorBase.stress_update(strain_inc, stress_n, state_n)` → `StressUpdateResult` — full constitutive integration (elastic trial → yield check → return mapping → consistent tangent). Equivalent to one UMAT call. `_PythonIntegratorBase.return_mapping(stress_trial, state_n)` → `ReturnMappingResult` — plastic correction only (closest point projection). NR path selected by `model.state_fields["stress"].kind` and `model.implicit_state_names`: scalar NR on Δλ when stress is Explicit and no other implicit states; vector NR on `[Δλ, q_implicit]` or `[σ, Δλ, q_implicit]` (when `stress = Implicit`) otherwise (max 50 iter, tol=1e-10). `_method` class variable on subclasses: `"auto"` (use `user_defined_return_mapping` if present, else `"numerical_newton"`), `"numerical_newton"` (framework NR), `"user_defined"` (requires model to implement `user_defined_return_mapping`). NR logic lives in `integrator/base.py`; consistent tangent via implicit differentiation in the same file (`_consistent_tangent`).
-- `simulation/_residual.py`: Two residual builders: `make_nr_residual(model, stress_trial, state_n)` → `(fn, meta, unflatten)` for the NR phase; `make_tangent_residual(model, stress_trial, state_n)` → `(fn, n_implicit, unflatten)` for the tangent/Jacobian phase.
+- `simulation/_layout.py`: `ResidualLayout` frozen dataclass — single source of truth for the NR unknown vector layout `x = [σ (ntens) | Δλ (1) | q_implicit_non_stress (declaration order)]`. Created via `ResidualLayout.from_model(model)`; provides `pack`, `unpack`, `state_slice` helpers used by `_residual.py`, `integrator/base.py`, and `verification/jacobian.py`.
+- `simulation/_residual.py`: `build_residual(model, stress_trial, state_n)` → `(residual_fn, layout)` — unified autograd-differentiable residual for both NR and tangent phases. `residual_fn(x)` returns a flat array. `build_state_from_x(model, x_conv, state_n, layout)` reconstructs the full state dict from a converged NR vector.
 - `simulation/driver.py`: `StrainDriver`, `StressDriver` (+ aliases `UniaxialDriver`, `GeneralDriver`) — step through strain/stress histories. Two APIs: `run(load, *, initial_stress=None, initial_state=None, collect_state)` → `DriverResult` (batch); `iter_run(load, *, initial_stress=None, initial_state=None)` → `Iterator[DriverStep]` (step-by-step, supports early break / mid-loop branching). `DriverStep` fields: `i`, `strain` (cumulative), `result` (`StressUpdateResult`), `converged`, `n_outer_iter`, `residual_inf`. `StressDriver.iter_run` accepts `raise_on_nonconverged=False` to yield non-converged steps instead of raising. `DriverResult` fields: `step_results: list[StressUpdateResult]` (primary); `stress`, `strain`, `fields` are derived properties.
 - `fitting/optimizer.py`: `fit_params()` wraps scipy.optimize (L-BFGS-B, Nelder-Mead, differential_evolution); loss defined in `fitting/objective.py`; uses drivers from `simulation/`
 - `verification/fd_check.py`: Compares AD tangent vs central finite differences
 - `verification/fortran_bridge.py`: f2py interface; calls compiled UMAT and compares output element-wise to Python (stress tol: 1e-6, tangent tol: 1e-5)
 - `verification/crosscheck_driver.py`: `CrosscheckStrainDriver` / `CrosscheckStressDriver` (both `Comparator` subclasses). Mirror `StrainDriver` / `StressDriver` respectively. `CrosscheckStressDriver.__init__` accepts `max_iter` / `tol` directly (no dict wrapper). `iter_run(load, *, initial_stress=None, initial_state=None)` yields `CrosscheckCaseResult` per step; `run(load)` returns `CrosscheckResult`. `CrosscheckCaseResult` holds `result_a`, `result_b` (raw `StressUpdateResult`) and `state_n` (step-start state) for use with `compare_jacobians`. Single-step comparison: pass a 1-row `FieldHistory` with `initial_stress`/`initial_state`.
+- `verification/jacobian.py`: `JacobianBlocks` dataclass and `ad_jacobian_blocks(model, result, state_n)` — computes the residual Jacobian at the converged point and decomposes it into named blocks (`dRsigma_dsigma`, `dRdlambda_dsigma`, `dRstate_dstate`, etc.). State blocks are keyed by variable name (e.g. `jac.dRstate_dsigma["alpha"]`); always `dict` (empty when no implicit non-stress states). Accepts both `StressUpdateResult` and `ReturnMappingResult` (latter requires `stress_trial=` kwarg). Import from `manforge.verification.jacobian`.
 - `verification/jacobian_compare.py`: `compare_jacobians(model, result_a, result_b, state_n)` — compare Jacobian blocks from two `StressUpdateResult` objects (opt-in debugging utility, not called automatically by crosscheck drivers).
 
 ### StressDimension (element dimensionality)

--- a/examples/crosscheck_umat_advanced.py
+++ b/examples/crosscheck_umat_advanced.py
@@ -40,7 +40,7 @@ from manforge.verification import (
     generate_strain_history,
     compare_jacobians,
 )
-from manforge.core.jacobian import ad_jacobian_blocks
+from manforge.verification.jacobian import ad_jacobian_blocks
 
 # ---------------------------------------------------------------------------
 # Shared setup
@@ -164,24 +164,24 @@ print("  3b: ad_jacobian_blocks — individual block access")
 jac = ad_jacobian_blocks(model, result_plastic, state_n_base)
 
 # 応力残差の σ 偏微分ブロック（ntens × ntens）
-print(f"     dstress_dsigma  shape : {np.asarray(jac.dstress_dsigma).shape}")
+print(f"     dRsigma_dsigma  shape : {np.asarray(jac.dRsigma_dsigma).shape}")
 # 降伏面の σ 勾配（ntens,）— 法線ベクトル
-print(f"     dyield_dsigma   shape : {np.asarray(jac.dyield_dsigma).shape}")
+print(f"     dRdlambda_dsigma shape: {np.asarray(jac.dRdlambda_dsigma).shape}")
 # Δλ に対する降伏感度（スカラー）
-print(f"     dyield_ddlambda       : {float(jac.dyield_ddlambda):.6f}")
-# state ブロック（reduced model では None; augmented では dict）
-print(f"     dstate_dstate         : {jac.dstate_dstate!r}")
+print(f"     dRdlambda_ddlambda    : {float(jac.dRdlambda_ddlambda):.6f}")
+# state ブロック（reduced model では {}; augmented では dict）
+print(f"     dRstate_dstate        : {jac.dRstate_dstate!r}")
 # 完全 Jacobian 行列（ntens+1 × ntens+1）
 print(f"     full matrix shape     : {np.asarray(jac.full).shape}")
 print()
 
 # --- 3b-2: augmented モデル (OWKinematic3D) での残差 Jacobian state ブロック ---
-# reduced モデルでは None だった dstress_dstate / dstate_dstate が
+# reduced モデルでは {} だった dRsigma_dstate / dRstate_dstate が
 # augmented モデルでは状態変数名をキーとする dict になる。
-# フィールド名の意味（"dstress" はすべて応力残差 R_σ の微分）:
-#   dstress_dstate['alpha']         = ∂R_σ / ∂q_alpha   (ntens × ntens)
-#   dstate_dstate['alpha']['alpha'] = ∂R_{q_alpha} / ∂q_alpha  (backstress 残差の自己微分)
-#   dstate_dsigma['alpha']          = ∂R_{q_alpha} / ∂σ
+# フィールド名の意味（"dRsigma" はすべて応力残差 R_σ の微分）:
+#   dRsigma_dstate['alpha']         = ∂R_σ / ∂q_alpha   (ntens × ntens)
+#   dRstate_dstate['alpha']['alpha'] = ∂R_{q_alpha} / ∂q_alpha  (backstress 残差の自己微分)
+#   dRstate_dsigma['alpha']          = ∂R_{q_alpha} / ∂σ
 from manforge.models.ow_kinematic import OWKinematic3D
 
 ow_model = OWKinematic3D(E=210_000.0, nu=0.3, sigma_y0=250.0, C_k=5_000.0, gamma=50.0)
@@ -193,11 +193,11 @@ result_ow = _PyInt(ow_model).stress_update(deps_ow, np.zeros(ow_model.ntens), st
 print("  3b-2: augmented model (OWKinematic3D) — state residual blocks")
 jac_ow = ad_jacobian_blocks(ow_model, result_ow, state_n_ow)
 # ∂R_σ/∂q_alpha — 応力残差 の backstress 微分 (ntens × ntens)
-print(f"     dstress_dstate['alpha'] shape         : {np.asarray(jac_ow.dstress_dstate['alpha']).shape}")
+print(f"     dRsigma_dstate['alpha'] shape          : {np.asarray(jac_ow.dRsigma_dstate['alpha']).shape}")
 # ∂R_{q_alpha}/∂q_alpha — backstress 残差の自己微分 (ntens × ntens)
-print(f"     dstate_dstate['alpha']['alpha'] shape : {np.asarray(jac_ow.dstate_dstate['alpha']['alpha']).shape}")
+print(f"     dRstate_dstate['alpha']['alpha'] shape : {np.asarray(jac_ow.dRstate_dstate['alpha']['alpha']).shape}")
 # ∂R_{q_alpha}/∂σ — backstress 残差の応力微分 (ntens × ntens)
-print(f"     dstate_dsigma['alpha'] shape          : {np.asarray(jac_ow.dstate_dsigma['alpha']).shape}")
+print(f"     dRstate_dsigma['alpha'] shape          : {np.asarray(jac_ow.dRstate_dsigma['alpha']).shape}")
 # full: ntens+1+n_state = 6+1+(6+1) = 14
 print(f"     full matrix shape                     : {np.asarray(jac_ow.full).shape}")
 print()

--- a/examples/example_verify_j2_analytical.py
+++ b/examples/example_verify_j2_analytical.py
@@ -16,13 +16,14 @@ Usage
     uv run python examples/example_verify_j2_analytical.py
 """
 
-import jax
-import jax.numpy as jnp
+import autograd
+import autograd.numpy as anp
 import numpy as np
 import numpy.testing as npt
 
-import manforge  # noqa: F401 — enables JAX float64
-from manforge.core.jacobian import ad_jacobian_blocks
+import manforge  # noqa: F401 — enables float64
+from manforge.verification.jacobian import ad_jacobian_blocks
+from manforge.core.state import _state_with_stress
 from manforge.models.j2_isotropic import J2Isotropic3D
 from manforge.simulation.driver import StrainDriver
 from manforge.simulation.integrator import (
@@ -49,8 +50,8 @@ print("=" * 60)
 print("  Part 1: Single plastic step — AD vs analytical")
 print("=" * 60)
 
-deps = jnp.array([3e-3, 0.0, 0.0, 0.0, 0.0, 0.0])
-stress_n = jnp.zeros(6)
+deps = anp.array([3e-3, 0.0, 0.0, 0.0, 0.0, 0.0])
+stress_n = anp.zeros(6)
 
 # --- numerical (Newton-Raphson) ---
 result_ad = PythonNumericalIntegrator(model).stress_update(deps, stress_n, state0)
@@ -103,34 +104,34 @@ print("=" * 60)
 
 jac = ad_jacobian_blocks(model, result_ad, state0)
 
-# --- flow direction: dyield_dsigma = df/dsigma = (3/2) s / sigma_vm ---
+# --- flow direction: dRdlambda_dsigma = df/dsigma = (3/2) s / sigma_vm ---
 s = model._dev(result_ad.stress)
 sigma_vm = model._vonmises(result_ad.stress)
 n_analytical = (3.0 / 2.0) * s / sigma_vm
 
-npt.assert_allclose(jac.dyield_dsigma, n_analytical, rtol=1e-10)
-print("  dyield_dsigma (flow direction n): PASS")
+npt.assert_allclose(jac.dRdlambda_dsigma, n_analytical, rtol=1e-10)
+print("  dRdlambda_dsigma (flow direction n): PASS")
 
-# cross-check: also matches jax.grad of yield_function
-n_ad = jax.grad(lambda sig: model.yield_function(sig, result_ad.state))(
-    result_ad.stress
-)
-npt.assert_allclose(jac.dyield_dsigma, n_ad, rtol=1e-10)
-print("  dyield_dsigma == jax.grad(f)   : PASS")
+# cross-check: also matches autograd.grad of yield_function
+n_ad = autograd.grad(
+    lambda sig: model.yield_function(_state_with_stress(result_ad.state, sig))
+)(result_ad.stress)
+npt.assert_allclose(jac.dRdlambda_dsigma, n_ad, rtol=1e-10)
+print("  dRdlambda_dsigma == autograd.grad(f): PASS")
 
-# --- dstress_ddlambda = C @ n (return mapping residual structure) ---
+# --- dRsigma_ddlambda = C @ n (return mapping residual structure) ---
 Cn = C @ n_analytical
-npt.assert_allclose(jac.dstress_ddlambda, Cn, rtol=1e-10)
-print("  dstress_ddlambda (= C @ n)     : PASS")
+npt.assert_allclose(jac.dRsigma_ddlambda, Cn, rtol=1e-10)
+print("  dRsigma_ddlambda (= C @ n)     : PASS")
 
-# --- dyield_ddlambda = -H (for J2 linear isotropic hardening) ---
-npt.assert_allclose(float(jac.dyield_ddlambda), -model.H, rtol=1e-10)
-print(f"  dyield_ddlambda (= -H = {float(jac.dyield_ddlambda):.1f}): PASS")
+# --- dRdlambda_ddlambda = -H (for J2 linear isotropic hardening) ---
+npt.assert_allclose(float(jac.dRdlambda_ddlambda), -model.H, rtol=1e-10)
+print(f"  dRdlambda_ddlambda (= -H = {float(jac.dRdlambda_ddlambda):.1f}): PASS")
 
-# --- reduced hardening: state blocks are None ---
-assert jac.dstate_dsigma is None
-assert jac.dstate_dstate is None
-print("  state blocks (reduced model)   : None (correct)")
+# --- reduced hardening: state blocks are empty dicts ---
+assert jac.dRstate_dsigma == {}
+assert jac.dRstate_dstate == {}
+print("  state blocks (reduced model)   : empty dicts (correct)")
 
 # --- full matrix shape ---
 assert jac.full.shape == (7, 7)  # ntens + 1 = 6 + 1
@@ -181,8 +182,10 @@ print(f"  Step {step_idx} user_defined_tangent: PASS")
 
 # Jacobian blocks for this step
 jac = ad_jacobian_blocks(model, rm, state_prev)
-n_step = jax.grad(lambda sig: model.yield_function(sig, rm.state))(rm.stress)
-npt.assert_allclose(jac.dyield_dsigma, n_step, rtol=1e-10)
+n_step = autograd.grad(
+    lambda sig: model.yield_function(_state_with_stress(rm.state, sig))
+)(rm.stress)
+npt.assert_allclose(jac.dRdlambda_dsigma, n_step, rtol=1e-10)
 print(f"  Step {step_idx} Jacobian blocks: PASS")
 print()
 

--- a/src/manforge/core/material/base.py
+++ b/src/manforge/core/material/base.py
@@ -189,14 +189,14 @@ class MaterialModel(ABC):
         state_n,
         state_trial,
     ) -> list:
-        """Return updated state variables after a plastic increment.
+        """Return updated non-stress explicit state variables after a plastic increment.
 
         Closed-form (explicit) update rule: given (Δλ, state_n, state_trial),
-        returns explicit state keys as a list of :class:`StateUpdate`.
-        Required for all state variables *not* listed in
-        :attr:`implicit_state_names`.  The ``stress`` key need only be returned
-        when a custom stress update is required; if omitted, the framework
-        auto-injects the associative formula.
+        returns the explicit **non-stress** state keys as a list of
+        :class:`StateUpdate`.  Required when any non-stress state is explicit.
+
+        Do **not** return ``stress`` from this method — the framework handles
+        the stress update via the NR residual system.
 
         Parameters
         ----------
@@ -205,12 +205,13 @@ class MaterialModel(ABC):
         state_n : State or dict
             State at the beginning of the increment.
         state_trial : State or dict
-            Trial state (``state_trial["stress"]`` is the elastic trial stress).
+            Trial state.  ``state_trial["stress"]`` is the **current σ NR iterate**
+            (use it to evaluate flow directions at the current state).
 
         Returns
         -------
         list[StateUpdate]
-            Updated explicit-state items (use ``self.<field>(value)`` syntax).
+            Updated explicit non-stress state items (``self.<field>(value)``).
 
         Raises
         ------
@@ -229,29 +230,44 @@ class MaterialModel(ABC):
         dlambda: anp.ndarray,
         state_n,
         state_trial,
+        *,
+        stress_trial: anp.ndarray = None,
     ) -> list:
         """Residual of the implicit state evolution equations.
 
         Defines R_h(state_new, Δλ, state_n, state_trial) = 0 for state
-        variables listed in :attr:`implicit_state_names`.  The ``stress`` key
-        need only be returned when a custom stress residual is required; if
-        omitted, the framework auto-injects the associative formula.
+        variables listed in :attr:`implicit_state_names`.  When stress is
+        declared ``Implicit``, return ``self.stress(R_stress)`` in the list
+        as well.
 
         Parameters
         ----------
         state_new : State or dict
             Proposed state values at step n+1 (NR unknowns).
+            ``state_new["stress"]`` is always the **current σ NR iterate**.
         dlambda : anp.ndarray, scalar
             Plastic multiplier increment Δλ.
         state_n : State or dict
             State at the beginning of the increment.
         state_trial : State or dict
-            Trial state (``state_trial["stress"]`` is the elastic trial stress).
+            Trial state.  ``state_trial["stress"]`` is the **current σ NR iterate**
+            (same as ``state_new["stress"]``), available for evaluating flow
+            directions at the current state.
+        stress_trial : anp.ndarray, shape (ntens,), keyword-only
+            Fixed elastic predictor σ_trial = σ_n + C Δε.  Use this (not
+            ``state_trial["stress"]``) when you need the fixed trial stress for
+            the associative residual formula::
+
+                R_stress = σ − stress_trial + Δλ·C·∂f/∂σ
+
+            Call :meth:`default_stress_residual` which accepts ``stress_trial``
+            directly, or use this kwarg to compute R_stress manually.
 
         Returns
         -------
         list[StateResidual]
             Residual items (use ``self.<field>(value)`` syntax).  Zero at convergence.
+            Optionally include ``self.dlambda(R_dl)`` to override the Δλ row.
         """
         raise NotImplementedError(
             f"{type(self).__name__}.state_residual() is not implemented. "
@@ -300,15 +316,16 @@ class MaterialModel(ABC):
         self,
         state_new,
         dlambda: anp.ndarray,
-        state_trial,
+        stress_trial: anp.ndarray,
     ) -> anp.ndarray:
         """Associative default R_stress = σ − σ_trial + Δλ·C·∂f/∂σ.
 
         Call this from :meth:`state_residual` when the model uses associative
         flow (flow direction = ∂f/∂σ)::
 
-            def state_residual(self, state_new, dlambda, state_n, state_trial):
-                R_stress = self.default_stress_residual(state_new, dlambda, state_trial)
+            def state_residual(self, state_new, dlambda, state_n, state_trial,
+                               *, stress_trial):
+                R_stress = self.default_stress_residual(state_new, dlambda, stress_trial)
                 R_alpha = ...
                 return [self.stress(R_stress), self.alpha(R_alpha), self.ep(R_ep)]
 
@@ -320,11 +337,11 @@ class MaterialModel(ABC):
         ----------
         state_new : State or dict
             Proposed state at step n+1 (NR iterate); ``state_new["stress"]``
-            is the current σ unknown.
+            is the current σ NR unknown.
         dlambda : scalar
             Plastic multiplier increment Δλ.
-        state_trial : State or dict
-            Trial state; ``state_trial["stress"]`` is the fixed elastic predictor σ_trial.
+        stress_trial : anp.ndarray, shape (ntens,)
+            Fixed elastic predictor σ_trial = σ_n + C Δε.
 
         Returns
         -------
@@ -333,7 +350,6 @@ class MaterialModel(ABC):
         import autograd
         from manforge.core.state import _state_with_stress
         stress = state_new["stress"]
-        stress_trial = state_trial["stress"]
         C = self.elastic_stiffness(state_new)
         n = autograd.grad(
             lambda s: self.yield_function(_state_with_stress(state_new, s))
@@ -346,31 +362,26 @@ class MaterialModel(ABC):
         state_n,
         state_trial,
     ) -> anp.ndarray:
-        """Return the framework-pre-computed associative stress iterate.
+        """Return the current σ NR iterate from ``state_trial``.
 
-        For ``stress = Explicit`` models the framework derives σ_{n+1} =
-        σ_trial − Δλ·C·∂f/∂σ before calling :meth:`update_state` and passes
-        it as ``state_trial["stress"]``.  This helper returns that value,
-        allowing user code to explicitly acknowledge the default associative
-        update::
+        In ``update_state``, ``state_trial["stress"]`` is the **current σ NR
+        iterate**.  This helper is a no-op that returns it, provided for
+        symmetry with :meth:`default_stress_residual`.
 
-            def update_state(self, dlambda, state_n, state_trial):
-                sig = self.default_stress_update(dlambda, state_n, state_trial)
-                return [self.stress(sig), self.ep(state_n["ep"] + dlambda)]
-
-        For a non-associative or damage-coupled Explicit stress update, compute
-        ``sig`` directly (from your own formula) and return ``self.stress(sig)``
-        instead of calling this helper.
+        .. deprecated::
+            ``stress`` must no longer be returned from ``update_state``.
+            This method exists only for models that have not yet been updated.
+            The framework ignores any ``stress`` value returned by
+            ``update_state``; the NR system drives σ directly.
 
         Parameters
         ----------
         dlambda : scalar
-            Plastic multiplier increment Δλ (unused; present for API symmetry
-            with :meth:`default_stress_residual`).
+            Unused.
         state_n : State or dict
-            State at the beginning of the increment (unused by default).
+            Unused.
         state_trial : State or dict
-            Trial state; ``state_trial["stress"]`` is the framework-pre-computed associative σ iterate.
+            ``state_trial["stress"]`` is the current σ NR iterate.
 
         Returns
         -------

--- a/src/manforge/core/state.py
+++ b/src/manforge/core/state.py
@@ -280,7 +280,10 @@ def _validate_state_items(
     expected_cls,
     method_name: str,
     model_name: str,
-) -> dict:
+    *,
+    extract_dlambda: bool = False,
+    hint: str = "",
+) -> "dict | tuple[dict, Any]":
     """Validate a list of StateResidual / StateUpdate and return a name→value dict.
 
     Called at the framework boundary (residual.py / solver.py) after
@@ -298,11 +301,18 @@ def _validate_state_items(
         ``"state_residual"`` or ``"update_state"`` (used in error messages).
     model_name : str
         Class name of the model (used in error messages).
+    extract_dlambda : bool, optional
+        When ``True``, ``DlambdaResidual`` items are separated from the state
+        items and returned as the second element of a tuple.
+    hint : str, optional
+        Extra guidance appended to missing-key error messages.
 
     Returns
     -------
     dict[str, array-like]
-        Mapping from field name to value, suitable for ``_flatten_state``.
+        Mapping from field name to value (when ``extract_dlambda=False``).
+    tuple[dict[str, array-like], Any]
+        ``(state_dict, dlambda_value_or_None)`` when ``extract_dlambda=True``.
 
     Raises
     ------
@@ -318,11 +328,19 @@ def _validate_state_items(
             f"got {type(returned).__name__}"
         )
     out: dict = {}
+    dl_items = []
     for item in returned:
+        if extract_dlambda and isinstance(item, DlambdaResidual):
+            dl_items.append(item)
+            continue
         if not isinstance(item, expected_cls):
+            extra_info = (
+                f" (self.dlambda(...) is not allowed in {method_name})"
+                if isinstance(item, DlambdaResidual) else ""
+            )
             raise TypeError(
                 f"{model_name}.{method_name}: every item must be "
-                f"{expected_cls.__name__} (use `self.<field>(value)`), "
+                f"{expected_cls.__name__} (use `self.<field>(value)`){extra_info}, "
                 f"got {type(item).__name__}"
             )
         if item.name in out:
@@ -330,6 +348,10 @@ def _validate_state_items(
                 f"{model_name}.{method_name}: duplicate entry for {item.name!r}"
             )
         out[item.name] = item.value
+    if extract_dlambda and len(dl_items) > 1:
+        raise ValueError(
+            f"{model_name}.{method_name}: duplicate self.dlambda(...) entries"
+        )
     actual = set(out.keys())
     if actual != expected_names:
         parts = []
@@ -337,9 +359,14 @@ def _validate_state_items(
         extra = actual - expected_names
         if missing:
             parts.append(f"missing: {sorted(missing)}")
+            if hint:
+                parts.append(hint)
         if extra:
             parts.append(f"unexpected: {sorted(extra)}")
         raise ValueError(f"{model_name}.{method_name}: {'; '.join(parts)}")
+    if extract_dlambda:
+        r_dl = dl_items[0].value if dl_items else None
+        return out, r_dl
     return out
 
 

--- a/src/manforge/models/af_kinematic.py
+++ b/src/manforge/models/af_kinematic.py
@@ -47,7 +47,7 @@ Notes
 import autograd.numpy as anp
 
 from manforge.core.material import MaterialModel3D, MaterialModelPS, MaterialModel1D
-from manforge.core.state import Explicit, NTENS
+from manforge.core.state import Explicit, NTENS  # Explicit used for alpha, ep; NTENS for shape
 from manforge.core.dimension import SOLID_3D, PLANE_STRESS, UNIAXIAL_1D, StressDimension
 
 
@@ -75,7 +75,6 @@ class AFKinematic3D(MaterialModel3D):
     """
 
     param_names = ["E", "nu", "sigma_y0", "C_k", "gamma"]
-    stress = Explicit(shape=NTENS, doc="Cauchy stress")
     alpha = Explicit(shape=NTENS, doc="backstress tensor")
     ep = Explicit(shape=(), doc="equivalent plastic strain")
 
@@ -100,14 +99,13 @@ class AFKinematic3D(MaterialModel3D):
 
         where ŝ = dev(σ − α_n) / σ_vm(σ − α_n).
         """
-        sig = self.default_stress_update(dlambda, state_n, state_trial)
         alpha_n = state_n["alpha"]
         xi = state_trial["stress"] - alpha_n
         s_xi = self._dev(xi)
         vm_safe = self._vonmises(xi)
         n_hat = s_xi / vm_safe
         alpha_new = (alpha_n + self.C_k * dlambda * n_hat) / (1.0 + self.gamma * dlambda)
-        return [self.stress(sig), self.alpha(alpha_new), self.ep(state_n["ep"] + dlambda)]
+        return [self.alpha(alpha_new), self.ep(state_n["ep"] + dlambda)]
 
 
 class AFKinematicPS(MaterialModelPS):
@@ -134,7 +132,6 @@ class AFKinematicPS(MaterialModelPS):
     """
 
     param_names = ["E", "nu", "sigma_y0", "C_k", "gamma"]
-    stress = Explicit(shape=NTENS, doc="Cauchy stress")
     alpha = Explicit(shape=NTENS, doc="backstress tensor")
     ep = Explicit(shape=(), doc="equivalent plastic strain")
 
@@ -154,14 +151,13 @@ class AFKinematicPS(MaterialModelPS):
 
     def update_state(self, dlambda, state_n, state_trial) -> list:
         """Armstrong-Frederick backstress update."""
-        sig = self.default_stress_update(dlambda, state_n, state_trial)
         alpha_n = state_n["alpha"]
         xi = state_trial["stress"] - alpha_n
         s_xi = self._dev(xi)
         vm_safe = self._vonmises(xi)
         n_hat = s_xi / vm_safe
         alpha_new = (alpha_n + self.C_k * dlambda * n_hat) / (1.0 + self.gamma * dlambda)
-        return [self.stress(sig), self.alpha(alpha_new), self.ep(state_n["ep"] + dlambda)]
+        return [self.alpha(alpha_new), self.ep(state_n["ep"] + dlambda)]
 
 
 class AFKinematic1D(MaterialModel1D):
@@ -187,7 +183,6 @@ class AFKinematic1D(MaterialModel1D):
     """
 
     param_names = ["E", "nu", "sigma_y0", "C_k", "gamma"]
-    stress = Explicit(shape=NTENS, doc="Cauchy stress")
     alpha = Explicit(shape=NTENS, doc="backstress tensor")
     ep = Explicit(shape=(), doc="equivalent plastic strain")
 
@@ -207,11 +202,10 @@ class AFKinematic1D(MaterialModel1D):
 
     def update_state(self, dlambda, state_n, state_trial) -> list:
         """Armstrong-Frederick backstress update."""
-        sig = self.default_stress_update(dlambda, state_n, state_trial)
         alpha_n = state_n["alpha"]
         xi = state_trial["stress"] - alpha_n
         s_xi = self._dev(xi)
         vm_safe = self._vonmises(xi)
         n_hat = s_xi / vm_safe
         alpha_new = (alpha_n + self.C_k * dlambda * n_hat) / (1.0 + self.gamma * dlambda)
-        return [self.stress(sig), self.alpha(alpha_new), self.ep(state_n["ep"] + dlambda)]
+        return [self.alpha(alpha_new), self.ep(state_n["ep"] + dlambda)]

--- a/src/manforge/models/j2_isotropic.py
+++ b/src/manforge/models/j2_isotropic.py
@@ -25,7 +25,7 @@ dε_p = Δλ · n,  n = df/dσ = (3/2) s / σ_vm  (unit normal in Mandel sense)
 import autograd.numpy as anp
 
 from manforge.core.material import MaterialModel3D, MaterialModelPS, MaterialModel1D
-from manforge.core.state import Explicit, NTENS
+from manforge.core.state import Explicit
 from manforge.core.dimension import SOLID_3D, PLANE_STRESS, UNIAXIAL_1D, StressDimension
 from manforge.core.result import ReturnMappingResult
 from manforge.verification.fortran_registry import verified_against_fortran
@@ -71,7 +71,6 @@ class J2Isotropic3D(MaterialModel3D):
     """
 
     param_names = ["E", "nu", "sigma_y0", "H"]
-    stress = Explicit(shape=NTENS, doc="Cauchy stress")
     ep = Explicit(shape=(), doc="equivalent plastic strain")
 
     def __init__(self, dimension: StressDimension = SOLID_3D, *,
@@ -89,8 +88,7 @@ class J2Isotropic3D(MaterialModel3D):
 
     def update_state(self, dlambda, state_n, state_trial) -> list:
         """Δep = Δλ (von Mises associative flow)."""
-        sig = self.default_stress_update(dlambda, state_n, state_trial)
-        return [self.stress(sig), self.ep(state_n["ep"] + dlambda)]
+        return [self.ep(state_n["ep"] + dlambda)]
 
     # ------------------------------------------------------------------
     # Analytical solver hooks
@@ -197,7 +195,6 @@ class J2IsotropicPS(MaterialModelPS):
     """
 
     param_names = ["E", "nu", "sigma_y0", "H"]
-    stress = Explicit(shape=NTENS, doc="Cauchy stress")
     ep = Explicit(shape=(), doc="equivalent plastic strain")
 
     def __init__(self, dimension: StressDimension = PLANE_STRESS, *,
@@ -215,8 +212,7 @@ class J2IsotropicPS(MaterialModelPS):
 
     def update_state(self, dlambda, state_n, state_trial) -> list:
         """Δep = Δλ (von Mises associative flow)."""
-        sig = self.default_stress_update(dlambda, state_n, state_trial)
-        return [self.stress(sig), self.ep(state_n["ep"] + dlambda)]
+        return [self.ep(state_n["ep"] + dlambda)]
 
 
 class J2Isotropic1D(MaterialModel1D):
@@ -241,7 +237,6 @@ class J2Isotropic1D(MaterialModel1D):
     """
 
     param_names = ["E", "nu", "sigma_y0", "H"]
-    stress = Explicit(shape=NTENS, doc="Cauchy stress")
     ep = Explicit(shape=(), doc="equivalent plastic strain")
 
     def __init__(self, dimension: StressDimension = UNIAXIAL_1D, *,
@@ -259,8 +254,7 @@ class J2Isotropic1D(MaterialModel1D):
 
     def update_state(self, dlambda, state_n, state_trial) -> list:
         """Δep = Δλ (von Mises associative flow)."""
-        sig = self.default_stress_update(dlambda, state_n, state_trial)
-        return [self.stress(sig), self.ep(state_n["ep"] + dlambda)]
+        return [self.ep(state_n["ep"] + dlambda)]
 
     # ------------------------------------------------------------------
     # Analytical solver hooks

--- a/src/manforge/models/ow_kinematic.py
+++ b/src/manforge/models/ow_kinematic.py
@@ -105,7 +105,7 @@ class OWKinematic3D(MaterialModel3D):
         xi = state["stress"] - state["alpha"]
         return self._vonmises(xi) - self.sigma_y0
 
-    def state_residual(self, state_new, dlambda, state_n, state_trial) -> list:
+    def state_residual(self, state_new, dlambda, state_n, state_trial, *, stress_trial) -> list:
         """Ohno-Wang implicit backstress residual.
 
         R_α = α_{n+1} − α_n − C_k Δλ n̂ + γ Δλ ‖α_{n+1}‖ α_{n+1} = 0
@@ -123,7 +123,7 @@ class OWKinematic3D(MaterialModel3D):
 
         alpha_vm = self._vonmises(alpha_new)
 
-        R_stress = self.default_stress_residual(state_new, dlambda, state_trial)
+        R_stress = self.default_stress_residual(state_new, dlambda, stress_trial)
         R_alpha = (
             alpha_new
             - state_n["alpha"]
@@ -175,7 +175,7 @@ class OWKinematicPS(MaterialModelPS):
         xi = state["stress"] - state["alpha"]
         return self._vonmises(xi) - self.sigma_y0
 
-    def state_residual(self, state_new, dlambda, state_n, state_trial) -> list:
+    def state_residual(self, state_new, dlambda, state_n, state_trial, *, stress_trial) -> list:
         """Ohno-Wang implicit backstress residual (plane stress)."""
         alpha_new = state_new["alpha"]
         stress_new = state_new["stress"]
@@ -184,7 +184,7 @@ class OWKinematicPS(MaterialModelPS):
         vm_safe = self._vonmises(xi)
         n_hat = s_xi / vm_safe
         alpha_vm = self._vonmises(alpha_new)
-        R_stress = self.default_stress_residual(state_new, dlambda, state_trial)
+        R_stress = self.default_stress_residual(state_new, dlambda, stress_trial)
         R_alpha = (
             alpha_new
             - state_n["alpha"]
@@ -235,7 +235,7 @@ class OWKinematic1D(MaterialModel1D):
         xi = state["stress"] - state["alpha"]
         return self._vonmises(xi) - self.sigma_y0
 
-    def state_residual(self, state_new, dlambda, state_n, state_trial) -> list:
+    def state_residual(self, state_new, dlambda, state_n, state_trial, *, stress_trial) -> list:
         """Ohno-Wang implicit backstress residual (1D)."""
         alpha_new = state_new["alpha"]
         stress_new = state_new["stress"]
@@ -244,7 +244,7 @@ class OWKinematic1D(MaterialModel1D):
         vm_safe = self._vonmises(xi)
         n_hat = s_xi / vm_safe
         alpha_vm = self._vonmises(alpha_new)
-        R_stress = self.default_stress_residual(state_new, dlambda, state_trial)
+        R_stress = self.default_stress_residual(state_new, dlambda, stress_trial)
         R_alpha = (
             alpha_new
             - state_n["alpha"]

--- a/src/manforge/simulation/_layout.py
+++ b/src/manforge/simulation/_layout.py
@@ -1,0 +1,170 @@
+"""ResidualLayout — central descriptor for the NR unknown/residual vector layout.
+
+Unknown vector:   x = [σ (ntens) | Δλ (1) | q_implicit_non_stress (n_imp, declaration order)]
+Residual vector:  R = [R_σ (ntens) | R_Δλ (1) | R_q_non_stress (n_imp, declaration order)]
+
+All slice/pack/unpack logic lives here so that _residual.py, integrator/base.py,
+and verification/jacobian.py share a single source of truth.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import autograd.numpy as anp
+import numpy as np
+
+if TYPE_CHECKING:
+    pass
+
+
+@dataclass(frozen=True)
+class ResidualLayout:
+    """Descriptor for the augmented NR residual system.
+
+    Parameters
+    ----------
+    ntens : int
+        Number of stress/strain components.
+    stress_kind : str
+        ``"implicit"`` when stress is declared ``Implicit``; ``"explicit"`` otherwise.
+    implicit_keys : tuple[str, ...]
+        Names of non-stress implicit state variables, **in declaration order**.
+    explicit_keys : tuple[str, ...]
+        Names of non-stress explicit state variables, in declaration order.
+    _shapes : tuple[tuple[str, tuple[int, ...]], ...]
+        ``(name, shape)`` pairs for each key in ``implicit_keys``, in the same order.
+        Shapes are concrete Python tuples (no NTENS sentinel).
+    """
+
+    ntens: int
+    stress_kind: str                                        # "implicit" | "explicit"
+    implicit_keys: tuple                                    # declaration order, stress excluded
+    explicit_keys: tuple                                    # declaration order, stress excluded
+    _shapes: tuple                                          # (name, shape) for implicit_keys
+
+    # ------------------------------------------------------------------
+    # Factory
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_model(cls, model) -> "ResidualLayout":
+        """Build a ResidualLayout from a MaterialModel instance."""
+        ntens = model.ntens
+        stress_kind = model.state_fields["stress"].kind
+        implicit_keys = tuple(
+            k for k in model.state_names
+            if k != "stress" and model.state_fields[k].kind == "implicit"
+        )
+        explicit_keys = tuple(
+            k for k in model.state_names
+            if k != "stress" and model.state_fields[k].kind == "explicit"
+        )
+        shapes = tuple(
+            (k, model.state_fields[k].resolve_shape(ntens))
+            for k in implicit_keys
+        )
+        return cls(
+            ntens=ntens,
+            stress_kind=stress_kind,
+            implicit_keys=implicit_keys,
+            explicit_keys=explicit_keys,
+            _shapes=shapes,
+        )
+
+    # ------------------------------------------------------------------
+    # Derived properties
+    # ------------------------------------------------------------------
+
+    @property
+    def is_stress_implicit(self) -> bool:
+        return self.stress_kind == "implicit"
+
+    @property
+    def n_implicit(self) -> int:
+        return sum(int(np.prod(s)) for _, s in self._shapes)
+
+    @property
+    def n_unknown(self) -> int:
+        return self.ntens + 1 + self.n_implicit
+
+    # ------------------------------------------------------------------
+    # Slice helpers
+    # ------------------------------------------------------------------
+
+    def stress_slice(self) -> slice:
+        return slice(0, self.ntens)
+
+    def dlambda_index(self) -> int:
+        return self.ntens
+
+    def state_slice(self, name: str) -> slice:
+        """Return the slice of the implicit-state block for *name*.
+
+        The slice is relative to the start of the state block (i.e. offset ntens+1
+        must be added by the caller when indexing into the full x or R vector).
+        """
+        offset = 0
+        for k, shp in self._shapes:
+            size = int(np.prod(shp))
+            if k == name:
+                return slice(offset, offset + size)
+            offset += size
+        raise KeyError(f"ResidualLayout: {name!r} is not an implicit non-stress key")
+
+    # ------------------------------------------------------------------
+    # Pack / unpack
+    # ------------------------------------------------------------------
+
+    def pack(self, sigma, dlambda, q_imp: dict):
+        """Assemble the unknown vector x from its components.
+
+        Parameters
+        ----------
+        sigma : array-like, shape (ntens,)
+        dlambda : scalar
+        q_imp : dict mapping implicit_keys → array
+            Only non-stress implicit states.  Missing keys default to zero.
+        """
+        parts = [anp.array(sigma), anp.atleast_1d(anp.array(dlambda))]
+        for k, shp in self._shapes:
+            v = q_imp.get(k, np.zeros(shp))
+            parts.append(anp.reshape(v, (-1,)) if shp else anp.atleast_1d(v))
+        return anp.concatenate(parts) if len(parts) > 1 else parts[0]
+
+    def unpack(self, x) -> tuple:
+        """Decompose x into (sigma, dlambda, q_imp_dict).
+
+        Returns
+        -------
+        sigma : array, shape (ntens,)
+        dlambda : scalar
+        q_imp : dict[str, array]
+        """
+        ntens = self.ntens
+        sigma = x[:ntens]
+        dlambda = x[ntens]
+        q_imp: dict = {}
+        idx = ntens + 1
+        for k, shp in self._shapes:
+            size = int(np.prod(shp))
+            chunk = x[idx: idx + size]
+            q_imp[k] = chunk.reshape(shp) if shp else chunk[0]
+            idx += size
+        return sigma, dlambda, q_imp
+
+    def pack_residual(self, R_stress, R_dlambda, R_state: dict):
+        """Assemble the residual vector R from its components.
+
+        Parameters
+        ----------
+        R_stress : array-like, shape (ntens,)
+        R_dlambda : scalar
+        R_state : dict mapping implicit_keys → array (may be empty)
+        """
+        parts = [anp.array(R_stress), anp.atleast_1d(R_dlambda)]
+        for k, shp in self._shapes:
+            v = R_state[k]
+            parts.append(anp.reshape(v, (-1,)) if shp else anp.atleast_1d(v))
+        return anp.concatenate(parts)

--- a/src/manforge/simulation/_residual.py
+++ b/src/manforge/simulation/_residual.py
@@ -4,43 +4,9 @@ import autograd.numpy as anp
 import numpy as np
 
 from manforge.core.state import (
-    StateResidual, StateUpdate, DlambdaResidual, State,
+    StateResidual, StateUpdate, _validate_state_items, State,
 )
-
-
-# ---------------------------------------------------------------------------
-# State flatten / unflatten helpers
-# ---------------------------------------------------------------------------
-
-def _flatten_state(state: dict):
-    """Flatten a state dict to a 1-D array (alphabetical key order).
-
-    Returns
-    -------
-    vec : array, shape (n_state,)
-    shapes : list of (key, shape) pairs — shapes are plain Python tuples,
-             safe to inspect outside of autograd's tracing context.
-    """
-    keys = sorted(state.keys())
-    shapes = [(k, np.asarray(state[k]).shape) for k in keys]
-    parts = []
-    for k, shp in shapes:
-        v = state[k]
-        parts.append(anp.reshape(v, (-1,)) if shp else anp.atleast_1d(v))
-    vec = anp.concatenate(parts) if parts else anp.zeros(0)
-    return vec, shapes
-
-
-def _unflatten_state(vec, shapes: list) -> dict:
-    """Reconstruct a state dict from a flat array and shape metadata."""
-    out = {}
-    idx = 0
-    for k, shp in shapes:
-        size = int(np.prod(shp)) if shp else 1
-        chunk = vec[idx: idx + size]
-        out[k] = chunk.reshape(shp) if shp else chunk[0]
-        idx += size
-    return out
+from manforge.simulation._layout import ResidualLayout
 
 
 # ---------------------------------------------------------------------------
@@ -53,238 +19,150 @@ def _wrap_state(data: dict, model) -> State:
 
 
 # ---------------------------------------------------------------------------
-# User method call helpers
-# ---------------------------------------------------------------------------
-
-def _call_update_state(model, dlambda, state_n_dict, state_trial_dict,
-                       expected_explicit_keys, model_name, require_stress=True):
-    """Call model.update_state(dlambda, state_n, state_trial) → dict.
-
-    *expected_explicit_keys* must NOT include "stress".  When *require_stress*
-    is True (the default), the returned list MUST include "stress".  Pass
-    ``require_stress=False`` when stress is Implicit and update_state is only
-    called for non-stress explicit states.
-    """
-    state_n = _wrap_state(state_n_dict, model)
-    state_trial = _wrap_state(state_trial_dict, model)
-    returned = model.update_state(dlambda, state_n, state_trial)
-    if not isinstance(returned, list):
-        raise TypeError(
-            f"{model_name}.update_state must return a list of StateUpdate "
-            f"(use `self.<field>(value)`), got {type(returned).__name__}"
-        )
-    for item in returned:
-        if isinstance(item, DlambdaResidual):
-            raise TypeError(
-                f"{model_name}.update_state: self.dlambda(...) is not allowed in "
-                "update_state (Δλ has no explicit update rule). "
-                "Use state_residual to override the Δλ residual instead."
-            )
-        if not isinstance(item, StateUpdate):
-            raise TypeError(
-                f"{model_name}.update_state: every item must be StateUpdate, "
-                f"got {type(item).__name__}"
-            )
-    expected_all = (expected_explicit_keys | {"stress"}) if require_stress else expected_explicit_keys
-    actual_keys = {item.name for item in returned}
-    if actual_keys != expected_all:
-        extra = actual_keys - expected_all
-        missing = expected_all - actual_keys
-        parts = []
-        if extra:
-            parts.append(f"unexpected keys: {sorted(extra)}")
-        if missing:
-            parts.append(f"missing keys: {sorted(missing)}")
-            if "stress" in missing:
-                parts.append(
-                    "Hint: add self.stress(self.default_stress_update(dlambda, state_n, state_trial))"
-                    " for associative flow, or self.stress(sig_new) for custom update"
-                )
-        raise ValueError(
-            f"{model_name}.update_state() returned wrong keys "
-            f"({'; '.join(parts)}). Expected: {sorted(expected_all)}"
-        )
-    return {item.name: item.value for item in returned}
-
-
-def _call_state_residual(model, state_new_dict, dlambda, state_n_dict, state_trial_dict,
-                         expected_implicit_keys, model_name):
-    """Call model.state_residual(state_new, dlambda, state_n, state_trial).
-
-    *expected_implicit_keys* must NOT include "stress".  The returned list
-    MUST include "stress" when stress is Implicit.
-
-    Returns
-    -------
-    tuple
-        ``(state_dict, r_dlambda_or_None)``
-    """
-    stress_field = model.state_fields["stress"]
-    do_implicit_stress = stress_field.kind == "implicit"
-    expected_all = (expected_implicit_keys | {"stress"}) if do_implicit_stress else expected_implicit_keys
-
-    state_new = _wrap_state(state_new_dict, model)
-    state_n = _wrap_state(state_n_dict, model)
-    state_trial = _wrap_state(state_trial_dict, model)
-    returned = model.state_residual(state_new, dlambda, state_n, state_trial)
-
-    if not isinstance(returned, list):
-        raise TypeError(
-            f"{model_name}.state_residual must return a list of StateResidual "
-            f"(use `self.<field>(value)`, optionally `self.dlambda(R)`), "
-            f"got {type(returned).__name__}"
-        )
-    state_items = []
-    dl_items = []
-    for item in returned:
-        if isinstance(item, DlambdaResidual):
-            dl_items.append(item)
-        elif isinstance(item, StateResidual):
-            state_items.append(item)
-        else:
-            raise TypeError(
-                f"{model_name}.state_residual: every item must be StateResidual "
-                f"or DlambdaResidual (self.dlambda(R)), "
-                f"got {type(item).__name__}"
-            )
-    if len(dl_items) > 1:
-        raise ValueError(
-            f"{model_name}.state_residual: duplicate self.dlambda(...) entries"
-        )
-    r_dl = dl_items[0].value if dl_items else None
-
-    actual_keys = {item.name for item in state_items}
-    if actual_keys != expected_all:
-        extra = actual_keys - expected_all
-        missing = expected_all - actual_keys
-        parts = []
-        if extra:
-            parts.append(f"unexpected keys: {sorted(extra)}")
-        if missing:
-            parts.append(f"missing keys: {sorted(missing)}")
-            if "stress" in missing:
-                parts.append(
-                    "Hint: add self.stress(self.default_stress_residual(state_new, dlambda, state_trial))"
-                    " for associative flow, or self.stress(R_custom) for non-associative"
-                )
-        raise ValueError(
-            f"{model_name}.state_residual() returned wrong keys "
-            f"({'; '.join(parts)}). Expected: {sorted(expected_all)}"
-        )
-    return {item.name: item.value for item in state_items}, r_dl
-
-
-# ---------------------------------------------------------------------------
 # Unified residual builder
 # ---------------------------------------------------------------------------
 
 def build_residual(model, stress_trial, state_n):
     """Build the unified NR/tangent residual function.
 
-    σ is always an independent variable.  Unknown vector layout::
+    Unknown / residual vector layout (declaration order, stress-first)::
 
-        x = [σ (ntens)] + [Δλ (1)] + [q_implicit_non_stress (n_imp)]?
+        x = [σ (ntens)] + [Δλ (1)] + [q_implicit_non_stress (declaration order)]
+        R = [R_σ (ntens)] + [R_Δλ (1)] + [R_q_non_stress (declaration order)]
 
-    This function serves both the NR phase (iterated until convergence) and
-    the tangent/Jacobian phase (Jacobian evaluated at the converged point).
+    σ is always an independent variable.  This function serves both the NR
+    phase (iterated until convergence) and the tangent/Jacobian phase
+    (Jacobian evaluated at the converged point).
 
-    For ``stress = Explicit`` models, R_stress is the default associative
-    residual (σ − σ_trial + Δλ·C·∂f/∂σ = 0).  The user's ``update_state``
-    result for stress is accepted (for validation) but ignored; σ_NR drives
-    the iteration.
+    ``state_trial["stress"]`` passed to ``update_state`` and ``state_residual``
+    is always the **current σ NR iterate**.  For models with
+    ``stress = Implicit``, the fixed elastic predictor σ_trial is provided
+    separately via the ``stress_trial`` keyword argument to ``state_residual``.
 
     Returns
     -------
-    residual_fn : callable(x) -> R  of size n_unknown
-    n_unknown : int  (= ntens + 1 + n_implicit)
-    unflatten_implicit : callable(flat) -> dict
+    residual_fn : callable(x) -> array of size layout.n_unknown
+        Autograd-differentiable residual function.
+    layout : ResidualLayout
+        Layout descriptor (pack/unpack/slice helpers).
     """
     from manforge.core.material import MaterialModel as _MaterialModel
-    ntens = model.ntens
-    stress_field = model.state_fields["stress"]
-    do_implicit_stress = (stress_field.kind == "implicit")
-    implicit_keys_non_stress = sorted(k for k in model.implicit_state_names if k != "stress")
-    explicit_keys_non_stress = set(
-        k for k in model.state_names
-        if k != "stress" and k not in model.implicit_state_names
-    )
+    layout = ResidualLayout.from_model(model)
     model_name = type(model).__name__
+    stress_trial_arr = anp.array(stress_trial)
     user_has_state_residual = (type(model).state_residual is not _MaterialModel.state_residual)
 
-    implicit_state_n = {k: state_n[k] for k in implicit_keys_non_stress}
-    flat_impl_n, implicit_shapes = _flatten_state(implicit_state_n)
-    n_implicit = len(flat_impl_n)
-
-    stress_trial_arr = anp.array(stress_trial)
-
-    def unflatten_implicit(flat):
-        return _unflatten_state(flat, implicit_shapes)
-
-    n_unknown = ntens + 1 + n_implicit
+    if layout.is_stress_implicit and not user_has_state_residual:
+        raise ValueError(
+            f"{model_name}: stress is Implicit but state_residual() is not implemented "
+            "— this should not happen."
+        )
 
     def residual_fn(x):
-        sig = x[:ntens]
-        dlambda = x[ntens]
-        q_imp = unflatten_implicit(x[ntens + 1:]) if n_implicit > 0 else {}
+        sigma, dlambda, q_imp = layout.unpack(x)
 
-        # state_trial for update_state: stress = current σ iterate
+        # state_trial["stress"] = current σ iterate for update_state
         state_trial_for_update = dict(state_n)
-        state_trial_for_update["stress"] = sig
+        state_trial_for_update["stress"] = sigma
 
-        # Compute non-stress explicit states
-        if explicit_keys_non_stress:
-            q_exp = _call_update_state(
-                model, dlambda, state_n, state_trial_for_update,
-                explicit_keys_non_stress, model_name,
-                require_stress=(not do_implicit_stress),
+        # Explicit non-stress states
+        q_exp: dict = {}
+        if layout.explicit_keys:
+            expected_explicit = set(layout.explicit_keys)
+            state_n_wrapped = _wrap_state(state_n, model)
+            trial_wrapped = _wrap_state(state_trial_for_update, model)
+            returned = model.update_state(dlambda, state_n_wrapped, trial_wrapped)
+            q_exp = _validate_state_items(
+                returned, expected_explicit, StateUpdate,
+                "update_state", model_name,
             )
-            q_full = {"stress": sig, **q_imp,
-                      **{k: v for k, v in q_exp.items() if k != "stress"}}
-        else:
-            q_full = {"stress": sig, **q_imp}
 
+        # Assemble full state
+        q_full = {"stress": sigma, **q_imp, **q_exp}
         q_full_state = _wrap_state(q_full, model)
 
-        # Collect optional R_dλ override and implicit-state residuals from state_residual
-        R_state_dict = {}
+        # Collect R_state and optional R_Δλ from state_residual
+        R_state_dict: dict = {}
         r_dl_override = None
         if user_has_state_residual:
+            expected_implicit = set(layout.implicit_keys)
+            if layout.is_stress_implicit:
+                expected_implicit = expected_implicit | {"stress"}
+            state_new_wrapped = _wrap_state(q_full, model)
+            state_n_wrapped = _wrap_state(state_n, model)
+            # state_trial["stress"] = current σ iterate (for flow direction / backstress)
             state_trial_for_residual = dict(state_n)
-            if do_implicit_stress:
-                # Implicit stress: state_trial["stress"] must be the fixed σ_trial so that
-                # R_stress = σ − σ_trial + ... differentiates correctly w.r.t. the iterate σ.
-                state_trial_for_residual["stress"] = stress_trial_arr
-            else:
-                # Explicit stress: pass current σ iterate so the user can evaluate
-                # flow direction / backstress direction at the current state.
-                state_trial_for_residual["stress"] = sig
-            R_state_dict, r_dl_override = _call_state_residual(
-                model, q_full, dlambda, state_n, state_trial_for_residual,
-                set(implicit_keys_non_stress), model_name,
+            state_trial_for_residual["stress"] = sigma
+            trial_wrapped = _wrap_state(state_trial_for_residual, model)
+            returned = model.state_residual(
+                state_new_wrapped, dlambda, state_n_wrapped, trial_wrapped,
+                stress_trial=stress_trial_arr,
             )
-        elif do_implicit_stress:
-            raise ValueError(
-                f"{model_name}: stress is Implicit but state_residual() is not implemented "
-                "— this should not happen."
+            hint = (
+                "add self.stress(self.default_stress_residual(state_new, dlambda, stress_trial))"
+                " for associative flow, or self.stress(R_custom) for non-associative"
+                if layout.is_stress_implicit else ""
+            )
+            R_state_dict, r_dl_override = _validate_state_items(
+                returned, expected_implicit, StateResidual,
+                "state_residual", model_name,
+                extract_dlambda=True,
+                hint=hint,
             )
 
-        # Δλ row: user override if provided, else yield_function default
+        # Δλ row
         R_dl = r_dl_override if r_dl_override is not None else model.yield_function(q_full_state)
 
-        # Stress residual row
-        if do_implicit_stress:
+        # σ row
+        if layout.is_stress_implicit:
             R_stress = R_state_dict["stress"]
         else:
             R_stress = model.default_stress_residual(
-                q_full_state, dlambda, {"stress": stress_trial_arr}
+                q_full_state, dlambda, stress_trial_arr
             )
 
-        R_state_non_stress = {k: v for k, v in R_state_dict.items() if k != "stress"}
-        parts = [R_stress, anp.atleast_1d(R_dl)]
-        if R_state_non_stress:
-            R_flat, _ = _flatten_state(R_state_non_stress)
-            parts.append(R_flat)
+        # Non-stress implicit state rows
+        R_q = {k: R_state_dict[k] for k in layout.implicit_keys}
 
-        return anp.concatenate(parts)
+        return layout.pack_residual(R_stress, R_dl, R_q)
 
-    return residual_fn, n_unknown, unflatten_implicit
+    return residual_fn, layout
+
+
+# ---------------------------------------------------------------------------
+# Post-convergence state reconstruction
+# ---------------------------------------------------------------------------
+
+def build_state_from_x(model, x_conv, state_n, layout: ResidualLayout) -> dict:
+    """Reconstruct the full state dict from a converged NR solution vector.
+
+    Calls ``update_state`` once to obtain explicit non-stress states, then
+    assembles ``{"stress": σ, **q_imp, **q_exp}``.
+
+    Parameters
+    ----------
+    model : MaterialModel
+    x_conv : array-like
+        Converged NR unknown vector.
+    state_n : dict
+        State at the beginning of the increment.
+    layout : ResidualLayout
+
+    Returns
+    -------
+    dict
+        Full state dict including ``"stress"``.
+    """
+    sigma, dlambda, q_imp = layout.unpack(np.asarray(x_conv))
+    q_exp: dict = {}
+    if layout.explicit_keys:
+        state_trial_dict = dict(state_n)
+        state_trial_dict["stress"] = sigma
+        state_n_wrapped = _wrap_state(state_n, model)
+        trial_wrapped = _wrap_state(state_trial_dict, model)
+        returned = model.update_state(dlambda, state_n_wrapped, trial_wrapped)
+        q_exp = _validate_state_items(
+            returned, set(layout.explicit_keys), StateUpdate,
+            "update_state", type(model).__name__,
+        )
+    return {"stress": sigma, **q_imp, **q_exp}

--- a/src/manforge/simulation/integrator/base.py
+++ b/src/manforge/simulation/integrator/base.py
@@ -8,7 +8,8 @@ import numpy as np
 
 from manforge.core.result import ReturnMappingResult, StressUpdateResult
 from manforge.core.dimension import StressDimension
-from manforge.simulation._residual import build_residual, _flatten_state, _wrap_state
+from manforge.simulation._residual import build_residual, build_state_from_x, _wrap_state
+from manforge.simulation._layout import ResidualLayout
 from manforge.core.state import _state_with_stress
 
 
@@ -115,30 +116,14 @@ class _PythonIntegratorBase:
     def _numerical_newton(self, stress_trial, state_n):
         """Unified NR return mapping.
 
-        Uses self._model / self._max_iter / self._tol / self._raise_on_nonconverged.
-        Unknown vector: x = [σ (ntens), Δλ (1), q_implicit_non_stress (n_imp)].
+        Unknown vector: x = [σ (ntens), Δλ (1), q_implicit_non_stress (declaration order)].
         """
-        from manforge.simulation._residual import _call_update_state
         model = self._model
-        ntens = model.ntens
-        implicit_keys_non_stress = sorted(
-            k for k in model.implicit_state_names if k != "stress"
-        )
-        explicit_keys_non_stress = set(
-            k for k in model.state_names
-            if k != "stress" and k not in model.implicit_state_names
-        )
-        do_implicit_stress = model.state_fields["stress"].kind == "implicit"
+        residual_fn, layout = build_residual(model, stress_trial, state_n)
 
-        residual_fn, n_unknown, unflatten_implicit = build_residual(
-            model, stress_trial, state_n
-        )
-        n_implicit = n_unknown - ntens - 1
-
-        implicit_state_n = {k: state_n[k] for k in implicit_keys_non_stress}
-        flat_impl_n, _ = _flatten_state(implicit_state_n)
-        x = anp.concatenate(
-            [anp.array(stress_trial), anp.array([0.0]), flat_impl_n]
+        x = layout.pack(
+            stress_trial, 0.0,
+            {k: state_n[k] for k in layout.implicit_keys}
         )
 
         residual_history = []
@@ -164,27 +149,17 @@ class _PythonIntegratorBase:
                 f"tol = {self._tol:.3e})"
             )
 
-        stress = x[:ntens]
-        dlambda_val = x[ntens]
-        q_imp = unflatten_implicit(x[ntens + 1:]) if n_implicit > 0 else {}
-        model_name = type(model).__name__
+        state_new = build_state_from_x(model, x, state_n, layout)
+        sigma, dlambda_val, _ = layout.unpack(np.asarray(x))
 
-        if explicit_keys_non_stress:
-            state_trial_dict = dict(state_n)
-            state_trial_dict["stress"] = stress
-            q_exp = _call_update_state(
-                model, dlambda_val, state_n, state_trial_dict,
-                explicit_keys_non_stress, model_name,
-                require_stress=(not do_implicit_stress),
-            )
-            if not do_implicit_stress and "stress" in q_exp:
-                stress = q_exp["stress"]
-            state_new = {"stress": stress, **q_imp,
-                         **{k: v for k, v in q_exp.items() if k != "stress"}}
-        else:
-            state_new = {"stress": stress, **q_imp}
-
-        return stress, state_new, anp.array(dlambda_val), n_iterations, residual_history, converged
+        return (
+            state_new["stress"],
+            state_new,
+            anp.array(dlambda_val),
+            n_iterations,
+            residual_history,
+            converged,
+        )
 
     def _consistent_tangent(self, rm, stress_n, state_n):
         """Consistent (algorithmic) tangent dσ_{n+1}/dΔε via implicit differentiation."""
@@ -204,40 +179,20 @@ class _PythonIntegratorBase:
         )(anp.array(stress))
         stress_trial = anp.array(stress) + float(dlambda) * (C_conv @ n_conv)
 
-        state_n_full = dict(state_n)
-        if "stress" not in state_n_full:
-            state_n_full["stress"] = anp.zeros(ntens)
-        implicit_keys_non_stress = sorted(
-            k for k in model.implicit_state_names if k != "stress"
-        )
-        implicit_state = {k: state[k] for k in implicit_keys_non_stress}
-        flat_impl, _ = _flatten_state(implicit_state)
+        residual_fn, layout = build_residual(model, stress_trial, state_n)
 
-        residual_fn, n_unknown, _ = build_residual(model, stress_trial, state_n_full)
-        x_conv = anp.concatenate(
-            [anp.array(stress), anp.array([float(dlambda)]), flat_impl]
-        )
-        A = autograd.jacobian(residual_fn)(x_conv)
+        q_imp = {k: state[k] for k in layout.implicit_keys}
+        x_conv = layout.pack(stress, dlambda, q_imp)
+
+        A = autograd.jacobian(residual_fn)(anp.array(x_conv))
         rhs = np.vstack(
-            [np.array(C_n), np.zeros((n_unknown - ntens, ntens))]
+            [np.array(C_n), np.zeros((layout.n_unknown - ntens, ntens))]
         )
         dxde = np.linalg.solve(np.array(A), rhs)
         return anp.array(dxde[:ntens, :])
 
     def return_mapping(self, stress_trial, state_n) -> ReturnMappingResult:
-        """Perform the plastic correction (return mapping) for one load increment.
-
-        Projects the elastic trial stress back onto the yield surface.
-        Does NOT compute the consistent tangent — call :meth:`stress_update`
-        for the complete constitutive integration including the tangent.
-
-        Parameters
-        ----------
-        stress_trial : array-like, shape (ntens,)
-            Elastic trial stress σ_trial = σ_n + C Δε.
-        state_n : dict
-            Internal state at the beginning of the increment.
-        """
+        """Perform the plastic correction (return mapping) for one load increment."""
         C_n = self._model.elastic_stiffness(state_n)
         rm = self._try_user_return_mapping(stress_trial, C_n, state_n)
         if rm is not None:
@@ -256,14 +211,10 @@ class _PythonIntegratorBase:
         )
 
     def stress_update(self, strain_inc, stress_n, state_n) -> StressUpdateResult:
-        """Perform a complete constitutive stress update for one load increment.
-
-        Executes: elastic trial → yield check → return mapping → consistent tangent.
-        """
+        """Perform a complete constitutive stress update for one load increment."""
         C_n = self._model.elastic_stiffness(state_n)
         stress_trial = stress_n + C_n @ strain_inc
 
-        # Yield check: build a state that includes stress for the new API
         from manforge.core.state import _state_with_stress as _swst
         state_trial = _swst(state_n, stress_trial)
         f_trial = self._model.yield_function(state_trial)

--- a/src/manforge/simulation/integrator/base.py
+++ b/src/manforge/simulation/integrator/base.py
@@ -9,7 +9,6 @@ import numpy as np
 from manforge.core.result import ReturnMappingResult, StressUpdateResult
 from manforge.core.dimension import StressDimension
 from manforge.simulation._residual import build_residual, build_state_from_x, _wrap_state
-from manforge.simulation._layout import ResidualLayout
 from manforge.core.state import _state_with_stress
 
 

--- a/src/manforge/verification/jacobian.py
+++ b/src/manforge/verification/jacobian.py
@@ -3,39 +3,122 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Iterator
 
 import autograd
 import autograd.numpy as anp
 import numpy as np
 
-from manforge.simulation._residual import build_residual, _flatten_state, _wrap_state
+from manforge.simulation._residual import build_residual
+from manforge.simulation._layout import ResidualLayout
 
 
 @dataclass
 class JacobianBlocks:
     """Named blocks of the return-mapping residual Jacobian at the converged point.
 
-    The Jacobian is computed from the tangent residual system where σ is
-    always an independent variable.  Explicit-state keys (not in
-    ``model.implicit_state_names``) do not appear in ``dstate_*`` fields.
+    The residual / unknown vector layout follows :class:`~manforge.simulation._layout.ResidualLayout`:
+    ``[σ (ntens) | Δλ (1) | q_implicit_non_stress (declaration order)]``.
+
+    Block naming convention: ``dR<row>_d<col>`` where the row / column labels are:
+
+    - ``sigma``   — the σ block (rows/cols 0 … ntens-1)
+    - ``dlambda`` — the Δλ row/col (index ntens)
+    - ``state``   — the implicit non-stress state block (rows/cols ntens+1 … )
+
+    State blocks are always ``dict[str, ndarray]`` (empty dict when there are no
+    implicit non-stress states), never ``None``.
+
+    Attributes
+    ----------
+    layout : ResidualLayout
+        Layout descriptor used to compute this Jacobian.
+    dRsigma_dsigma : ndarray, shape (ntens, ntens)
+        ∂R_σ / ∂σ
+    dRsigma_ddlambda : ndarray, shape (ntens,)
+        ∂R_σ / ∂Δλ
+    dRsigma_dstate : dict[str, ndarray]
+        ∂R_σ / ∂q_k for each implicit non-stress state key.
+    dRdlambda_dsigma : ndarray, shape (ntens,)
+        ∂R_Δλ / ∂σ  (gradient of the Δλ-row w.r.t. σ)
+    dRdlambda_ddlambda : float
+        ∂R_Δλ / ∂Δλ
+    dRdlambda_dstate : dict[str, ndarray]
+        ∂R_Δλ / ∂q_k for each implicit non-stress state key.
+    dRstate_dsigma : dict[str, ndarray]
+        ∂R_qj / ∂σ for each implicit non-stress key j.
+    dRstate_ddlambda : dict[str, ndarray]
+        ∂R_qj / ∂Δλ for each implicit non-stress key j.
+    dRstate_dstate : dict[str, dict[str, ndarray]]
+        ∂R_qj / ∂q_k (row j → col k → array).
+    full : ndarray, shape (n_unknown, n_unknown)
+        Full Jacobian matrix.
     """
 
-    dstress_dsigma: anp.ndarray
-    dstress_ddlambda: anp.ndarray
-    dyield_dsigma: anp.ndarray
-    dyield_ddlambda: anp.ndarray
-    dstress_dstate: dict | None
-    dyield_dstate: dict | None
-    dstate_dsigma: dict | None
-    dstate_ddlambda: dict | None
-    dstate_dstate: dict | None
+    layout: ResidualLayout
+
+    dRsigma_dsigma: anp.ndarray
+    dRsigma_ddlambda: anp.ndarray
+    dRsigma_dstate: dict
+
+    dRdlambda_dsigma: anp.ndarray
+    dRdlambda_ddlambda: float
+    dRdlambda_dstate: dict
+
+    dRstate_dsigma: dict
+    dRstate_ddlambda: dict
+    dRstate_dstate: dict
+
     full: anp.ndarray
+
+    def iter_blocks(self) -> Iterator[tuple[str, anp.ndarray]]:
+        """Iterate over all non-empty named blocks as ``(name, array)`` pairs.
+
+        Scalar blocks are yielded as-is; dict blocks are expanded with
+        ``"block_name::key"`` labels.
+
+        Useful for :func:`compare_jacobians`.
+        """
+        ntens = self.layout.ntens
+
+        yield "dRsigma_dsigma",   self.dRsigma_dsigma
+        yield "dRsigma_ddlambda", self.dRsigma_ddlambda
+        yield "dRdlambda_dsigma",    self.dRdlambda_dsigma
+        yield "dRdlambda_ddlambda",  np.atleast_1d(self.dRdlambda_ddlambda)
+
+        for name, d in [
+            ("dRsigma_dstate",   self.dRsigma_dstate),
+            ("dRdlambda_dstate",    self.dRdlambda_dstate),
+            ("dRstate_dsigma",  self.dRstate_dsigma),
+            ("dRstate_ddlambda", self.dRstate_ddlambda),
+        ]:
+            for key, arr in d.items():
+                yield f"{name}::{key}", np.asarray(arr)
+
+        for row_key, col_dict in self.dRstate_dstate.items():
+            for col_key, arr in col_dict.items():
+                yield f"dRstate_dstate::{row_key}::{col_key}", np.asarray(arr)
 
 
 def ad_jacobian_blocks(
     model, result, state_n: dict, *, stress_trial=None
 ) -> JacobianBlocks:
-    """Compute the residual Jacobian at the converged point and decompose into blocks."""
+    """Compute the residual Jacobian at the converged point and decompose into blocks.
+
+    Parameters
+    ----------
+    model : MaterialModel
+    result : StressUpdateResult or ReturnMappingResult
+        Converged result from a stress integration step.
+    state_n : dict
+        State at the beginning of the increment (must include ``"stress"``).
+    stress_trial : array-like, optional
+        Required when *result* is a :class:`~manforge.core.result.ReturnMappingResult`.
+
+    Returns
+    -------
+    JacobianBlocks
+    """
     from manforge.core.result import StressUpdateResult
 
     if isinstance(result, StressUpdateResult):
@@ -60,85 +143,50 @@ def ad_jacobian_blocks(
                 "stress_trial=... explicitly."
             )
 
-    ntens = model.ntens
-    implicit_keys_non_stress = sorted([k for k in model.implicit_state_names if k != "stress"])
-    implicit_state = {k: state[k] for k in implicit_keys_non_stress}
-    flat_impl, _ = _flatten_state(implicit_state)
-    n_implicit = len(flat_impl)
+    residual_fn, layout = build_residual(model, stress_trial, state_n)
+    ntens = layout.ntens
 
-    # state_n must include "stress" for tangent residual
-    state_n_full = dict(state_n)
-    if "stress" not in state_n_full:
-        state_n_full["stress"] = anp.zeros(ntens)
+    # Build the converged x vector
+    q_imp = {k: state[k] for k in layout.implicit_keys}
+    x_conv = layout.pack(stress, dlambda, q_imp)
 
-    residual_fn, _, _ = build_residual(model, stress_trial, state_n_full)
+    J = autograd.jacobian(residual_fn)(anp.array(x_conv))
 
-    x_conv = anp.concatenate([
-        anp.array(stress),
-        anp.array([float(dlambda)]),
-        flat_impl,
-    ])
-    J = autograd.jacobian(residual_fn)(x_conv)
-
-    dstress_dsigma   = J[:ntens, :ntens]
-    dstress_ddlambda = J[:ntens, ntens]
-    dyield_dsigma    = J[ntens, :ntens]
-    dyield_ddlambda  = J[ntens, ntens]
-
-    if n_implicit == 0:
-        return JacobianBlocks(
-            dstress_dsigma=dstress_dsigma,
-            dstress_ddlambda=dstress_ddlambda,
-            dyield_dsigma=dyield_dsigma,
-            dyield_ddlambda=dyield_ddlambda,
-            dstress_dstate=None,
-            dyield_dstate=None,
-            dstate_dsigma=None,
-            dstate_ddlambda=None,
-            dstate_dstate=None,
-            full=J,
-        )
-
-    slices = _build_state_slices(implicit_state, implicit_keys_non_stress)
-
-    dstress_dstate: dict = {}
-    dyield_dstate:  dict = {}
-    dstate_dsigma:  dict = {}
-    dstate_ddlambda: dict = {}
-    dstate_dstate:  dict = {}
+    dRsigma_dsigma    = J[:ntens, :ntens]
+    dRsigma_ddlambda  = J[:ntens, ntens]
+    dRdlambda_dsigma  = J[ntens, :ntens]
+    dRdlambda_ddlambda = J[ntens, ntens]
 
     q0 = ntens + 1
-    for key, sl in slices.items():
+    dRsigma_dstate:    dict = {}
+    dRdlambda_dstate:  dict = {}
+    dRstate_dsigma:    dict = {}
+    dRstate_ddlambda:  dict = {}
+    dRstate_dstate:    dict = {}
+
+    for k in layout.implicit_keys:
+        sl = layout.state_slice(k)
         q_sl = slice(q0 + sl.start, q0 + sl.stop)
-        dstress_dstate[key]  = J[:ntens, q_sl]
-        dyield_dstate[key]   = J[ntens, q_sl]
-        dstate_dsigma[key]   = J[q_sl, :ntens]
-        dstate_ddlambda[key] = J[q_sl, ntens]
-        dstate_dstate[key]   = {}
-        for key2, sl2 in slices.items():
+        dRsigma_dstate[k]   = J[:ntens, q_sl]
+        dRdlambda_dstate[k] = J[ntens, q_sl]
+        dRstate_dsigma[k]   = J[q_sl, :ntens]
+        dRstate_ddlambda[k] = J[q_sl, ntens]
+        dRstate_dstate[k]   = {}
+        for k2 in layout.implicit_keys:
+            sl2 = layout.state_slice(k2)
             q_sl2 = slice(q0 + sl2.start, q0 + sl2.stop)
-            dstate_dstate[key][key2] = J[q_sl, q_sl2]
+            dRstate_dstate[k][k2] = J[q_sl, q_sl2]
 
     return JacobianBlocks(
-        dstress_dsigma=dstress_dsigma,
-        dstress_ddlambda=dstress_ddlambda,
-        dyield_dsigma=dyield_dsigma,
-        dyield_ddlambda=dyield_ddlambda,
-        dstress_dstate=dstress_dstate,
-        dyield_dstate=dyield_dstate,
-        dstate_dsigma=dstate_dsigma,
-        dstate_ddlambda=dstate_ddlambda,
-        dstate_dstate=dstate_dstate,
+        layout=layout,
+        dRsigma_dsigma=dRsigma_dsigma,
+        dRsigma_ddlambda=dRsigma_ddlambda,
+        dRsigma_dstate=dRsigma_dstate,
+        dRdlambda_dsigma=dRdlambda_dsigma,
+        dRdlambda_ddlambda=dRdlambda_ddlambda,
+        dRdlambda_dstate=dRdlambda_dstate,
+        dRstate_dsigma=dRstate_dsigma,
+        dRstate_ddlambda=dRstate_ddlambda,
+        dRstate_dstate=dRstate_dstate,
         full=J,
     )
-
-
-def _build_state_slices(state: dict, keys: list) -> dict:
-    slices = {}
-    offset = 0
-    for key in keys:
-        val = np.asarray(state[key])
-        size = val.size
-        slices[key] = slice(offset, offset + size)
-        offset += size
-    return slices

--- a/src/manforge/verification/jacobian_compare.py
+++ b/src/manforge/verification/jacobian_compare.py
@@ -1,11 +1,9 @@
 """Jacobian block comparison for diagnosing failed crosschecks.
 
 :func:`compare_jacobians` compares the residual Jacobian blocks computed by
-:func:`~manforge.core.jacobian.ad_jacobian_blocks` for two
+:func:`~manforge.verification.jacobian.ad_jacobian_blocks` for two
 :class:`~manforge.core.result.StressUpdateResult` objects.  It is
-intended for manual use when a crosscheck fails:
-
-::
+intended for manual use when a crosscheck fails::
 
     cc = CrosscheckStrainDriver(int_a, int_b)
     for case in cc.iter_run(load):
@@ -32,8 +30,7 @@ class JacobianComparisonResult:
     passed : bool
         ``True`` if every block is within ``rtol``.
     blocks : dict[str, float]
-        Block name → maximum relative error.  Dict-valued blocks use
-        ``"block_name::var"`` as the key.
+        Block label → maximum relative error.
     max_rel_err : float
         Maximum relative error across all blocks.
     """
@@ -74,36 +71,18 @@ def compare_jacobians(
     jac_a = ad_jacobian_blocks(model, result_a, state_n)
     jac_b = ad_jacobian_blocks(model, result_b, state_n)
 
-    _SCALAR_BLOCKS = [
-        "dstress_dsigma",
-        "dstress_ddlambda",
-        "dyield_dsigma",
-        "dyield_ddlambda",
-    ]
-    _DICT_BLOCKS = [
-        "dstress_dstate",
-        "dyield_dstate",
-        "dstate_dsigma",
-        "dstate_ddlambda",
-        "dstate_dstate",
-    ]
-
     block_errs: dict[str, float] = {}
+    for label, arr_a in jac_a.iter_blocks():
+        # Find matching block in jac_b by iterating it too
+        # Simpler: collect jac_b into a dict first
+        pass
 
-    for name in _SCALAR_BLOCKS:
-        va = np.asarray(getattr(jac_a, name), dtype=float)
-        vb = np.asarray(getattr(jac_b, name), dtype=float)
-        block_errs[name] = _array_rel_err(va, vb)
+    blocks_b = {label: arr for label, arr in jac_b.iter_blocks()}
 
-    for name in _DICT_BLOCKS:
-        da = getattr(jac_a, name)
-        db = getattr(jac_b, name)
-        if da is None or db is None:
-            continue
-        for key in da:
-            va = np.asarray(da[key], dtype=float)
-            vb = np.asarray(db.get(key, np.zeros_like(va)), dtype=float)
-            block_errs[f"{name}::{key}"] = _array_rel_err(va, vb)
+    for label, arr_a in jac_a.iter_blocks():
+        arr_a = np.asarray(arr_a, dtype=float)
+        arr_b = np.asarray(blocks_b.get(label, np.zeros_like(arr_a)), dtype=float)
+        block_errs[label] = _array_rel_err(arr_a, arr_b)
 
     max_err = max(block_errs.values()) if block_errs else 0.0
 

--- a/src/manforge/verification/jacobian_compare.py
+++ b/src/manforge/verification/jacobian_compare.py
@@ -72,11 +72,6 @@ def compare_jacobians(
     jac_b = ad_jacobian_blocks(model, result_b, state_n)
 
     block_errs: dict[str, float] = {}
-    for label, arr_a in jac_a.iter_blocks():
-        # Find matching block in jac_b by iterating it too
-        # Simpler: collect jac_b into a dict first
-        pass
-
     blocks_b = {label: arr for label, arr in jac_b.iter_blocks()}
 
     for label, arr_a in jac_a.iter_blocks():

--- a/tests/fixtures/implicit_models.py
+++ b/tests/fixtures/implicit_models.py
@@ -28,7 +28,7 @@ class _AFKinematicImplicit3D(AFKinematic3D):
     alpha = Implicit(shape=NTENS, doc="backstress tensor (implicit override)")
     ep = Implicit(shape=(), doc="equivalent plastic strain (implicit override)")
 
-    def state_residual(self, state_new, dlambda, state_n, state_trial):
+    def state_residual(self, state_new, dlambda, state_n, state_trial, *, stress_trial):
         alpha_n = state_n["alpha"]
         stress = state_new["stress"]
         xi = stress - alpha_n
@@ -37,7 +37,7 @@ class _AFKinematicImplicit3D(AFKinematic3D):
         n_hat = s_xi / vm_safe
 
         scale = 1.0 + self.gamma * dlambda
-        R_stress = self.default_stress_residual(state_new, dlambda, state_trial)
+        R_stress = self.default_stress_residual(state_new, dlambda, stress_trial)
         R_alpha = state_new["alpha"] * scale - alpha_n - self.C_k * dlambda * n_hat
         R_ep = state_new["ep"] - state_n["ep"] - dlambda
         return [self.stress(R_stress), self.alpha(R_alpha), self.ep(R_ep)]
@@ -50,7 +50,7 @@ class _AFKinematicImplicitPS(AFKinematicPS):
     alpha = Implicit(shape=NTENS, doc="backstress tensor (implicit override)")
     ep = Implicit(shape=(), doc="equivalent plastic strain (implicit override)")
 
-    def state_residual(self, state_new, dlambda, state_n, state_trial):
+    def state_residual(self, state_new, dlambda, state_n, state_trial, *, stress_trial):
         alpha_n = state_n["alpha"]
         stress = state_new["stress"]
         xi = stress - alpha_n
@@ -59,7 +59,7 @@ class _AFKinematicImplicitPS(AFKinematicPS):
         n_hat = s_xi / vm_safe
 
         scale = 1.0 + self.gamma * dlambda
-        R_stress = self.default_stress_residual(state_new, dlambda, state_trial)
+        R_stress = self.default_stress_residual(state_new, dlambda, stress_trial)
         R_alpha = state_new["alpha"] * scale - alpha_n - self.C_k * dlambda * n_hat
         R_ep = state_new["ep"] - state_n["ep"] - dlambda
         return [self.stress(R_stress), self.alpha(R_alpha), self.ep(R_ep)]
@@ -76,7 +76,7 @@ class _AFKinematicImplicitPE(AFKinematic3D):
         super().__init__(dimension=PLANE_STRAIN,
                          E=210000.0, nu=0.3, sigma_y0=250.0, C_k=10000.0, gamma=100.0)
 
-    def state_residual(self, state_new, dlambda, state_n, state_trial):
+    def state_residual(self, state_new, dlambda, state_n, state_trial, *, stress_trial):
         alpha_n = state_n["alpha"]
         stress = state_new["stress"]
         xi = stress - alpha_n
@@ -85,7 +85,7 @@ class _AFKinematicImplicitPE(AFKinematic3D):
         n_hat = s_xi / vm_safe
 
         scale = 1.0 + self.gamma * dlambda
-        R_stress = self.default_stress_residual(state_new, dlambda, state_trial)
+        R_stress = self.default_stress_residual(state_new, dlambda, stress_trial)
         R_alpha = state_new["alpha"] * scale - alpha_n - self.C_k * dlambda * n_hat
         R_ep = state_new["ep"] - state_n["ep"] - dlambda
         return [self.stress(R_stress), self.alpha(R_alpha), self.ep(R_ep)]

--- a/tests/integration/test_dlambda_override.py
+++ b/tests/integration/test_dlambda_override.py
@@ -63,11 +63,9 @@ class _J2ScalarWithDlambdaOverride(MaterialModel3D):
         return self._vonmises(state["stress"]) - self.sigma_y0
 
     def update_state(self, dlambda, state_n, state_trial):
-        ep_new = state_n["ep"] + dlambda
-        stress_new = self.default_stress_update(dlambda, state_n, state_trial)
-        return [self.ep(ep_new), self.stress(stress_new)]
+        return [self.ep(state_n["ep"] + dlambda)]
 
-    def state_residual(self, state_new, dlambda, state_n, state_trial):
+    def state_residual(self, state_new, dlambda, state_n, state_trial, *, stress_trial):
         # Explicit override that is mathematically identical to the default
         return [self.dlambda(self.yield_function(state_new))]
 
@@ -91,9 +89,7 @@ class _J2ScalarDefault(MaterialModel3D):
         return self._vonmises(state["stress"]) - self.sigma_y0
 
     def update_state(self, dlambda, state_n, state_trial):
-        ep_new = state_n["ep"] + dlambda
-        stress_new = self.default_stress_update(dlambda, state_n, state_trial)
-        return [self.ep(ep_new), self.stress(stress_new)]
+        return [self.ep(state_n["ep"] + dlambda)]
 
 
 def _plastic_strain_increment():
@@ -172,7 +168,7 @@ class _KinematicWithDlambdaOverride(MaterialModel3D):
         xi = state["stress"] - state["alpha"]
         return self._vonmises(xi) - self.sigma_y0
 
-    def state_residual(self, state_new, dlambda, state_n, state_trial):
+    def state_residual(self, state_new, dlambda, state_n, state_trial, *, stress_trial):
         xi_new = state_new["stress"] - state_new["alpha"]
         f_new = self._vonmises(xi_new) - self.sigma_y0
         # flow direction n = df/dσ at current iterate
@@ -208,7 +204,7 @@ class _KinematicDefault(MaterialModel3D):
         xi = state["stress"] - state["alpha"]
         return self._vonmises(xi) - self.sigma_y0
 
-    def state_residual(self, state_new, dlambda, state_n, state_trial):
+    def state_residual(self, state_new, dlambda, state_n, state_trial, *, stress_trial):
         import autograd
         from manforge.core.state import _state_with_stress
         n = autograd.grad(

--- a/tests/integration/test_partial_implicit.py
+++ b/tests/integration/test_partial_implicit.py
@@ -35,10 +35,9 @@ class _AFAlphaImplicit(AFKinematic3D):
     alpha = Implicit(shape=NTENS, doc="backstress (implicit override)")
 
     def update_state(self, dlambda, state_n, state_trial):
-        sig = self.default_stress_update(dlambda, state_n, state_trial)
-        return [self.stress(sig), self.ep(state_n["ep"] + dlambda)]
+        return [self.ep(state_n["ep"] + dlambda)]
 
-    def state_residual(self, state_new, dlambda, state_n, state_trial):
+    def state_residual(self, state_new, dlambda, state_n, state_trial, *, stress_trial):
         alpha_n = state_n["alpha"]
         stress = state_trial["stress"]
         xi = stress - alpha_n
@@ -64,7 +63,7 @@ class _AFAlphaImplicitStress(AFKinematic3D):
         # stress is Implicit: only return the explicit ep key
         return [self.ep(state_n["ep"] + dlambda)]
 
-    def state_residual(self, state_new, dlambda, state_n, state_trial):
+    def state_residual(self, state_new, dlambda, state_n, state_trial, *, stress_trial):
         alpha_n = state_n["alpha"]
         stress = state_new["stress"]
         xi = stress - alpha_n
@@ -72,7 +71,7 @@ class _AFAlphaImplicitStress(AFKinematic3D):
         vm_safe = self._vonmises(xi)
         n_hat = s_xi / vm_safe
         scale = 1.0 + self.gamma * dlambda
-        R_stress = self.default_stress_residual(state_new, dlambda, state_trial)
+        R_stress = self.default_stress_residual(state_new, dlambda, stress_trial)
         R_alpha = state_new["alpha"] * scale - alpha_n - self.C_k * dlambda * n_hat
         return [self.stress(R_stress), self.alpha(R_alpha)]
 

--- a/tests/unit/test_compare_jacobians.py
+++ b/tests/unit/test_compare_jacobians.py
@@ -51,7 +51,7 @@ class TestCompareJacobiansJ2:
         """blocks dict should contain at least the four scalar block keys."""
         r, state0 = _result(model, 3e-3)
         out = compare_jacobians(model, r, r, state0)
-        for key in ("dstress_dsigma", "dstress_ddlambda", "dyield_dsigma", "dyield_ddlambda"):
+        for key in ("dRsigma_dsigma", "dRsigma_ddlambda", "dRdlambda_dsigma", "dRdlambda_ddlambda"):
             assert key in out.blocks
 
     def test_max_rel_err_equals_max_of_blocks(self, model):

--- a/tests/unit/test_dlambda_validation.py
+++ b/tests/unit/test_dlambda_validation.py
@@ -48,7 +48,7 @@ class _DlambdaOnlyModel(MaterialModel3D):
     def elastic_stiffness(self, state):
         return self.isotropic_C(_LAM, _MU)
 
-    def state_residual(self, state_new, dlambda, state_n, state_trial):
+    def state_residual(self, state_new, dlambda, state_n, state_trial, *, stress_trial):
         return [self.dlambda(self.yield_function(state_new))]
 
 
@@ -69,7 +69,7 @@ class _AlphaModel(MaterialModel3D):
     def elastic_stiffness(self, state):
         return self.isotropic_C(_LAM, _MU)
 
-    def state_residual(self, state_new, dlambda, state_n, state_trial):
+    def state_residual(self, state_new, dlambda, state_n, state_trial, *, stress_trial):
         R_alpha = state_new["alpha"] - state_n["alpha"]
         return [self.alpha(R_alpha)]
 
@@ -89,7 +89,7 @@ class _DuplicateDlambdaModel(MaterialModel3D):
     def elastic_stiffness(self, state):
         return self.isotropic_C(_LAM, _MU)
 
-    def state_residual(self, state_new, dlambda, state_n, state_trial):
+    def state_residual(self, state_new, dlambda, state_n, state_trial, *, stress_trial):
         R_alpha = state_new["alpha"] - state_n["alpha"]
         return [
             self.alpha(R_alpha),
@@ -113,7 +113,7 @@ class _BadItemModel(MaterialModel3D):
     def elastic_stiffness(self, state):
         return self.isotropic_C(_LAM, _MU)
 
-    def state_residual(self, state_new, dlambda, state_n, state_trial):
+    def state_residual(self, state_new, dlambda, state_n, state_trial, *, stress_trial):
         return [42]  # wrong type
 
 
@@ -175,16 +175,14 @@ def test_dlambda_not_in_state_fields():
 # ---------------------------------------------------------------------------
 
 def test_update_state_rejects_dlambda_residual():
+    """update_state returning self.dlambda(...) raises TypeError via the integrator."""
+    from manforge.simulation.integrator import PythonIntegrator
     model = _DlambdaInUpdateState(sigma_y0=250.0)
-    state_n = model.make_state(stress=anp.zeros(6), ep=anp.array(0.0))
-    stress_trial = anp.zeros(6)
-    import numpy as np
-    from manforge.simulation._residual import _call_update_state
+    state_n = model.initial_state()
+    # Uniaxial strain that triggers yielding (sigma_vm > 250 MPa at E≈200GPa)
+    deps = anp.array([2e-3, 0.0, 0.0, 0.0, 0.0, 0.0])
     with pytest.raises(TypeError, match="self.dlambda.*not allowed in update_state"):
-        _call_update_state(
-            model, anp.array(0.01), state_n, state_n,
-            {"ep"}, "_DlambdaInUpdateState"
-        )
+        PythonIntegrator(model).stress_update(deps, anp.zeros(6), state_n)
 
 
 # ---------------------------------------------------------------------------
@@ -192,15 +190,13 @@ def test_update_state_rejects_dlambda_residual():
 # ---------------------------------------------------------------------------
 
 def test_state_residual_duplicate_dlambda_raises():
-    import numpy as np
-    from manforge.simulation._residual import _call_state_residual
+    """state_residual returning self.dlambda(...) twice raises ValueError via integrator."""
+    from manforge.simulation.integrator import PythonIntegrator
     model = _DuplicateDlambdaModel(sigma_y0=250.0)
-    state_n = model.make_state(stress=anp.zeros(6), alpha=anp.zeros(6))
+    state_n = model.initial_state()
+    deps = anp.array([2e-3, 0.0, 0.0, 0.0, 0.0, 0.0])
     with pytest.raises(ValueError, match="duplicate self.dlambda"):
-        _call_state_residual(
-            model, dict(state_n), anp.array(0.01), dict(state_n), dict(state_n),
-            {"alpha"}, "_DuplicateDlambdaModel"
-        )
+        PythonIntegrator(model).stress_update(deps, anp.zeros(6), state_n)
 
 
 # ---------------------------------------------------------------------------
@@ -208,41 +204,52 @@ def test_state_residual_duplicate_dlambda_raises():
 # ---------------------------------------------------------------------------
 
 def test_state_residual_bad_item_raises():
-    from manforge.simulation._residual import _call_state_residual
+    """state_residual returning a non-StateResidual item raises TypeError via integrator."""
+    from manforge.simulation.integrator import PythonIntegrator
     model = _BadItemModel(sigma_y0=250.0)
-    state_n = model.make_state(stress=anp.zeros(6), alpha=anp.zeros(6))
-    with pytest.raises(TypeError, match="StateResidual.*DlambdaResidual"):
-        _call_state_residual(
-            model, dict(state_n), anp.array(0.01), dict(state_n), dict(state_n),
-            {"alpha"}, "_BadItemModel"
-        )
+    state_n = model.initial_state()
+    deps = anp.array([2e-3, 0.0, 0.0, 0.0, 0.0, 0.0])
+    with pytest.raises(TypeError):
+        PythonIntegrator(model).stress_update(deps, anp.zeros(6), state_n)
 
 
 # ---------------------------------------------------------------------------
-# Tests: _call_state_residual returns (dict, r_dl) correctly
+# Tests: state_residual dlambda extraction returns (dict, r_dl) correctly
 # ---------------------------------------------------------------------------
 
-def test_call_state_residual_with_dlambda_override():
-    from manforge.simulation._residual import _call_state_residual
+def test_state_residual_with_dlambda_override_extracts_correctly():
+    """state_residual returning only self.dlambda(R) → empty dict + non-None r_dl."""
+    from manforge.core.state import _validate_state_items, StateResidual
     model = _DlambdaOnlyModel(sigma_y0=250.0)
     state_n = model.make_state(stress=anp.zeros(6))
-    state_dict = dict(state_n)
-    result_dict, r_dl = _call_state_residual(
-        model, state_dict, anp.array(0.0), state_dict, state_dict,
-        set(), "_DlambdaOnlyModel"
+    from manforge.simulation._residual import _wrap_state
+    state_wrapped = _wrap_state(state_n, model)
+    returned = model.state_residual(
+        state_wrapped, anp.array(0.0), state_wrapped, state_wrapped,
+        stress_trial=anp.zeros(6),
+    )
+    result_dict, r_dl = _validate_state_items(
+        returned, set(), StateResidual, "state_residual", "_DlambdaOnlyModel",
+        extract_dlambda=True,
     )
     assert result_dict == {}
     assert r_dl is not None
 
 
-def test_call_state_residual_without_dlambda_returns_none():
-    from manforge.simulation._residual import _call_state_residual
+def test_state_residual_without_dlambda_extracts_none():
+    """state_residual returning only alpha → dict with 'alpha' + None r_dl."""
+    from manforge.core.state import _validate_state_items, StateResidual
     model = _AlphaModel(sigma_y0=250.0, H_k=1000.0)
     state_n = model.make_state(stress=anp.zeros(6), alpha=anp.zeros(6))
-    state_dict = dict(state_n)
-    result_dict, r_dl = _call_state_residual(
-        model, state_dict, anp.array(0.0), state_dict, state_dict,
-        {"alpha"}, "_AlphaModel"
+    from manforge.simulation._residual import _wrap_state
+    state_wrapped = _wrap_state(state_n, model)
+    returned = model.state_residual(
+        state_wrapped, anp.array(0.0), state_wrapped, state_wrapped,
+        stress_trial=anp.zeros(6),
+    )
+    result_dict, r_dl = _validate_state_items(
+        returned, {"alpha"}, StateResidual, "state_residual", "_AlphaModel",
+        extract_dlambda=True,
     )
     assert "alpha" in result_dict
     assert r_dl is None

--- a/tests/unit/test_jacobian_blocks.py
+++ b/tests/unit/test_jacobian_blocks.py
@@ -41,21 +41,21 @@ class TestReducedBlocks:
         result, state0 = _plastic_result(model)
         jac = ad_jacobian_blocks(model, result, state0)
         ntens = model.ntens
-        assert jac.dstress_dsigma.shape == (ntens, ntens)
-        assert jac.dstress_ddlambda.shape == (ntens,)
-        assert jac.dyield_dsigma.shape == (ntens,)
+        assert jac.dRsigma_dsigma.shape == (ntens, ntens)
+        assert jac.dRsigma_ddlambda.shape == (ntens,)
+        assert jac.dRdlambda_dsigma.shape == (ntens,)
         assert jac.full.shape == (ntens + 1, ntens + 1)
 
-    def test_state_blocks_are_none(self, model):
+    def test_state_blocks_are_empty_dicts(self, model):
         result, state0 = _plastic_result(model)
         jac = ad_jacobian_blocks(model, result, state0)
-        assert jac.dstress_dstate is None
-        assert jac.dyield_dstate is None
-        assert jac.dstate_dsigma is None
-        assert jac.dstate_ddlambda is None
-        assert jac.dstate_dstate is None
+        assert jac.dRsigma_dstate == {}
+        assert jac.dRdlambda_dstate == {}
+        assert jac.dRstate_dsigma == {}
+        assert jac.dRstate_ddlambda == {}
+        assert jac.dRstate_dstate == {}
 
-    def test_dyield_dsigma_matches_flow_direction(self, model):
+    def test_dRdlambda_dsigma_matches_flow_direction(self, model):
         result, state0 = _plastic_result(model)
         jac = ad_jacobian_blocks(model, result, state0)
 
@@ -63,7 +63,7 @@ class TestReducedBlocks:
         from manforge.core.state import _state_with_stress
         n_ad = autograd.grad(lambda s: model.yield_function(_state_with_stress(result.state, s)))(result.stress)
         np.testing.assert_allclose(
-            np.array(jac.dyield_dsigma), np.array(n_ad), rtol=1e-10
+            np.array(jac.dRdlambda_dsigma), np.array(n_ad), rtol=1e-10
         )
 
     def test_full_matrix_blocks_consistent(self, model):
@@ -71,10 +71,10 @@ class TestReducedBlocks:
         jac = ad_jacobian_blocks(model, result, state0)
         ntens = model.ntens
 
-        np.testing.assert_array_equal(jac.dstress_dsigma, jac.full[:ntens, :ntens])
-        np.testing.assert_array_equal(jac.dstress_ddlambda, jac.full[:ntens, ntens])
-        np.testing.assert_array_equal(jac.dyield_dsigma, jac.full[ntens, :ntens])
-        np.testing.assert_array_equal(jac.dyield_ddlambda, jac.full[ntens, ntens])
+        np.testing.assert_array_equal(jac.dRsigma_dsigma, jac.full[:ntens, :ntens])
+        np.testing.assert_array_equal(jac.dRsigma_ddlambda, jac.full[:ntens, ntens])
+        np.testing.assert_array_equal(jac.dRdlambda_dsigma, jac.full[ntens, :ntens])
+        np.testing.assert_array_equal(jac.dRdlambda_ddlambda, jac.full[ntens, ntens])
 
     def test_elastic_step_raises_no_error(self, model):
         deps = anp.array([1e-4, 0, 0, 0, 0, 0])
@@ -90,12 +90,12 @@ class TestReducedBlocks:
 # ---------------------------------------------------------------------------
 
 class TestReducedBlocksAF:
-    def test_af_state_blocks_are_none(self, af_model):
+    def test_af_state_blocks_are_empty_dicts(self, af_model):
         result, state0 = _plastic_result(af_model)
         jac = ad_jacobian_blocks(af_model, result, state0)
-        # AF is reduced hardening — state blocks should be None
-        assert jac.dstate_dsigma is None
-        assert jac.dstate_dstate is None
+        # AF is reduced hardening — state blocks should be empty dicts
+        assert jac.dRstate_dsigma == {}
+        assert jac.dRstate_dstate == {}
 
 
 # ---------------------------------------------------------------------------
@@ -111,10 +111,10 @@ class TestAugmentedBlocks:
     def test_state_block_keys(self, ow_model):
         result, state0 = _plastic_result(ow_model)
         jac = ad_jacobian_blocks(ow_model, result, state0)
-        # OW has state_names = ["alpha", "ep"] -> sorted keys
-        assert set(jac.dstate_dsigma.keys()) == {"alpha", "ep"}
-        assert set(jac.dstate_ddlambda.keys()) == {"alpha", "ep"}
-        assert set(jac.dstate_dstate.keys()) == {"alpha", "ep"}
+        # OW has implicit_keys = ["alpha", "ep"] (declaration order)
+        assert set(jac.dRstate_dsigma.keys()) == {"alpha", "ep"}
+        assert set(jac.dRstate_ddlambda.keys()) == {"alpha", "ep"}
+        assert set(jac.dRstate_dstate.keys()) == {"alpha", "ep"}
 
     def test_state_block_shapes(self, ow_model):
         result, state0 = _plastic_result(ow_model)
@@ -122,10 +122,10 @@ class TestAugmentedBlocks:
         ntens = ow_model.ntens
         # alpha: shape (ntens,) -> n_state contribution = ntens
         # ep: scalar -> n_state contribution = 1
-        assert jac.dstate_dsigma["alpha"].shape == (ntens, ntens)
-        assert jac.dstate_dsigma["ep"].shape == (1, ntens)
-        assert jac.dstate_ddlambda["alpha"].shape == (ntens,)
-        assert jac.dstate_ddlambda["ep"].shape == (1,)
+        assert jac.dRstate_dsigma["alpha"].shape == (ntens, ntens)
+        assert jac.dRstate_dsigma["ep"].shape == (1, ntens)
+        assert jac.dRstate_ddlambda["alpha"].shape == (ntens,)
+        assert jac.dRstate_ddlambda["ep"].shape == (1,)
 
     @pytest.mark.slow
     def test_full_matrix_size(self, ow_model):
@@ -136,14 +136,14 @@ class TestAugmentedBlocks:
         n_state = ntens + 1
         assert jac.full.shape == (ntens + 1 + n_state, ntens + 1 + n_state)
 
-    def test_dyield_dsigma_matches_flow_direction(self, ow_model):
+    def test_dRdlambda_dsigma_matches_flow_direction(self, ow_model):
         result, state0 = _plastic_result(ow_model)
         jac = ad_jacobian_blocks(ow_model, result, state0)
 
         from manforge.core.state import _state_with_stress
         n_ad = autograd.grad(lambda s: ow_model.yield_function(_state_with_stress(result.state, s)))(result.stress)
         np.testing.assert_allclose(
-            np.array(jac.dyield_dsigma), np.array(n_ad), rtol=1e-10
+            np.array(jac.dRdlambda_dsigma), np.array(n_ad), rtol=1e-10
         )
 
 
@@ -160,7 +160,7 @@ class TestReturnMappingResultPath:
         rm = PythonIntegrator(model).return_mapping(st, state0)
         jac = ad_jacobian_blocks(model, rm, state0, stress_trial=st)
         assert isinstance(jac, JacobianBlocks)
-        assert jac.dstress_dsigma.shape == (model.ntens, model.ntens)
+        assert jac.dRsigma_dsigma.shape == (model.ntens, model.ntens)
 
     def test_matches_stress_update_result(self, model):
         deps = (lambda _a: (_a.__setitem__(0, 3e-3), _a)[1])(np.zeros(model.ntens))
@@ -174,7 +174,7 @@ class TestReturnMappingResultPath:
         jac_su = ad_jacobian_blocks(model, su, state0)
 
         np.testing.assert_allclose(
-            np.array(jac_rm.dstress_dsigma), np.array(jac_su.dstress_dsigma), rtol=1e-10
+            np.array(jac_rm.dRsigma_dsigma), np.array(jac_su.dRsigma_dsigma), rtol=1e-10
         )
 
     def test_missing_stress_trial_raises(self, model):

--- a/tests/unit/test_material_bases.py
+++ b/tests/unit/test_material_bases.py
@@ -559,7 +559,7 @@ def test_mixed_implicit_explicit_requires_both_methods():
         def update_state(self, dlambda, state_n, state_trial):
             return [self.ep(state_n["ep"] + dlambda)]
 
-        def state_residual(self, state_new, dlambda, state_n, state_trial):
+        def state_residual(self, state_new, dlambda, state_n, state_trial, *, stress_trial):
             return [self.alpha(state_new["alpha"] - state_n["alpha"])]
 
     assert OK.implicit_state_names == ["alpha"]
@@ -579,7 +579,7 @@ def test_all_implicit_states_no_update_state_needed():
         def yield_function(self, state):
             pass
 
-        def state_residual(self, state_new, dlambda, state_n, state_trial):
+        def state_residual(self, state_new, dlambda, state_n, state_trial, *, stress_trial):
             return [self.alpha(anp.array(0.0)), self.ep(anp.array(0.0))]
 
     assert set(OKImplicit.implicit_state_names) == {"alpha", "ep"}

--- a/tests/unit/test_state_fields.py
+++ b/tests/unit/test_state_fields.py
@@ -52,7 +52,7 @@ class _AlphaEP(MaterialModel3D):
     def update_state(self, dlambda, state_n, state_trial):
         return [self.ep(state_n["ep"] + dlambda)]
 
-    def state_residual(self, state_new, dlambda, state_n, state_trial):
+    def state_residual(self, state_new, dlambda, state_n, state_trial, *, stress_trial):
         return [self.alpha(state_new["alpha"] - state_n["alpha"])]
 
 
@@ -65,7 +65,7 @@ class _AllImplicit(MaterialModel3D):
     def yield_function(self, state):
         return anp.array(0.0)
 
-    def state_residual(self, state_new, dlambda, state_n, state_trial):
+    def state_residual(self, state_new, dlambda, state_n, state_trial, *, stress_trial):
         return [
             self.alpha(state_new["alpha"] - state_n["alpha"]),
             self.ep(state_new["ep"] - state_n["ep"]),
@@ -116,7 +116,7 @@ def test_mro_override_explicit_to_implicit():
     class _Override(_AlphaEP):
         ep = Implicit(shape=(), doc="overridden to implicit")
 
-        def state_residual(self, state_new, dlambda, state_n, state_trial):
+        def state_residual(self, state_new, dlambda, state_n, state_trial, *, stress_trial):
             return [
                 self.alpha(state_new["alpha"] - state_n["alpha"]),
                 self.ep(state_new["ep"] - state_n["ep"]),

--- a/tests/unit/test_stress_field.py
+++ b/tests/unit/test_stress_field.py
@@ -58,7 +58,7 @@ def test_stress_implicit_declaration():
         def yield_function(self, state):
             return self._vonmises(state["stress"]) - 250.0
 
-        def state_residual(self, state_new, dlambda, state_n, state_trial):
+        def state_residual(self, state_new, dlambda, state_n, state_trial, *, stress_trial):
             return [self.ep(state_new["ep"] - state_n["ep"] - dlambda)]
 
     assert _M.state_fields["stress"].kind == "implicit"
@@ -142,7 +142,7 @@ class _CustomStressResidual(MaterialModel3D):
         sigma_y = self.sigma_y0 + self.H * state["ep"]
         return self._vonmises(state["stress"]) - sigma_y
 
-    def state_residual(self, state_new, dlambda, state_n, state_trial):
+    def state_residual(self, state_new, dlambda, state_n, state_trial, *, stress_trial):
         # Hand-coded J2 associative R_stress using correct Mandel-scaled flow direction.
         # n_hat = (3/2) * s * m² / σ_vm  (m = Mandel factors; m²=[1,1,1,2,2,2] for 3D)
         # This matches autograd.grad(yield_function w.r.t. stress) without nested autograd.
@@ -152,7 +152,7 @@ class _CustomStressResidual(MaterialModel3D):
         vm = self._vonmises(stress)
         m2 = anp.array(self.dimension.mandel_factors_np) ** 2
         n_hat = 1.5 * (s * m2) / vm
-        R_stress = stress - state_trial["stress"] + dlambda * (C @ n_hat)
+        R_stress = stress - stress_trial + dlambda * (C @ n_hat)
         R_ep = state_new["ep"] - state_n["ep"] - dlambda
         return [self.stress(R_stress), self.ep(R_ep)]
 


### PR DESCRIPTION
## Summary

- **`simulation/_layout.py` 新設** — `ResidualLayout` frozen dataclass が NR 未知数ベクトル `x = [σ | Δλ | q_imp_decl_order]` のレイアウトを 1 箇所に集約。以前は `_residual.py`・`integrator/base.py`・`verification/jacobian.py` の 4 箇所にハードコードされていたスライス計算を撤去
- **`build_residual` 統合** — `(residual_fn, layout)` を返す単一関数に。`residual_fn(x)` は array のみ返す (autograd 互換)。`build_state_from_x()` 追加で収束後 state 再構築から `update_state` 二重呼び出しを解消
- **`state_residual` 新シグネチャ** — `stress_trial` kwarg 追加。`state_trial["stress"]` は常に現在 σ iterate に統一し、固定試行応力は kwarg で分離
- **`JacobianBlocks` 改名** — `dyield_*` → `dRdlambda_*`、`dstate_*` → `dRstate_*`。状態ブロックは常に `dict`（`None` 廃止）。`iter_blocks()` ヘルパ追加
- **`update_state` 簡素化** — `stress` 返却を規約上禁止。フレームワークが σ を NR で直接制御

## Test plan

- [x] `make test-unit` — 287 tests pass
- [x] `make test-integration` — 249 tests pass (計 536 tests)
- [x] 新規 `_layout.py` のユニットテストは既存 `test_jacobian_blocks.py` / `test_partial_implicit.py` 経由で間接的にカバー

🤖 Generated with [Claude Code](https://claude.com/claude-code)