### PR TITLE
feat: SCALAR sentinel 導入 — shape=() の意味的明示化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,18 +53,18 @@ manforge is a framework for validating Fortran UMAT (Abaqus user material) const
 `MaterialModel` is the internal ABC. Users subclass one of the stress-state base classes and implement the required material-physics methods. State variables are declared as class-level `StateField` attributes using `Implicit` / `Explicit` from `manforge.core.state` (importable via `from manforge.core import Implicit, Explicit`):
 
 ```python
-from manforge.core import Implicit, Explicit, NTENS
+from manforge.core import Implicit, Explicit, NTENS, SCALAR
 
 class MyModel(MaterialModel3D):
     param_names = ["E", "nu", "sigma_y0"]
-    ep    = Explicit(shape=(),    doc="equivalent plastic strain")
-    alpha = Implicit(shape=NTENS, doc="backstress tensor")
+    ep    = Explicit(shape=SCALAR, doc="equivalent plastic strain")
+    alpha = Implicit(shape=NTENS,  doc="backstress tensor")
     stress = Implicit(shape=NTENS, doc="Cauchy stress (NR unknown)")  # optional
 ```
 
 - `Explicit(shape, doc)` — state updated in closed form via `update_state`; no NR unknown.
 - `Implicit(shape, doc)` — state solved as NR unknown via `state_residual`.
-- `shape` accepts `NTENS` (resolves to `(ntens,)` at construction time), `()` (scalar), an `int`, or a tuple. The string `"ntens"` is no longer accepted — use `NTENS` instead.
+- `shape` accepts `NTENS` (resolves to `(ntens,)` at construction time), `SCALAR` (scalar 0-d state, preferred over `()`), an `int`, or a tuple. Passing `()` directly is also accepted (backward compatible). The string `"ntens"` is no longer accepted — use `NTENS` instead.
 - **`stress` field**: If not declared, the framework auto-attaches `stress = Explicit(shape=NTENS)` and uses the associative default update (`σ ← σ_trial − Δλ·C·∂f/∂σ`). Declaring `stress = Implicit(shape=NTENS)` makes σ an NR unknown (fully-coupled vector NR).
 - `state_names` and `implicit_state_names` are derived automatically from field declarations by `__init_subclass__`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ class MyModel(MaterialModel3D):
 
 - `Explicit(shape, doc)` — state updated in closed form via `update_state`; no NR unknown.
 - `Implicit(shape, doc)` — state solved as NR unknown via `state_residual`.
-- `shape` accepts `NTENS` (resolves to `(ntens,)` at construction time), `SCALAR` (scalar 0-d state, preferred over `()`), an `int`, or a tuple. Passing `()` directly is also accepted (backward compatible). The string `"ntens"` is no longer accepted — use `NTENS` instead.
+- `shape` accepts `NTENS` (resolved to `(ntens,)` when `resolve_shape` is called during layout/state initialization), `SCALAR` (scalar 0-d state, preferred over `()`), an `int`, or a tuple. Passing `()` directly is also accepted (backward compatible). The string `"ntens"` is no longer accepted — use `NTENS` instead.
 - **`stress` field**: If not declared, the framework auto-attaches `stress = Explicit(shape=NTENS)` and uses the associative default update (`σ ← σ_trial − Δλ·C·∂f/∂σ`). Declaring `stress = Implicit(shape=NTENS)` makes σ an NR unknown (fully-coupled vector NR).
 - `state_names` and `implicit_state_names` are derived automatically from field declarations by `__init_subclass__`.
 

--- a/README.md
+++ b/README.md
@@ -95,12 +95,12 @@ MaterialModel  ──defines──▶  yield_function / update_state / state_res
 
 ```python
 import autograd.numpy as anp
-from manforge.core import Implicit, Explicit, NTENS
+from manforge.core import Implicit, Explicit, NTENS, SCALAR
 from manforge.core.material import MaterialModel3D
 
 class MyModel(MaterialModel3D):
     param_names = ["E", "nu", "sigma_y0", "H"]
-    ep = Explicit(shape=(), doc="equivalent plastic strain")
+    ep = Explicit(shape=SCALAR, doc="equivalent plastic strain")
 
     def __init__(self, *, E, nu, sigma_y0, H):
         super().__init__()
@@ -139,7 +139,7 @@ class MyImplicitModel(MaterialModel3D):
     param_names = ["E", "nu", "sigma_y0", "C_k", "gamma"]
     stress = Implicit(shape=NTENS, doc="Cauchy stress (NR unknown)")
     alpha  = Implicit(shape=NTENS, doc="backstress tensor")
-    ep     = Implicit(shape=(),    doc="equivalent plastic strain")
+    ep     = Implicit(shape=SCALAR, doc="equivalent plastic strain")
 
     def yield_function(self, state):
         xi = state["stress"] - state["alpha"]

--- a/src/manforge/core/__init__.py
+++ b/src/manforge/core/__init__.py
@@ -1,4 +1,4 @@
-from manforge.core.state import Implicit, Explicit, State, NTENS, StateResidual, StateUpdate, DlambdaResidual
+from manforge.core.state import Implicit, Explicit, State, NTENS, SCALAR, StateResidual, StateUpdate, DlambdaResidual
 from manforge.core.dimension import (
     StressDimension,
     SOLID_3D,
@@ -13,6 +13,7 @@ __all__ = [
     "Explicit",
     "State",
     "NTENS",
+    "SCALAR",
     "StateResidual",
     "StateUpdate",
     "DlambdaResidual",

--- a/src/manforge/core/material/base.py
+++ b/src/manforge/core/material/base.py
@@ -16,13 +16,13 @@ class MaterialModel(ABC):
     using :func:`~manforge.core.state.Implicit` and
     :func:`~manforge.core.state.Explicit`::
 
-        from manforge.core.state import Implicit, Explicit, NTENS
+        from manforge.core.state import Implicit, Explicit, NTENS, SCALAR
 
         class MyModel(MaterialModel3D):
             param_names = ["E", "nu", "sigma_y0", "C_k", "gamma"]
-            stress = Implicit(shape=NTENS, doc="Cauchy stress")   # NR unknown
-            alpha  = Implicit(shape=NTENS, doc="backstress tensor")
-            ep     = Explicit(shape=(),    doc="equivalent plastic strain")
+            stress = Implicit(shape=NTENS,   doc="Cauchy stress")   # NR unknown
+            alpha  = Implicit(shape=NTENS,   doc="backstress tensor")
+            ep     = Explicit(shape=SCALAR,  doc="equivalent plastic strain")
 
     ``state_names`` and ``implicit_state_names`` are derived automatically from
     the field declarations; hand-declaring these lists raises ``TypeError``.

--- a/src/manforge/core/state.py
+++ b/src/manforge/core/state.py
@@ -2,12 +2,12 @@
 
 Usage in a model class::
 
-    from manforge.core import Implicit, Explicit, NTENS
+    from manforge.core import Implicit, Explicit, NTENS, SCALAR
 
     class OWKinematic3D(MaterialModel3D):
-        stress = Implicit(shape=NTENS, doc="Cauchy stress")   # NR unknown
-        alpha  = Implicit(shape=NTENS, doc="backstress tensor")
-        ep     = Implicit(shape=(),    doc="equivalent plastic strain")
+        stress = Implicit(shape=NTENS,   doc="Cauchy stress")   # NR unknown
+        alpha  = Implicit(shape=NTENS,   doc="backstress tensor")
+        ep     = Implicit(shape=SCALAR,  doc="equivalent plastic strain")
 
 The ``Implicit`` / ``Explicit`` descriptors replace the old list-based
 ``state_names`` / ``implicit_state_names`` declarations.  ``MaterialModel.
@@ -75,6 +75,29 @@ NTENS = _NtensSentinel()
 
 
 # ---------------------------------------------------------------------------
+# SCALAR sentinel
+# ---------------------------------------------------------------------------
+
+class _ScalarSentinel:
+    """Placeholder shape resolved to ``()`` at StateField.resolve_shape()."""
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:
+        return "SCALAR"
+
+    def __reduce__(self):
+        return (_get_scalar_sentinel, ())
+
+
+def _get_scalar_sentinel():
+    return SCALAR
+
+
+SCALAR = _ScalarSentinel()
+
+
+# ---------------------------------------------------------------------------
 # StateField descriptor
 # ---------------------------------------------------------------------------
 
@@ -87,12 +110,14 @@ class StateField:
     kind : str
         ``"implicit"`` — treated as an NR unknown (goes into `state_residual`).
         ``"explicit"`` — updated in closed form (goes into `update_state`).
-    shape : _NtensSentinel, tuple, or int
-        Array shape.  Use ``NTENS`` (from ``manforge.core``) to denote a vector
-        of length ``model.ntens`` (resolved at construction time).  Use ``()``
-        for a scalar state.  An ``int`` ``n`` is equivalent to ``(n,)``.
-        Any other tuple is used directly (e.g. ``(6, 6)``).
-        The string ``"ntens"`` is no longer accepted — use ``NTENS``.
+    shape : _NtensSentinel, _ScalarSentinel, tuple, or int
+        Array shape.  Use ``NTENS`` (from ``manforge.core``) for a vector of
+        length ``model.ntens``.  Use ``SCALAR`` (from ``manforge.core``) for a
+        0-d scalar state (preferred over ``()``).  An ``int`` ``n`` is
+        equivalent to ``(n,)``.  Any other tuple is used directly (e.g.
+        ``(6, 6)``).  Passing ``()`` directly is also accepted (backward
+        compatible).  The string ``"ntens"`` is no longer accepted — use
+        ``NTENS``.
     default : callable or None
         Factory ``(model) -> array`` for the initial value.  ``None`` → zeros
         of the resolved shape.
@@ -152,9 +177,11 @@ class StateField:
         return StateUpdate(name=self.name, value=value)
 
     def resolve_shape(self, ntens: int) -> tuple:
-        """Return the concrete shape with NTENS substituted."""
+        """Return the concrete shape with NTENS/SCALAR substituted."""
         if self.shape is NTENS:
             return (ntens,)
+        if self.shape is SCALAR:
+            return ()
         if isinstance(self.shape, int):
             return (self.shape,)
         return tuple(self.shape)

--- a/src/manforge/models/af_kinematic.py
+++ b/src/manforge/models/af_kinematic.py
@@ -47,7 +47,7 @@ Notes
 import autograd.numpy as anp
 
 from manforge.core.material import MaterialModel3D, MaterialModelPS, MaterialModel1D
-from manforge.core.state import Explicit, NTENS  # Explicit used for alpha, ep; NTENS for shape
+from manforge.core.state import Explicit, NTENS, SCALAR
 from manforge.core.dimension import SOLID_3D, PLANE_STRESS, UNIAXIAL_1D, StressDimension
 
 
@@ -76,7 +76,7 @@ class AFKinematic3D(MaterialModel3D):
 
     param_names = ["E", "nu", "sigma_y0", "C_k", "gamma"]
     alpha = Explicit(shape=NTENS, doc="backstress tensor")
-    ep = Explicit(shape=(), doc="equivalent plastic strain")
+    ep = Explicit(shape=SCALAR, doc="equivalent plastic strain")
 
     def __init__(self, dimension: StressDimension = SOLID_3D, *,
                  E: float, nu: float, sigma_y0: float, C_k: float, gamma: float):
@@ -133,7 +133,7 @@ class AFKinematicPS(MaterialModelPS):
 
     param_names = ["E", "nu", "sigma_y0", "C_k", "gamma"]
     alpha = Explicit(shape=NTENS, doc="backstress tensor")
-    ep = Explicit(shape=(), doc="equivalent plastic strain")
+    ep = Explicit(shape=SCALAR, doc="equivalent plastic strain")
 
     def __init__(self, dimension: StressDimension = PLANE_STRESS, *,
                  E: float, nu: float, sigma_y0: float, C_k: float, gamma: float):
@@ -184,7 +184,7 @@ class AFKinematic1D(MaterialModel1D):
 
     param_names = ["E", "nu", "sigma_y0", "C_k", "gamma"]
     alpha = Explicit(shape=NTENS, doc="backstress tensor")
-    ep = Explicit(shape=(), doc="equivalent plastic strain")
+    ep = Explicit(shape=SCALAR, doc="equivalent plastic strain")
 
     def __init__(self, dimension: StressDimension = UNIAXIAL_1D, *,
                  E: float, nu: float, sigma_y0: float, C_k: float, gamma: float):

--- a/src/manforge/models/j2_isotropic.py
+++ b/src/manforge/models/j2_isotropic.py
@@ -25,7 +25,7 @@ dε_p = Δλ · n,  n = df/dσ = (3/2) s / σ_vm  (unit normal in Mandel sense)
 import autograd.numpy as anp
 
 from manforge.core.material import MaterialModel3D, MaterialModelPS, MaterialModel1D
-from manforge.core.state import Explicit
+from manforge.core.state import Explicit, SCALAR
 from manforge.core.dimension import SOLID_3D, PLANE_STRESS, UNIAXIAL_1D, StressDimension
 from manforge.core.result import ReturnMappingResult
 from manforge.verification.fortran_registry import verified_against_fortran
@@ -71,7 +71,7 @@ class J2Isotropic3D(MaterialModel3D):
     """
 
     param_names = ["E", "nu", "sigma_y0", "H"]
-    ep = Explicit(shape=(), doc="equivalent plastic strain")
+    ep = Explicit(shape=SCALAR, doc="equivalent plastic strain")
 
     def __init__(self, dimension: StressDimension = SOLID_3D, *,
                  E: float, nu: float, sigma_y0: float, H: float):
@@ -195,7 +195,7 @@ class J2IsotropicPS(MaterialModelPS):
     """
 
     param_names = ["E", "nu", "sigma_y0", "H"]
-    ep = Explicit(shape=(), doc="equivalent plastic strain")
+    ep = Explicit(shape=SCALAR, doc="equivalent plastic strain")
 
     def __init__(self, dimension: StressDimension = PLANE_STRESS, *,
                  E: float, nu: float, sigma_y0: float, H: float):
@@ -237,7 +237,7 @@ class J2Isotropic1D(MaterialModel1D):
     """
 
     param_names = ["E", "nu", "sigma_y0", "H"]
-    ep = Explicit(shape=(), doc="equivalent plastic strain")
+    ep = Explicit(shape=SCALAR, doc="equivalent plastic strain")
 
     def __init__(self, dimension: StressDimension = UNIAXIAL_1D, *,
                  E: float, nu: float, sigma_y0: float, H: float):

--- a/src/manforge/models/ow_kinematic.py
+++ b/src/manforge/models/ow_kinematic.py
@@ -57,7 +57,7 @@ Notes
 import autograd.numpy as anp
 
 from manforge.core.material import MaterialModel1D, MaterialModel3D, MaterialModelPS
-from manforge.core.state import Implicit, NTENS
+from manforge.core.state import Implicit, NTENS, SCALAR
 from manforge.core.dimension import SOLID_3D, PLANE_STRESS, UNIAXIAL_1D, StressDimension
 
 
@@ -89,7 +89,7 @@ class OWKinematic3D(MaterialModel3D):
     stress = Implicit(shape=NTENS, doc="Cauchy stress")
     param_names = ["E", "nu", "sigma_y0", "C_k", "gamma"]
     alpha = Implicit(shape=NTENS, doc="backstress tensor")
-    ep = Implicit(shape=(), doc="equivalent plastic strain")
+    ep = Implicit(shape=SCALAR, doc="equivalent plastic strain")
 
     def __init__(self, dimension: StressDimension = SOLID_3D, *,
                  E: float, nu: float, sigma_y0: float, C_k: float, gamma: float):
@@ -159,7 +159,7 @@ class OWKinematicPS(MaterialModelPS):
     stress = Implicit(shape=NTENS, doc="Cauchy stress")
     param_names = ["E", "nu", "sigma_y0", "C_k", "gamma"]
     alpha = Implicit(shape=NTENS, doc="backstress tensor")
-    ep = Implicit(shape=(), doc="equivalent plastic strain")
+    ep = Implicit(shape=SCALAR, doc="equivalent plastic strain")
 
     def __init__(self, dimension: StressDimension = PLANE_STRESS, *,
                  E: float, nu: float, sigma_y0: float, C_k: float, gamma: float):
@@ -219,7 +219,7 @@ class OWKinematic1D(MaterialModel1D):
     stress = Implicit(shape=NTENS, doc="Cauchy stress")
     param_names = ["E", "nu", "sigma_y0", "C_k", "gamma"]
     alpha = Implicit(shape=NTENS, doc="backstress tensor")
-    ep = Implicit(shape=(), doc="equivalent plastic strain")
+    ep = Implicit(shape=SCALAR, doc="equivalent plastic strain")
 
     def __init__(self, dimension: StressDimension = UNIAXIAL_1D, *,
                  E: float, nu: float, sigma_y0: float, C_k: float, gamma: float):

--- a/tests/unit/test_state_fields.py
+++ b/tests/unit/test_state_fields.py
@@ -17,7 +17,7 @@ import pytest
 import autograd.numpy as anp
 
 from manforge.core.state import (
-    Implicit, Explicit, StateField, collect_state_fields, State, _make, NTENS,
+    Implicit, Explicit, StateField, collect_state_fields, State, _make, NTENS, SCALAR,
     StateResidual, StateUpdate, _validate_state_items,
 )
 from manforge.core.material import MaterialModel3D, MaterialModel1D
@@ -167,6 +167,20 @@ def test_ntens_string_raises_typeerror():
 def test_scalar_shape_resolves_to_empty_tuple():
     f = Explicit(shape=())
     assert f.resolve_shape(ntens=6) == ()
+
+
+def test_scalar_sentinel_resolves_to_empty_tuple():
+    f = Explicit(shape=SCALAR)
+    assert f.resolve_shape(ntens=6) == ()
+
+
+def test_scalar_sentinel_initial_value_is_zero_d():
+    model = _EP(SOLID_3D)
+    f = Explicit(shape=SCALAR)
+    object.__setattr__(f, "name", "ep")
+    val = f.initial_value(model)
+    assert np.asarray(val).shape == ()
+    assert float(val) == 0.0
 
 
 def test_int_shape_resolves_to_singleton_tuple():

--- a/tests/unit/test_state_fields.py
+++ b/tests/unit/test_state_fields.py
@@ -177,7 +177,6 @@ def test_scalar_sentinel_resolves_to_empty_tuple():
 def test_scalar_sentinel_initial_value_is_zero_d():
     model = _EP(SOLID_3D)
     f = Explicit(shape=SCALAR)
-    object.__setattr__(f, "name", "ep")
     val = f.initial_value(model)
     assert np.asarray(val).shape == ()
     assert float(val) == 0.0


### PR DESCRIPTION
## Summary

- `NTENS` と対称な `SCALAR` sentinel を `manforge.core` に追加し、スカラー状態変数の宣言を `shape=SCALAR` と書けるようにした
- `StateField.resolve_shape` で `SCALAR → ()` に解決するため、内部表現・layout 動作・`state["ep"].shape == ()` の ABI は完全に不変
- `shape=()` は後方互換で引き続き有効

## 変更内容

- `src/manforge/core/state.py` — `_ScalarSentinel` / `SCALAR` 追加、`resolve_shape` に分岐追加、docstring 更新
- `src/manforge/core/__init__.py` — `SCALAR` を re-export
- リファレンスモデル 9 宣言 (`j2_isotropic`, `af_kinematic`, `ow_kinematic`) を `shape=SCALAR` に置換
- `CLAUDE.md` / `README.md` / `base.py` docstring を更新
- `tests/unit/test_state_fields.py` に `SCALAR` の resolve / initial_value テスト 2 ケース追加

## Before / After

```python
# Before
ep    = Explicit(shape=(),    doc="equivalent plastic strain")
alpha = Implicit(shape=NTENS, doc="backstress tensor")

# After
ep    = Explicit(shape=SCALAR, doc="equivalent plastic strain")
alpha = Implicit(shape=NTENS,  doc="backstress tensor")
```

## Test plan

- [x] `tests/unit/test_state_fields.py` — SCALAR sentinel の resolve / initial_value テスト追加
- [x] `make test` — 505 passed, 0 failed（既存テスト含む全 fast テスト green）
- [x] `shape=()` を使う既存 fixtures / テスト 16+ 宣言がそのままパスし、後方互換を保証

🤖 Generated with [Claude Code](https://claude.com/claude-code)