### PR TITLE
feat: MixedDriver — 混合ひずみ/応力境界条件ドライバを追加

### DIFF
--- a/src/manforge/simulation/__init__.py
+++ b/src/manforge/simulation/__init__.py
@@ -3,6 +3,7 @@ from manforge.simulation.driver import (
     DriverBase,
     StrainDriver,
     StressDriver,
+    MixedDriver,
 )
 from manforge.simulation.integrator import (
     StressIntegrator,
@@ -19,6 +20,7 @@ __all__ = [
     "DriverBase",
     "StrainDriver",
     "StressDriver",
+    "MixedDriver",
     "DriverStep",
     "StressIntegrator",
     "PythonIntegrator",

--- a/src/manforge/simulation/driver.py
+++ b/src/manforge/simulation/driver.py
@@ -1,4 +1,4 @@
-"""Simulation drivers: strain-controlled and stress-controlled loading.
+"""Simulation drivers: strain-controlled, stress-controlled, and mixed loading.
 
 All drivers share the same interface via :class:`DriverBase`:
 
@@ -386,6 +386,315 @@ class StressDriver(DriverBase):
         strain_rows = []
         for step in self.iter_run(load, raise_on_nonconverged=True,
                                   initial_stress=initial_stress, initial_state=initial_state):
+            step_results.append(step.result)
+            strain_rows.append(step.strain)
+        strain_out = (
+            np.stack(strain_rows)
+            if strain_rows
+            else np.zeros((0, self.integrator.ntens))
+        )
+        return DriverResult(
+            step_results=step_results,
+            strain=strain_out,
+            collect_state=collect_state,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Mixed boundary-condition driver
+# ---------------------------------------------------------------------------
+
+def _validate_idx_arg(name: str, seq, ntens: int) -> list[int]:
+    """Validate a Voigt index sequence; return a sorted list."""
+    try:
+        lst = list(seq)
+    except TypeError:
+        raise TypeError(f"{name} must be iterable, got {type(seq).__name__!r}")
+    for v in lst:
+        if not isinstance(v, (int, np.integer)):
+            raise TypeError(f"All elements of {name} must be int, got {type(v).__name__!r}")
+    ints = [int(v) for v in lst]
+    if len(ints) != len(set(ints)):
+        raise ValueError(f"{name} contains duplicate indices: {ints}")
+    for v in ints:
+        if not (0 <= v < ntens):
+            raise ValueError(
+                f"{name} index {v} is out of range for ntens={ntens}"
+            )
+    return sorted(ints)
+
+
+class MixedDriver(DriverBase):
+    """Mixed strain/stress boundary-condition driver.
+
+    Some Voigt components are strain-controlled (prescribed history) while the
+    remaining components are stress-controlled (target stress, default zero).
+    The driver solves the free strain components by inner Newton-Raphson on the
+    consistent tangent (ddsdde[F, F]).
+
+    Typical use case: 3-D solid (ntens=6) with ε11 ramped and σ22..σ23 = 0,
+    recovering a uniaxial-stress test from a 3-D model without writing a 1-D
+    wrapper.
+
+    Parameters
+    ----------
+    integrator : StressIntegrator
+        Constitutive integrator.
+    prescribed_strain_idx : Sequence[int]
+        Voigt indices whose strain is prescribed by the caller (P components).
+        Must not be empty.
+    prescribed_stress_idx : Sequence[int] or None, optional
+        Voigt indices whose stress is prescribed (F components).  If ``None``
+        (default), inferred as the complement of ``prescribed_strain_idx`` in
+        ``range(ntens)``.
+    max_iter : int, optional
+        Maximum inner Newton-Raphson iterations per step (default 20).
+    tol : float, optional
+        Convergence tolerance on the L∞ norm of the stress residual on the
+        F components (default 1e-8).
+
+    Notes
+    -----
+    Voigt order is ``[11, 22, 33, 12, 13, 23]`` (engineering shear).
+
+    The union of ``prescribed_strain_idx`` and ``prescribed_stress_idx`` must
+    equal ``range(ntens)`` exactly; the intersection must be empty.
+
+    When ``len(prescribed_stress_idx) == 0`` (full strain control), the inner
+    NR is skipped and the driver behaves identically to :class:`StrainDriver`.
+
+    If ``D_FF = ddsdde[F, F]`` becomes singular (rare for J2-associative
+    models), ``numpy.linalg.LinAlgError`` propagates to the caller.
+    """
+
+    def __init__(
+        self,
+        integrator,
+        *,
+        prescribed_strain_idx,
+        prescribed_stress_idx=None,
+        max_iter: int = 20,
+        tol: float = 1e-8,
+    ) -> None:
+        super().__init__(integrator)
+        ntens = integrator.ntens
+
+        P = _validate_idx_arg("prescribed_strain_idx", prescribed_strain_idx, ntens)
+        if len(P) == 0:
+            raise ValueError(
+                "prescribed_strain_idx must not be empty; use StressDriver instead"
+            )
+
+        if prescribed_stress_idx is None:
+            F = sorted(set(range(ntens)) - set(P))
+        else:
+            F = _validate_idx_arg("prescribed_stress_idx", prescribed_stress_idx, ntens)
+
+        if set(P) | set(F) != set(range(ntens)):
+            raise ValueError(
+                f"Union of prescribed_strain_idx and prescribed_stress_idx must cover all "
+                f"{ntens} components.  Got P={P}, F={F}."
+            )
+        if set(P) & set(F):
+            raise ValueError(
+                "prescribed_strain_idx and prescribed_stress_idx must be disjoint.  "
+                f"Overlap: {sorted(set(P) & set(F))}"
+            )
+
+        self._P = np.array(P, dtype=int)
+        self._F = np.array(F, dtype=int)
+        self.max_iter = max_iter
+        self.tol = tol
+
+    def iter_run(
+        self,
+        load: FieldHistory,
+        *,
+        prescribed_stress_history=None,
+        raise_on_nonconverged: bool = True,
+        initial_stress=None,
+        initial_state=None,
+    ) -> Iterator[DriverStep]:
+        """Yield per-step results for mixed strain/stress boundary conditions.
+
+        Parameters
+        ----------
+        load : FieldHistory
+            Must have ``type = FieldType.STRAIN``.  ``load.data`` shape
+            ``(N, len(prescribed_strain_idx))`` — cumulative prescribed strain
+            at each step for the P components.
+        prescribed_stress_history : array-like of shape (N, len(prescribed_stress_idx)) or None
+            Target stress values for the F components at each step.  If ``None``
+            (default), all F components are held at zero.
+        raise_on_nonconverged : bool, optional
+            If ``True`` (default), raise :exc:`RuntimeError` when inner NR does
+            not converge.  If ``False``, yield a :class:`DriverStep` with
+            ``converged=False`` and immediately stop iteration.
+        initial_stress : array-like or None, optional
+            Full stress tensor (ntens,) at the start of the history.
+        initial_state : dict or None, optional
+            State dict at the start of the history.
+
+        Yields
+        ------
+        DriverStep
+            Includes ``n_outer_iter`` and ``residual_inf`` for NR diagnostics.
+        """
+        integrator = self.integrator
+        ntens = integrator.ntens
+        P, F = self._P, self._F
+        nP, nF = len(P), len(F)
+
+        if load.type != FieldType.STRAIN:
+            raise ValueError(
+                f"MixedDriver expects load.type=FieldType.STRAIN, got {load.type!r}"
+            )
+        eps_P_hist = np.asarray(load.data, dtype=float)
+        if eps_P_hist.ndim != 2 or eps_P_hist.shape[1] != nP:
+            raise ValueError(
+                f"load.data must have shape (N, {nP}), got {eps_P_hist.shape}"
+            )
+        N = eps_P_hist.shape[0]
+
+        if prescribed_stress_history is None:
+            if nF == 0:
+                sigF_hist = np.zeros((N, 0))
+            else:
+                sigF_hist = np.zeros((N, nF))
+        else:
+            if nF == 0:
+                raise ValueError(
+                    "prescribed_stress_history provided but there are no "
+                    "stress-prescribed components (nF=0)"
+                )
+            sigF_hist = np.asarray(prescribed_stress_history, dtype=float)
+            if sigF_hist.shape != (N, nF):
+                raise ValueError(
+                    f"prescribed_stress_history must have shape ({N}, {nF}), "
+                    f"got {sigF_hist.shape}"
+                )
+
+        stress_n = (
+            np.zeros(ntens) if initial_stress is None
+            else np.array(initial_stress, dtype=float)
+        )
+        state_n = (
+            integrator.initial_state() if initial_state is None
+            else {k: np.asarray(v) for k, v in initial_state.items()}
+        )
+        eps_total = np.zeros(ntens)
+
+        for i in range(N):
+            deps = np.zeros(ntens)
+            deps[P] = eps_P_hist[i] - eps_total[P]
+
+            if nF == 0:
+                rm = integrator.stress_update(deps, stress_n, state_n)
+                converged = True
+                k = 0
+                residual_inf = 0.0
+            else:
+                sigma_F_target = sigF_hist[i]
+
+                # Initial estimate: elastic compliance restricted to F-F block
+                if hasattr(integrator, "elastic_stiffness"):
+                    C0 = np.array(integrator.elastic_stiffness(state_n))
+                else:
+                    rm0 = integrator.stress_update(np.zeros(ntens), stress_n, state_n)
+                    C0 = np.array(rm0.ddsdde)
+                C0_FF = C0[np.ix_(F, F)]
+                C0_FP = C0[np.ix_(F, P)]
+                rhs0 = (sigma_F_target - stress_n[F]) - C0_FP @ deps[P]
+                deps[F] = np.linalg.solve(C0_FF, rhs0)
+
+                converged = False
+                residual_F = np.full(nF, np.inf)
+                rm = None
+                k = 0
+                for k in range(self.max_iter):
+                    rm = integrator.stress_update(deps, stress_n, state_n)
+                    residual_F = sigma_F_target - np.array(rm.stress)[F]
+                    if float(np.max(np.abs(residual_F))) < self.tol:
+                        converged = True
+                        break
+                    D_FF = np.array(rm.ddsdde)[np.ix_(F, F)]
+                    deps[F] = deps[F] + np.linalg.solve(D_FF, residual_F)
+
+                residual_inf = float(np.max(np.abs(residual_F)))
+
+            if not converged:
+                if raise_on_nonconverged:
+                    raise RuntimeError(
+                        f"MixedDriver: NR did not converge at step {i} "
+                        f"(||residual_F||_inf = {residual_inf:.3e}, "
+                        f"tol = {self.tol:.3e})"
+                    )
+                yield DriverStep(
+                    i=i,
+                    strain=eps_total.copy(),
+                    result=rm,
+                    converged=False,
+                    n_outer_iter=k + 1,
+                    residual_inf=residual_inf,
+                )
+                return
+
+            eps_total = eps_total + deps
+            stress_n = rm.stress
+            state_n = rm.state
+            yield DriverStep(
+                i=i,
+                strain=eps_total.copy(),
+                result=rm,
+                converged=True,
+                n_outer_iter=k + 1,
+                residual_inf=residual_inf,
+            )
+
+    def run(
+        self,
+        load: FieldHistory,
+        *,
+        prescribed_stress_history=None,
+        collect_state: dict[str, FieldType] | None = None,
+        initial_stress=None,
+        initial_state=None,
+    ) -> DriverResult:
+        """Run the mixed strain/stress loading history.
+
+        Parameters
+        ----------
+        load : FieldHistory
+            Must have ``type = FieldType.STRAIN`` and shape
+            ``(N, len(prescribed_strain_idx))``.
+        prescribed_stress_history : array-like of shape (N, len(prescribed_stress_idx)) or None
+            Target stress for the F components.  Defaults to zero.
+        collect_state : dict[str, FieldType] or None, optional
+            State variables to include in the result.
+        initial_stress : array-like or None, optional
+            Stress tensor at the start (default zero).
+        initial_state : dict or None, optional
+            State dict at the start (default integrator initial state).
+
+        Returns
+        -------
+        DriverResult
+
+        Raises
+        ------
+        RuntimeError
+            If inner NR does not converge within ``max_iter`` iterations at
+            any step.
+        """
+        step_results = []
+        strain_rows = []
+        for step in self.iter_run(
+            load,
+            prescribed_stress_history=prescribed_stress_history,
+            raise_on_nonconverged=True,
+            initial_stress=initial_stress,
+            initial_state=initial_state,
+        ):
             step_results.append(step.result)
             strain_rows.append(step.strain)
         strain_out = (

--- a/src/manforge/simulation/driver.py
+++ b/src/manforge/simulation/driver.py
@@ -405,7 +405,7 @@ class StressDriver(DriverBase):
 # ---------------------------------------------------------------------------
 
 def _validate_idx_arg(name: str, seq, ntens: int) -> list[int]:
-    """Validate a Voigt index sequence; return a sorted list."""
+    """Validate a Voigt index sequence; return list in original order."""
     try:
         lst = list(seq)
     except TypeError:
@@ -421,7 +421,7 @@ def _validate_idx_arg(name: str, seq, ntens: int) -> list[int]:
             raise ValueError(
                 f"{name} index {v} is out of range for ntens={ntens}"
             )
-    return sorted(ints)
+    return ints
 
 
 class MixedDriver(DriverBase):
@@ -442,11 +442,14 @@ class MixedDriver(DriverBase):
         Constitutive integrator.
     prescribed_strain_idx : Sequence[int]
         Voigt indices whose strain is prescribed by the caller (P components).
-        Must not be empty.
+        Must not be empty.  The order of indices determines the column order
+        expected in ``load.data``: ``load.data[:, k]`` is the history for
+        ``prescribed_strain_idx[k]``.
     prescribed_stress_idx : Sequence[int] or None, optional
         Voigt indices whose stress is prescribed (F components).  If ``None``
         (default), inferred as the complement of ``prescribed_strain_idx`` in
-        ``range(ntens)``.
+        ascending index order.  When provided explicitly, the order determines
+        the column order of ``prescribed_stress_history``.
     max_iter : int, optional
         Maximum inner Newton-Raphson iterations per step (default 20).
     tol : float, optional
@@ -459,6 +462,10 @@ class MixedDriver(DriverBase):
 
     The union of ``prescribed_strain_idx`` and ``prescribed_stress_idx`` must
     equal ``range(ntens)`` exactly; the intersection must be empty.
+
+    Index order is preserved: ``load.data[:, k]`` maps to
+    ``prescribed_strain_idx[k]``, and ``prescribed_stress_history[:, k]``
+    maps to ``prescribed_stress_idx[k]``.
 
     When ``len(prescribed_stress_idx) == 0`` (full strain control), the inner
     NR is skipped and the driver behaves identically to :class:`StrainDriver`.

--- a/src/manforge/simulation/types.py
+++ b/src/manforge/simulation/types.py
@@ -398,11 +398,18 @@ class DriverStep:
     result : StressUpdateResult
         Full stress-update result: stress, state, ddsdde, dlambda, is_plastic, etc.
     converged : bool
-        Outer NR convergence flag (StressDriver only; always ``True`` for StrainDriver).
+        NR convergence flag.  Always ``True`` for :class:`~manforge.simulation.driver.StrainDriver`.
+        For :class:`~manforge.simulation.driver.StressDriver` and
+        :class:`~manforge.simulation.driver.MixedDriver` reflects whether the
+        outer / inner Newton-Raphson loop converged within ``max_iter``.
     n_outer_iter : int
-        Number of outer NR iterations (StressDriver only; ``1`` for StrainDriver).
+        Number of NR iterations taken.  ``1`` for
+        :class:`~manforge.simulation.driver.StrainDriver`; the outer-loop count
+        for :class:`~manforge.simulation.driver.StressDriver`; the inner-loop
+        count for :class:`~manforge.simulation.driver.MixedDriver`.
     residual_inf : float
-        Final L∞ residual of outer NR (StressDriver only; ``0.0`` for StrainDriver).
+        Final L∞ norm of the NR residual.  ``0.0`` for
+        :class:`~manforge.simulation.driver.StrainDriver`.
 
     Examples
     --------
@@ -413,7 +420,7 @@ class DriverStep:
                 print(f"Plasticity onset at step {step.i}")
                 break
 
-    Inspect StressDriver convergence details::
+    Inspect NR convergence diagnostics (StressDriver / MixedDriver)::
 
         for step in driver.iter_run(model, load):
             print(step.i, step.n_outer_iter, step.residual_inf)

--- a/tests/integration/test_mixed_driver.py
+++ b/tests/integration/test_mixed_driver.py
@@ -1,0 +1,387 @@
+"""Tests for MixedDriver (mixed strain/stress boundary-condition driver)."""
+
+import numpy as np
+import pytest
+
+from manforge.core.dimension import SOLID_3D, UNIAXIAL_1D
+from manforge.models.j2_isotropic import J2Isotropic1D, J2Isotropic3D
+from manforge.simulation.driver import MixedDriver, StrainDriver, StressDriver
+from manforge.simulation.integrator import PythonNumericalIntegrator
+from manforge.simulation.types import FieldHistory, FieldType
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def strain_load(data, name="Strain"):
+    return FieldHistory(FieldType.STRAIN, name, data)
+
+
+def stress_load(data, name="Stress"):
+    return FieldHistory(FieldType.STRESS, name, data)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def model_3d():
+    return J2Isotropic3D(SOLID_3D, E=210000.0, nu=0.3, sigma_y0=250.0, H=1000.0)
+
+
+@pytest.fixture
+def model_1d():
+    return J2Isotropic1D(UNIAXIAL_1D, E=210000.0, nu=0.3, sigma_y0=250.0, H=1000.0)
+
+
+@pytest.fixture
+def integ_3d(model_3d):
+    return PythonNumericalIntegrator(model_3d)
+
+
+@pytest.fixture
+def integ_1d(model_1d):
+    return PythonNumericalIntegrator(model_1d)
+
+
+# ---------------------------------------------------------------------------
+# __init__ validation
+# ---------------------------------------------------------------------------
+
+def test_validation_duplicate_strain_idx(integ_3d):
+    with pytest.raises(ValueError, match="duplicate"):
+        MixedDriver(integ_3d, prescribed_strain_idx=[0, 0])
+
+
+def test_validation_out_of_range(integ_3d):
+    with pytest.raises(ValueError, match="out of range"):
+        MixedDriver(integ_3d, prescribed_strain_idx=[7])
+
+
+def test_validation_overlap(integ_3d):
+    with pytest.raises(ValueError, match="disjoint"):
+        MixedDriver(integ_3d, prescribed_strain_idx=[0, 1],
+                    prescribed_stress_idx=[1, 2, 3, 4, 5])
+
+
+def test_validation_incomplete_union(integ_3d):
+    with pytest.raises(ValueError, match="cover all"):
+        MixedDriver(integ_3d, prescribed_strain_idx=[0],
+                    prescribed_stress_idx=[1, 2, 3])  # missing 4, 5
+
+
+def test_validation_empty_strain_idx(integ_3d):
+    with pytest.raises(ValueError, match="must not be empty"):
+        MixedDriver(integ_3d, prescribed_strain_idx=[])
+
+
+def test_validation_load_type_must_be_strain(integ_3d):
+    driver = MixedDriver(integ_3d, prescribed_strain_idx=[0])
+    N = 5
+    bad_load = stress_load(np.zeros((N, 6)))
+    with pytest.raises(ValueError, match="FieldType.STRAIN"):
+        list(driver.iter_run(bad_load))
+
+
+def test_validation_load_shape_must_match_nP(integ_3d):
+    driver = MixedDriver(integ_3d, prescribed_strain_idx=[0])
+    N = 5
+    bad_load = strain_load(np.zeros((N, 6)))  # expects (N, 1)
+    with pytest.raises(ValueError, match=r"\(N, 1\)"):
+        list(driver.iter_run(bad_load))
+
+
+def test_validation_stress_history_shape_mismatch(integ_3d):
+    driver = MixedDriver(integ_3d, prescribed_strain_idx=[0])
+    N = 5
+    load = strain_load(np.zeros((N, 1)))
+    bad_sig = np.zeros((N, 3))  # expects (N, 5)
+    with pytest.raises(ValueError, match=r"\(5, 5\)"):
+        list(driver.iter_run(load, prescribed_stress_history=bad_sig))
+
+
+def test_complement_inferred_from_strain_idx(integ_3d):
+    driver = MixedDriver(integ_3d, prescribed_strain_idx=[0])
+    np.testing.assert_array_equal(driver._P, [0])
+    np.testing.assert_array_equal(driver._F, [1, 2, 3, 4, 5])
+
+
+def test_explicit_stress_idx_matches_complement(integ_3d):
+    driver = MixedDriver(integ_3d, prescribed_strain_idx=[0],
+                         prescribed_stress_idx=[1, 2, 3, 4, 5])
+    np.testing.assert_array_equal(driver._P, [0])
+    np.testing.assert_array_equal(driver._F, [1, 2, 3, 4, 5])
+
+
+def test_validation_stress_history_provided_when_nF_zero(integ_3d):
+    driver = MixedDriver(integ_3d, prescribed_strain_idx=[0, 1, 2, 3, 4, 5])
+    N = 3
+    load = strain_load(np.zeros((N, 6)))
+    with pytest.raises(ValueError, match="no stress-prescribed"):
+        list(driver.iter_run(load, prescribed_stress_history=np.zeros((N, 1))))
+
+
+# ---------------------------------------------------------------------------
+# Output shape
+# ---------------------------------------------------------------------------
+
+def test_output_shapes(integ_3d):
+    N = 10
+    driver = MixedDriver(integ_3d, prescribed_strain_idx=[0])
+    load = strain_load(np.linspace(0, 0.005, N).reshape(-1, 1))
+    result = driver.run(load)
+    assert result.stress.shape == (N, 6)
+    assert result.strain.shape == (N, 6)
+
+
+# ---------------------------------------------------------------------------
+# Elastic uniaxial: 3D model, ε11 controlled, σ_other = 0
+# ---------------------------------------------------------------------------
+
+def test_uniaxial_elastic_stress_11(model_3d, integ_3d):
+    E, nu = model_3d.E, model_3d.nu
+    sigma_y0 = model_3d.sigma_y0
+    N = 20
+    eps_max = 0.5 * sigma_y0 / E  # stay elastic
+
+    load = strain_load(np.linspace(0, eps_max, N).reshape(-1, 1))
+    driver = MixedDriver(integ_3d, prescribed_strain_idx=[0])
+    result = driver.run(load)
+
+    eps_hist = np.linspace(0, eps_max, N)
+    np.testing.assert_allclose(result.stress[:, 0], E * eps_hist, rtol=1e-5,
+                               err_msg="σ11 must equal E * ε11 in elastic regime")
+
+
+def test_uniaxial_elastic_lateral_stress_zero(model_3d, integ_3d):
+    E, sigma_y0 = model_3d.E, model_3d.sigma_y0
+    N = 20
+    eps_max = 0.5 * sigma_y0 / E
+
+    load = strain_load(np.linspace(0, eps_max, N).reshape(-1, 1))
+    result = MixedDriver(integ_3d, prescribed_strain_idx=[0]).run(load)
+
+    np.testing.assert_allclose(result.stress[:, 1:], 0.0, atol=1e-6,
+                               err_msg="σ_other must be ~0 under uniaxial strain control")
+
+
+def test_uniaxial_elastic_lateral_strains(model_3d, integ_3d):
+    E, nu, sigma_y0 = model_3d.E, model_3d.nu, model_3d.sigma_y0
+    N = 20
+    eps_max = 0.5 * sigma_y0 / E
+    eps_hist = np.linspace(0, eps_max, N)
+
+    load = strain_load(eps_hist.reshape(-1, 1))
+    result = MixedDriver(integ_3d, prescribed_strain_idx=[0]).run(load)
+
+    np.testing.assert_allclose(result.strain[:, 1], -nu * eps_hist, rtol=1e-5,
+                               err_msg="ε22 must equal -ν·ε11 in elastic regime")
+    np.testing.assert_allclose(result.strain[:, 2], -nu * eps_hist, rtol=1e-5,
+                               err_msg="ε33 must equal -ν·ε11 in elastic regime")
+    np.testing.assert_allclose(result.strain[:, 3:], 0.0, atol=1e-10,
+                               err_msg="shear strains must be zero under uniaxial loading")
+
+
+# ---------------------------------------------------------------------------
+# Plastic: MixedDriver(ε11 control) matches StressDriver(σ11 target, others=0)
+# ---------------------------------------------------------------------------
+
+def test_uniaxial_plastic_matches_stressdriver(model_3d, integ_3d):
+    """MixedDriver and StressDriver must agree on stress and strain under uniaxial loading."""
+    sigma_y0 = model_3d.sigma_y0
+    E = model_3d.E
+    N = 30
+    eps_max = 3.0 * sigma_y0 / E  # well into plastic zone
+
+    load_mixed = strain_load(np.linspace(0, eps_max, N).reshape(-1, 1))
+    res_mixed = MixedDriver(integ_3d, prescribed_strain_idx=[0]).run(load_mixed)
+
+    # Build σ11 target history from MixedDriver output, feed into StressDriver
+    sig_history = np.zeros((N, 6))
+    sig_history[:, 0] = res_mixed.stress[:, 0]
+    res_stress = StressDriver(integ_3d).run(stress_load(sig_history))
+
+    np.testing.assert_allclose(res_mixed.stress, res_stress.stress, atol=1e-5,
+                               err_msg="Stress mismatch between MixedDriver and StressDriver")
+    np.testing.assert_allclose(res_mixed.strain, res_stress.strain, atol=1e-5,
+                               err_msg="Strain mismatch between MixedDriver and StressDriver")
+
+
+# ---------------------------------------------------------------------------
+# Consistency with 1D StrainDriver
+# ---------------------------------------------------------------------------
+
+def test_consistency_with_1d_strain_driver(model_3d, integ_3d, model_1d, integ_1d):
+    """MixedDriver(3D, ε11 control) must produce the same σ11 and ep as StrainDriver(1D)."""
+    sigma_y0 = model_3d.sigma_y0
+    E = model_3d.E
+    N = 30
+    eps_max = 3.0 * sigma_y0 / E
+
+    eps_hist = np.linspace(0, eps_max, N)
+    load_mixed = strain_load(eps_hist.reshape(-1, 1))
+    res_3d = MixedDriver(integ_3d, prescribed_strain_idx=[0]).run(
+        load_mixed, collect_state={"ep": FieldType.STRAIN}
+    )
+
+    # 1D StrainDriver with the same ε11 history (shape (N,) uniaxial)
+    res_1d = StrainDriver(integ_1d).run(
+        FieldHistory(FieldType.STRAIN, "Strain", eps_hist),
+        collect_state={"ep": FieldType.STRAIN},
+    )
+
+    np.testing.assert_allclose(res_3d.stress[:, 0], res_1d.stress[:, 0], rtol=1e-4,
+                               err_msg="σ11 mismatch between 3D MixedDriver and 1D StrainDriver")
+    np.testing.assert_allclose(res_3d.fields["ep"].data, res_1d.fields["ep"].data, rtol=1e-4,
+                               err_msg="ep mismatch between 3D MixedDriver and 1D StrainDriver")
+
+
+# ---------------------------------------------------------------------------
+# Biaxial: ε11 controlled + σ22 = constant lateral pressure
+# ---------------------------------------------------------------------------
+
+def test_biaxial_constant_lateral_stress(model_3d, integ_3d):
+    """σ22 target must be satisfied at every step while ε11 is ramped."""
+    sigma_y0 = model_3d.sigma_y0
+    E = model_3d.E
+    N = 30
+    eps_max = 2.0 * sigma_y0 / E
+    sigma22_target = -100.0  # compressive lateral pressure
+
+    load = strain_load(np.linspace(0, eps_max, N).reshape(-1, 1))
+
+    # prescribed_stress_history: (N, 5) with σ22 in first column
+    sig_F = np.zeros((N, 5))
+    sig_F[:, 0] = sigma22_target  # F=[1,2,3,4,5] so index 0 → Voigt component 1 = σ22
+
+    driver = MixedDriver(integ_3d, prescribed_strain_idx=[0])
+    result = driver.run(load, prescribed_stress_history=sig_F)
+
+    np.testing.assert_allclose(result.stress[:, 1], sigma22_target, atol=1e-5,
+                               err_msg="σ22 must match the prescribed target")
+    np.testing.assert_allclose(result.stress[:, 2:], 0.0, atol=1e-5,
+                               err_msg="σ33, σ12, σ13, σ23 must be ~0 (not prescribed)")
+
+
+# ---------------------------------------------------------------------------
+# Degenerate case: full strain control (nF = 0)
+# ---------------------------------------------------------------------------
+
+def test_full_strain_control_matches_strain_driver(model_3d, integ_3d):
+    """MixedDriver with all 6 components strain-controlled must agree with StrainDriver."""
+    sigma_y0 = model_3d.sigma_y0
+    E = model_3d.E
+    N = 20
+
+    strain6 = np.zeros((N, 6))
+    strain6[:, 0] = np.linspace(0, 3.0 * sigma_y0 / E, N)
+
+    load_mixed = strain_load(strain6)
+    load_strain = FieldHistory(FieldType.STRAIN, "Strain", strain6)
+
+    res_mixed = MixedDriver(integ_3d, prescribed_strain_idx=[0, 1, 2, 3, 4, 5]).run(load_mixed)
+    res_strain = StrainDriver(integ_3d).run(load_strain)
+
+    np.testing.assert_allclose(res_mixed.stress, res_strain.stress, atol=1e-10)
+    np.testing.assert_allclose(res_mixed.strain, res_strain.strain, atol=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# Convergence failure
+# ---------------------------------------------------------------------------
+
+def test_max_iter_one_raises(model_3d, integ_3d):
+    """max_iter=1 must fail on a plastic step and raise RuntimeError."""
+    sigma_y0 = model_3d.sigma_y0
+    E = model_3d.E
+    # single large step into plastic zone
+    load = strain_load(np.array([[3.0 * sigma_y0 / E]]))
+    driver = MixedDriver(integ_3d, prescribed_strain_idx=[0], max_iter=1)
+    with pytest.raises(RuntimeError, match="NR did not converge"):
+        driver.run(load)
+
+
+def test_raise_on_nonconverged_false_yields_and_stops(model_3d, integ_3d):
+    """raise_on_nonconverged=False must yield a non-converged step and stop."""
+    sigma_y0 = model_3d.sigma_y0
+    E = model_3d.E
+    N = 3
+    eps_hist = np.linspace(0, 3.0 * sigma_y0 / E, N).reshape(-1, 1)
+    load = strain_load(eps_hist)
+
+    driver = MixedDriver(integ_3d, prescribed_strain_idx=[0], max_iter=1)
+    steps = list(driver.iter_run(load, raise_on_nonconverged=False))
+
+    assert len(steps) >= 1
+    # At least one step must be non-converged (the driver stops after the first failure)
+    non_converged = [s for s in steps if not s.converged]
+    assert len(non_converged) == 1
+    assert non_converged[0].i < N  # stopped before end
+
+
+# ---------------------------------------------------------------------------
+# initial_stress / initial_state
+# ---------------------------------------------------------------------------
+
+def test_initial_stress_and_state_accepted(model_3d, integ_3d):
+    """initial_stress / initial_state must be accepted and simulation must converge."""
+    sigma_y0 = model_3d.sigma_y0
+    E = model_3d.E
+    N = 10
+    # First run: get a mid-point state
+    eps_first = np.linspace(0, sigma_y0 / E, N).reshape(-1, 1)
+    res_first = MixedDriver(integ_3d, prescribed_strain_idx=[0]).run(strain_load(eps_first))
+
+    mid_stress = res_first.step_results[-1].stress
+    mid_state = res_first.step_results[-1].state
+
+    # Second run continuing from that state
+    eps_second = np.linspace(sigma_y0 / E, 2.0 * sigma_y0 / E, N).reshape(-1, 1)
+    driver = MixedDriver(integ_3d, prescribed_strain_idx=[0])
+    result = driver.run(
+        strain_load(eps_second),
+        initial_stress=mid_stress,
+        initial_state=mid_state,
+    )
+    assert result.stress.shape == (N, 6)
+    assert all(s.converged for s in result.step_results)
+
+
+# ---------------------------------------------------------------------------
+# collect_state
+# ---------------------------------------------------------------------------
+
+def test_collect_state_ep(model_3d, integ_3d):
+    """collect_state must include ep in the result fields."""
+    sigma_y0 = model_3d.sigma_y0
+    E = model_3d.E
+    N = 20
+    load = strain_load(np.linspace(0, 3.0 * sigma_y0 / E, N).reshape(-1, 1))
+    result = MixedDriver(integ_3d, prescribed_strain_idx=[0]).run(
+        load, collect_state={"ep": FieldType.STRAIN}
+    )
+    assert "ep" in result.fields
+    ep = result.fields["ep"].data
+    assert ep.shape == (N,)
+    assert result.fields["ep"].type == FieldType.STRAIN
+    assert ep[-1] > 0.0, "ep should be positive after plastic loading"
+
+
+# ---------------------------------------------------------------------------
+# ε_P fidelity: prescribed strain components must equal the input history
+# ---------------------------------------------------------------------------
+
+def test_prescribed_strain_equals_input(model_3d, integ_3d):
+    """eps_total[P] at each step must equal the prescribed strain history."""
+    sigma_y0 = model_3d.sigma_y0
+    E = model_3d.E
+    N = 30
+    eps_hist = np.linspace(0, 3.0 * sigma_y0 / E, N)
+
+    load = strain_load(eps_hist.reshape(-1, 1))
+    result = MixedDriver(integ_3d, prescribed_strain_idx=[0]).run(load)
+
+    np.testing.assert_allclose(result.strain[:, 0], eps_hist, atol=1e-12,
+                               err_msg="ε11 (P component) must equal the prescribed input history")

--- a/tests/integration/test_mixed_driver.py
+++ b/tests/integration/test_mixed_driver.py
@@ -164,7 +164,7 @@ def test_uniaxial_elastic_lateral_stress_zero(model_3d, integ_3d):
     result = MixedDriver(integ_3d, prescribed_strain_idx=[0]).run(load)
 
     np.testing.assert_allclose(result.stress[:, 1:], 0.0, atol=1e-6,
-                               err_msg="σ_other must be ~0 under uniaxial strain control")
+                               err_msg="σ_other must be ~0 under uniaxial stress control (σ=0 prescribed)")
 
 
 def test_uniaxial_elastic_lateral_strains(model_3d, integ_3d):


### PR DESCRIPTION
## Summary

- `MixedDriver` を新設。任意の Voigt 成分を strain 制御 / stress 制御に振り分け、内側 Newton-Raphson で自由ひずみ成分を解く。
- 典型用途: 3D solid (ntens=6) で ε11 をランプし、σ22..σ23 = 0 を保つ uniaxial-stress 試験を 1D ラッパなしで再現。
- `simulation/__init__.py` に `MixedDriver` を export 追加。既存 `StrainDriver` / `StressDriver` への変更なし。

## 動作概要

```python
from manforge.simulation import MixedDriver
from manforge.simulation.types import FieldHistory, FieldType

driver = MixedDriver(
    integrator,
    prescribed_strain_idx=(0,),   # ε11 を制御
    # prescribed_stress_idx は省略可 (補集合を自動推論 → [1,2,3,4,5])
)
result = driver.run(FieldHistory(FieldType.STRAIN, "Strain", eps11_hist))  # (N, 1)
# result.stress[:, 0] = σ11  / result.stress[:, 1:] ≈ 0
# result.strain[:, 0] = ε11  / result.strain[:, 1:] = 横ひずみ (自由)
```

biaxial（σ22 = −100 MPa 一定 + ε11 制御）:

```python
sig_F = np.zeros((N, 5))
sig_F[:, 0] = -100.0          # F=[1,2,3,4,5] の先頭 → Voigt 成分 1 = σ22
result = driver.run(load, prescribed_stress_history=sig_F)
```

## 実装の核心

| | 説明 |
|---|---|
| **P 成分** (prescribed_strain_idx) | 入力履歴をひずみとして固定、反復中に変更しない |
| **F 成分** (prescribed_stress_idx) | `C0[F,F]` で初期推定 → `ddsdde[F,F]` で内側 NR |
| **nF = 0** | 内側 NR をスキップ、`StrainDriver` と等価動作 |
| **nP = 0** | reject (`ValueError`) — `StressDriver` を使う旨のメッセージ |

## Test plan

- [x] バリデーション: 重複 idx / 範囲外 / P∩F≠∅ / P∪F≠全成分 / 空 P / 不正 load type・shape → `ValueError`
- [x] 弾性解析解との一致: σ11 = E·ε11、ε22=ε33=−ν·ε11、σ_other ≈ 0
- [x] `StressDriver` 全成分版との数値一致 (atol=1e-5、弾性〜塑性域)
- [x] `StrainDriver(J2Isotropic1D)` との σ11 / ep 一致
- [x] biaxial: σ22 = −100 MPa 拘束が全ステップで満足されること
- [x] nF=0 縮退: `StrainDriver` と完全一致
- [x] 収束失敗: `max_iter=1` で `RuntimeError`、`raise_on_nonconverged=False` で非収束 step を yield して停止
- [x] `initial_stress` / `initial_state` / `collect_state` が正常動作
- [x] `ε_total[P]` が入力履歴に完全一致 (atol=1e-12)

全 24 テスト通過 / 既存 571 テストへのリグレッションなし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)