### PR TITLE
feat(utils): smooth_heaviside / smooth_min / smooth_max を追加

### DIFF
--- a/src/manforge/utils/smooth.py
+++ b/src/manforge/utils/smooth.py
@@ -4,7 +4,19 @@ All functions are composed entirely of autograd/numpy primitives and are
 fully differentiable everywhere, including at the singular points of their
 non-smooth counterparts.
 
-Default: ``eps = 1e-30``.  With float64, ``sqrt(1e-30) ≈ 3e-16``.
+Functions and their parameters:
+
+  smooth_sqrt(x, eps=1e-30)        √(x + ε²)                  ε: denominator stabiliser
+  smooth_abs(x, eps=1e-30)         √(x² + ε²)                 ε: denominator stabiliser
+  smooth_norm(v, eps=1e-30)        √(v·v + ε²)                ε: denominator stabiliser
+  smooth_macaulay(x, eps=1e-30)    (x + smooth_abs(x)) / 2    ε: denominator stabiliser
+  smooth_direction(v, eps=1e-30)   v / smooth_norm(v)          ε: denominator stabiliser
+  smooth_heaviside(x, beta=50.0)   0.5·(1 + tanh(β·x/2))      β: transition sharpness
+  smooth_min(a, b, eps=1e-30)      (a+b - smooth_abs(a-b)) / 2  ε: denominator stabiliser
+  smooth_max(a, b, eps=1e-30)      (a+b + smooth_abs(a-b)) / 2  ε: denominator stabiliser
+
+``eps`` regularises denominators at zero; with float64, ``sqrt(1e-30) ≈ 3e-16``.
+``beta`` controls the steepness of the Heaviside step: larger β → sharper transition.
 """
 
 import autograd.numpy as anp
@@ -35,3 +47,22 @@ def smooth_macaulay(x: anp.ndarray, eps: float = _DEFAULT_EPS) -> anp.ndarray:
 def smooth_direction(v: anp.ndarray, eps: float = _DEFAULT_EPS) -> anp.ndarray:
     """Smooth unit direction: v / smooth_norm(v)."""
     return v / smooth_norm(v, eps)
+
+
+def smooth_heaviside(x: anp.ndarray, beta: float = 50.0) -> anp.ndarray:
+    """Smooth Heaviside step: 0.5·(1 + tanh(β·x/2)).
+
+    tanh formulation avoids exp overflow that would arise from 1/(1+exp(-βx)).
+    At x=0 returns exactly 0.5; larger β gives a sharper transition.
+    """
+    return 0.5 * (1.0 + anp.tanh(0.5 * beta * x))
+
+
+def smooth_min(a: anp.ndarray, b: anp.ndarray, eps: float = _DEFAULT_EPS) -> anp.ndarray:
+    """Smooth minimum: (a + b - smooth_abs(a - b)) / 2."""
+    return 0.5 * (a + b - smooth_abs(a - b, eps))
+
+
+def smooth_max(a: anp.ndarray, b: anp.ndarray, eps: float = _DEFAULT_EPS) -> anp.ndarray:
+    """Smooth maximum: (a + b + smooth_abs(a - b)) / 2."""
+    return 0.5 * (a + b + smooth_abs(a - b, eps))

--- a/src/manforge/utils/smooth.py
+++ b/src/manforge/utils/smooth.py
@@ -12,10 +12,10 @@ Functions and their parameters:
   smooth_macaulay(x, eps=1e-30)    (x + smooth_abs(x)) / 2    ε: denominator stabiliser
   smooth_direction(v, eps=1e-30)   v / smooth_norm(v)          ε: denominator stabiliser
   smooth_heaviside(x, beta=50.0)   0.5·(1 + tanh(β·x/2))      β: transition sharpness
-  smooth_min(a, b, eps=1e-30)      (a+b - smooth_abs(a-b)) / 2  ε: denominator stabiliser
-  smooth_max(a, b, eps=1e-30)      (a+b + smooth_abs(a-b)) / 2  ε: denominator stabiliser
+  smooth_min(a, b, eps=1e-30)      b + (d - smooth_abs(d)) / 2  ε: denominator stabiliser
+  smooth_max(a, b, eps=1e-30)      b + (d + smooth_abs(d)) / 2  ε: denominator stabiliser
 
-``eps`` regularises denominators at zero; with float64, ``sqrt(1e-30) ≈ 3e-16``.
+``eps`` regularises denominators at zero; with float64, ``sqrt(1e-30) ≈ 1e-15``.
 ``beta`` controls the steepness of the Heaviside step: larger β → sharper transition.
 """
 
@@ -59,10 +59,20 @@ def smooth_heaviside(x: anp.ndarray, beta: float = 50.0) -> anp.ndarray:
 
 
 def smooth_min(a: anp.ndarray, b: anp.ndarray, eps: float = _DEFAULT_EPS) -> anp.ndarray:
-    """Smooth minimum: (a + b - smooth_abs(a - b)) / 2."""
-    return 0.5 * (a + b - smooth_abs(a - b, eps))
+    """Smooth minimum: b + (d - smooth_abs(d)) / 2, where d = a - b.
+
+    Avoids the a+b intermediate to prevent overflow when a and b are large
+    with the same sign.
+    """
+    d = a - b
+    return b + 0.5 * (d - smooth_abs(d, eps))
 
 
 def smooth_max(a: anp.ndarray, b: anp.ndarray, eps: float = _DEFAULT_EPS) -> anp.ndarray:
-    """Smooth maximum: (a + b + smooth_abs(a - b)) / 2."""
-    return 0.5 * (a + b + smooth_abs(a - b, eps))
+    """Smooth maximum: b + (d + smooth_abs(d)) / 2, where d = a - b.
+
+    Avoids the a+b intermediate to prevent overflow when a and b are large
+    with the same sign.
+    """
+    d = a - b
+    return b + 0.5 * (d + smooth_abs(d, eps))

--- a/tests/unit/test_smooth.py
+++ b/tests/unit/test_smooth.py
@@ -19,6 +19,9 @@ from manforge.utils.smooth import (
     smooth_norm,
     smooth_macaulay,
     smooth_direction,
+    smooth_heaviside,
+    smooth_min,
+    smooth_max,
     _DEFAULT_EPS,
 )
 
@@ -286,3 +289,142 @@ class TestAFPattern:
         # Gradient at dlambda=0 (where xi = stress - alpha = 0)
         grad = autograd.grad(alpha_sq_norm)(anp.array(0.0))
         assert np.isfinite(float(grad)), f"gradient is not finite: {grad}"
+
+
+# ---------------------------------------------------------------------------
+# smooth_heaviside
+# ---------------------------------------------------------------------------
+
+class TestSmoothHeaviside:
+    def test_large_positive_approaches_one(self):
+        """For x >> 0: smooth_heaviside(x) ≈ 1."""
+        val = float(smooth_heaviside(anp.array(100.0)))
+        np.testing.assert_allclose(val, 1.0, atol=1e-10)
+
+    def test_large_negative_approaches_zero(self):
+        """For x << 0: smooth_heaviside(x) ≈ 0."""
+        val = float(smooth_heaviside(anp.array(-100.0)))
+        np.testing.assert_allclose(val, 0.0, atol=1e-10)
+
+    def test_at_zero_returns_half(self):
+        """At x=0: value = 0.5 exactly."""
+        val = float(smooth_heaviside(anp.array(0.0)))
+        np.testing.assert_allclose(val, 0.5, atol=1e-15)
+
+    def test_gradient_positive_at_zero(self):
+        """At x=0: gradient > 0 (monotone increasing)."""
+        grad = float(autograd.grad(smooth_heaviside)(anp.array(0.0)))
+        assert grad > 0.0, f"Expected positive gradient, got {grad}"
+
+    def test_gradient_finite_everywhere(self):
+        """Gradient is finite for a range of inputs."""
+        xs = anp.linspace(-10.0, 10.0, 201)
+        for x in xs:
+            g = float(autograd.grad(smooth_heaviside)(x))
+            assert np.isfinite(g), f"gradient not finite at x={x}: {g}"
+
+    def test_larger_beta_sharper_transition(self):
+        """Larger beta gives value closer to 1 at small positive x."""
+        x = anp.array(0.1)
+        val_low = float(smooth_heaviside(x, beta=1.0))
+        val_high = float(smooth_heaviside(x, beta=50.0))
+        assert val_high > val_low, "larger beta should give sharper step"
+
+    def test_array_broadcast(self):
+        """Works on arrays element-wise."""
+        xs = anp.array([-10.0, 0.0, 10.0])
+        result = smooth_heaviside(xs)
+        assert result.shape == (3,)
+        assert float(result[1]) == pytest.approx(0.5, abs=1e-15)
+
+
+# ---------------------------------------------------------------------------
+# smooth_min
+# ---------------------------------------------------------------------------
+
+class TestSmoothMin:
+    def test_min_of_two_distinct(self):
+        """smooth_min(2, 3) ≈ 2."""
+        val = float(smooth_min(anp.array(2.0), anp.array(3.0)))
+        np.testing.assert_allclose(val, 2.0, rtol=1e-10)
+
+    def test_min_negative(self):
+        """smooth_min(-1, 5) ≈ -1."""
+        val = float(smooth_min(anp.array(-1.0), anp.array(5.0)))
+        np.testing.assert_allclose(val, -1.0, rtol=1e-10)
+
+    def test_equal_inputs(self):
+        """smooth_min(x, x) ≈ x (continuous at a=b)."""
+        x = anp.array(3.0)
+        val = float(smooth_min(x, x))
+        np.testing.assert_allclose(val, 3.0, rtol=1e-10)
+
+    def test_gradient_finite(self):
+        """Gradient w.r.t. first argument is finite."""
+        grad = float(autograd.grad(lambda a: smooth_min(a, anp.array(1.0)))(anp.array(0.5)))
+        assert np.isfinite(grad)
+
+    def test_symmetric(self):
+        """smooth_min(a, b) == smooth_min(b, a)."""
+        a, b = anp.array(2.0), anp.array(5.0)
+        np.testing.assert_allclose(float(smooth_min(a, b)), float(smooth_min(b, a)), rtol=1e-12)
+
+    def test_array_broadcast(self):
+        """Works on arrays element-wise."""
+        a = anp.array([1.0, 5.0, -2.0])
+        b = anp.array([3.0, 2.0,  1.0])
+        result = smooth_min(a, b)
+        expected = anp.array([1.0, 2.0, -2.0])
+        np.testing.assert_allclose(np.array(result), np.array(expected), rtol=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# smooth_max
+# ---------------------------------------------------------------------------
+
+class TestSmoothMax:
+    def test_max_of_two_distinct(self):
+        """smooth_max(2, 3) ≈ 3."""
+        val = float(smooth_max(anp.array(2.0), anp.array(3.0)))
+        np.testing.assert_allclose(val, 3.0, rtol=1e-10)
+
+    def test_max_negative(self):
+        """smooth_max(-1, 5) ≈ 5."""
+        val = float(smooth_max(anp.array(-1.0), anp.array(5.0)))
+        np.testing.assert_allclose(val, 5.0, rtol=1e-10)
+
+    def test_equal_inputs(self):
+        """smooth_max(x, x) ≈ x."""
+        x = anp.array(3.0)
+        val = float(smooth_max(x, x))
+        np.testing.assert_allclose(val, 3.0, rtol=1e-10)
+
+    def test_gradient_finite(self):
+        """Gradient w.r.t. first argument is finite."""
+        grad = float(autograd.grad(lambda a: smooth_max(a, anp.array(1.0)))(anp.array(2.0)))
+        assert np.isfinite(grad)
+
+    def test_symmetric(self):
+        """smooth_max(a, b) == smooth_max(b, a)."""
+        a, b = anp.array(2.0), anp.array(5.0)
+        np.testing.assert_allclose(float(smooth_max(a, b)), float(smooth_max(b, a)), rtol=1e-12)
+
+    def test_array_broadcast(self):
+        """Works on arrays element-wise."""
+        a = anp.array([1.0, 5.0, -2.0])
+        b = anp.array([3.0, 2.0,  1.0])
+        result = smooth_max(a, b)
+        expected = anp.array([3.0, 5.0, 1.0])
+        np.testing.assert_allclose(np.array(result), np.array(expected), rtol=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# smooth_min / smooth_max consistency
+# ---------------------------------------------------------------------------
+
+class TestSmoothMinMaxConsistency:
+    def test_min_plus_max_equals_sum(self):
+        """smooth_min(a,b) + smooth_max(a,b) == a + b."""
+        a, b = anp.array(2.7), anp.array(-1.3)
+        total = float(smooth_min(a, b)) + float(smooth_max(a, b))
+        np.testing.assert_allclose(total, float(a + b), rtol=1e-12)


### PR DESCRIPTION
## Summary

- `smooth_heaviside(x, beta=50)` — シグモイド `0.5·(1+tanh(β·x/2))`。`exp` overflow を回避するため `tanh` 経由で実装。loading/unloading switch や viscoplastic step function の将来利用向け。
- `smooth_min(a, b, eps=1e-30)` — `(a+b - smooth_abs(a-b)) / 2`。stress cap・damage threshold 等で滑らかな min が必要なケース向け。
- `smooth_max(a, b, eps=1e-30)` — `(a+b + smooth_abs(a-b)) / 2`。
- モジュール docstring に全 8 関数の一覧表を追記（関数名 / 公式 / パラメータの意味）。

現時点での具体的な model 適用先はなし（汎用ツールキット位置づけ）。AF/OW の `n_hat` リファクタは次元横断の意味論の違い（Mandel 重み・PS 欠落成分補正・1D スケール）があるため別タスクに分離。

## Test plan

- [ ] `uv run pytest tests/unit/test_smooth.py -v` — 54 件全パス (既存 34 + 新規 20)
- [ ] `make test` — 616 件全パス、リグレッションなし
- [ ] autograd トレース下での勾配有限性を各テストで検証済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)