### PR TITLE
fix(utils): smooth_heaviside の tanh VJP overflow を custom primitive で根本対処

### DIFF
--- a/src/manforge/utils/smooth.py
+++ b/src/manforge/utils/smooth.py
@@ -19,9 +19,24 @@ Functions and their parameters:
 ``beta`` controls the steepness of the Heaviside step: larger β → sharper transition.
 """
 
+import numpy as _np
 import autograd.numpy as anp
+from autograd.extend import defvjp, primitive
 
 _DEFAULT_EPS: float = 1e-30
+
+
+@primitive
+def _stable_tanh(x):
+    """autograd primitive whose VJP uses ``1 − tanh(x)²`` instead of
+    ``1 / cosh(x)²``, avoiding float64 overflow at ``|x| ≳ 354``.
+    Forward value is identical to ``np.tanh``; only :func:`smooth_heaviside`
+    uses this; global ``anp.tanh`` is untouched.
+    """
+    return _np.tanh(x)
+
+
+defvjp(_stable_tanh, lambda ans, x: lambda g: g * (1.0 - ans * ans))
 
 
 def smooth_sqrt(x: anp.ndarray, eps: float = _DEFAULT_EPS) -> anp.ndarray:
@@ -52,10 +67,12 @@ def smooth_direction(v: anp.ndarray, eps: float = _DEFAULT_EPS) -> anp.ndarray:
 def smooth_heaviside(x: anp.ndarray, beta: float = 50.0) -> anp.ndarray:
     """Smooth Heaviside step: 0.5·(1 + tanh(β·x/2)).
 
-    tanh formulation avoids exp overflow that would arise from 1/(1+exp(-βx)).
+    Uses :func:`_stable_tanh` so the autograd VJP follows ``1 − tanh²``
+    instead of ``1 / cosh²``, avoiding overflow at ``|β·x/2| ≳ 354``
+    (i.e. ``|x| ≳ 709/β``; with default β=50, ``|x| ≳ 14.2``).
     At x=0 returns exactly 0.5; larger β gives a sharper transition.
     """
-    return 0.5 * (1.0 + anp.tanh(0.5 * beta * x))
+    return 0.5 * (1.0 + _stable_tanh(0.5 * beta * x))
 
 
 def smooth_min(a: anp.ndarray, b: anp.ndarray, eps: float = _DEFAULT_EPS) -> anp.ndarray:

--- a/src/manforge/utils/smooth.py
+++ b/src/manforge/utils/smooth.py
@@ -19,7 +19,7 @@ Functions and their parameters:
 ``beta`` controls the steepness of the Heaviside step: larger β → sharper transition.
 """
 
-import numpy as _np
+import numpy as np
 import autograd.numpy as anp
 from autograd.extend import defvjp, primitive
 
@@ -27,13 +27,13 @@ _DEFAULT_EPS: float = 1e-30
 
 
 @primitive
-def _stable_tanh(x):
+def _stable_tanh(x: anp.ndarray) -> anp.ndarray:
     """autograd primitive whose VJP uses ``1 − tanh(x)²`` instead of
     ``1 / cosh(x)²``, avoiding float64 overflow at ``|x| ≳ 354``.
     Forward value is identical to ``np.tanh``; only :func:`smooth_heaviside`
     uses this; global ``anp.tanh`` is untouched.
     """
-    return _np.tanh(x)
+    return np.tanh(x)
 
 
 defvjp(_stable_tanh, lambda ans, x: lambda g: g * (1.0 - ans * ans))

--- a/tests/unit/test_smooth.py
+++ b/tests/unit/test_smooth.py
@@ -317,11 +317,27 @@ class TestSmoothHeaviside:
         assert grad > 0.0, f"Expected positive gradient, got {grad}"
 
     def test_gradient_finite_everywhere(self):
-        """Gradient is finite for a range of inputs."""
-        xs = anp.linspace(-10.0, 10.0, 201)
+        """Gradient is finite for a range of inputs including saturation."""
+        xs = anp.linspace(-20.0, 20.0, 401)
         for x in xs:
             g = float(autograd.grad(smooth_heaviside)(x))
             assert np.isfinite(g), f"gradient not finite at x={x}: {g}"
+
+    def test_gradient_no_overflow_warning_at_saturation(self):
+        """Saturation region must not raise overflow RuntimeWarning.
+
+        Regression: autograd's default tanh VJP computes ``g / cosh(x)**2``
+        which overflows float64 at ``|x| ≳ 354``.  _stable_tanh replaces
+        the VJP with ``g * (1 - tanh(x)**2)`` to eliminate the warning.
+        """
+        import warnings
+
+        grad_fn = autograd.grad(smooth_heaviside)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            for x_val in [15.0, 100.0, 1000.0, -15.0, -1000.0]:
+                g = float(grad_fn(anp.array(x_val)))
+                assert np.isfinite(g), f"grad not finite at x={x_val}: {g}"
 
     def test_larger_beta_sharper_transition(self):
         """Larger beta gives value closer to 1 at small positive x."""


### PR DESCRIPTION
## Summary

- `smooth_heaviside` の autograd 逆伝播で発生していた `RuntimeWarning: overflow encountered in scalar power` を根本修正
- 原因: autograd 組み込みの tanh VJP が `g / cosh(x)**2` を計算するため、デフォルト `beta=50` では `|x| ≳ 14.2` で float64 overflow
- 対処: `_stable_tanh` カスタムプリミティブを定義し、VJP を恒等式 `1 − tanh(x)²` に置き換え。グローバル `anp.tanh` は無傷

## Test plan

- [x] `uv run pytest tests/unit/test_smooth.py -v -W error::RuntimeWarning` — 55 tests pass、overflow 警告がエラー昇格しないことを確認
- [x] `make test-unit` — 366 tests pass、既存テストへの影響なし
- [x] 新規リグレッションテスト `test_gradient_no_overflow_warning_at_saturation`: `|x| = 15, 100, 1000, -15, -1000` で `RuntimeWarning` が出ないことを `warnings.simplefilter("error")` で検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)