### PR TITLE
refactor(core): StressDimension Strategy 化 + MaterialModel delegate 追加 (Step 1/3)

### DIFF
--- a/src/manforge/core/dimension.py
+++ b/src/manforge/core/dimension.py
@@ -1,7 +1,6 @@
 """StressDimension: dimensionality descriptor for stress/strain analyses."""
 
 import math
-from abc import ABC
 from dataclasses import dataclass
 
 import autograd.numpy as anp
@@ -11,12 +10,13 @@ from manforge.utils.smooth import smooth_sqrt, smooth_abs
 
 
 @dataclass(frozen=True)
-class StressDimension(ABC):
+class StressDimension:
     """Dimensionality descriptor for a stress analysis.
 
-    Concrete subclasses implement the operator methods (dev, hydrostatic, etc.).
-    Direct instantiation of this class is supported for structural validation
-    tests, but operators will raise NotImplementedError.
+    Operator methods (dev, hydrostatic, isotropic_C, I_vol, I_dev,
+    vonmises_norm) are implemented by the concrete derived classes
+    (_Solid3DLikeDimension, _PlaneStressDimension, _Uniaxial1DDimension).
+    Calling them on the bare base class raises NotImplementedError.
     """
 
     name: str

--- a/src/manforge/core/dimension.py
+++ b/src/manforge/core/dimension.py
@@ -1,14 +1,23 @@
 """StressDimension: dimensionality descriptor for stress/strain analyses."""
 
 import math
+from abc import ABC
 from dataclasses import dataclass
 
+import autograd.numpy as anp
 import numpy as np
+
+from manforge.utils.smooth import smooth_sqrt, smooth_abs
 
 
 @dataclass(frozen=True)
-class StressDimension:
-    """Dimensionality descriptor for a stress analysis."""
+class StressDimension(ABC):
+    """Dimensionality descriptor for a stress analysis.
+
+    Concrete subclasses implement the operator methods (dev, hydrostatic, etc.).
+    Direct instantiation of this class is supported for structural validation
+    tests, but operators will raise NotImplementedError.
+    """
 
     name: str
     ntens: int
@@ -68,6 +77,158 @@ class StressDimension:
     def identity_jnp(self) -> np.ndarray:
         return self.identity_np
 
+    # ------------------------------------------------------------------
+    # Operator interface — overridden by derived classes
+    # ------------------------------------------------------------------
+
+    def hydrostatic(self, stress):
+        raise NotImplementedError(f"{type(self).__name__}.hydrostatic is not implemented")
+
+    def dev(self, stress):
+        raise NotImplementedError(f"{type(self).__name__}.dev is not implemented")
+
+    def isotropic_C(self, lam, mu):
+        raise NotImplementedError(f"{type(self).__name__}.isotropic_C is not implemented")
+
+    def I_vol(self):
+        raise NotImplementedError(f"{type(self).__name__}.I_vol is not implemented")
+
+    def I_dev(self):
+        raise NotImplementedError(f"{type(self).__name__}.I_dev is not implemented")
+
+    def vonmises_norm(self, s):
+        raise NotImplementedError(f"{type(self).__name__}.vonmises_norm is not implemented")
+
+    def missing_dev_components(self, s):
+        """Default: zeros(n_missing) for states where all direct components are stored."""
+        return anp.zeros(self.n_missing)
+
+
+# ---------------------------------------------------------------------------
+# Derived concrete classes
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class _Solid3DLikeDimension(StressDimension):
+    """Full-rank dimension (ndi == ndi_phys): SOLID_3D and PLANE_STRAIN."""
+
+    def __post_init__(self):
+        super().__post_init__()
+        if self.ndi != self.ndi_phys:
+            raise ValueError(
+                f"_Solid3DLikeDimension '{self.name}' requires ndi == ndi_phys "
+                f"(got ndi={self.ndi}, ndi_phys={self.ndi_phys})."
+            )
+
+    def hydrostatic(self, stress):
+        return (stress[0] + stress[1] + stress[2]) / 3.0
+
+    def dev(self, stress):
+        return stress - self.hydrostatic(stress) * self.identity_np
+
+    def isotropic_C(self, lam, mu):
+        delta_6 = anp.array([1.0, 1.0, 1.0, 0.0, 0.0, 0.0])
+        scale_6 = anp.array([2.0, 2.0, 2.0, 1.0, 1.0, 1.0])
+        C6 = lam * anp.outer(delta_6, delta_6) + mu * anp.diag(scale_6)
+        if self.ntens == 6:
+            return C6
+        idx = anp.array([0, 1, 2, 3])
+        return C6[anp.ix_(idx, idx)]
+
+    def I_vol(self):
+        delta = self.identity_np
+        return anp.outer(delta, delta) / 3.0
+
+    def I_dev(self):
+        return anp.eye(self.ntens) - self.I_vol()
+
+    def vonmises_norm(self, s):
+        # n_missing == 0, so vonmises = sqrt(3/2 * s_m·s_m). Inline for
+        # symmetry with PS/1D (avoids MaterialModel.vonmises round-trip).
+        s_m = s * self.mandel_factors_np
+        return smooth_sqrt(1.5 * anp.dot(s_m, s_m))
+
+
+@dataclass(frozen=True)
+class _PlaneStressDimension(StressDimension):
+    """Plane-stress dimension (PLANE_STRESS): is_plane_stress=True, ntens=3."""
+
+    def __post_init__(self):
+        super().__post_init__()
+        if not self.is_plane_stress:
+            raise ValueError(
+                f"_PlaneStressDimension '{self.name}' requires is_plane_stress=True."
+            )
+
+    def hydrostatic(self, stress):
+        return (stress[0] + stress[1]) / 3.0
+
+    def dev(self, stress):
+        return stress - self.hydrostatic(stress) * self.identity_np
+
+    def isotropic_C(self, lam, mu):
+        delta_6 = anp.array([1.0, 1.0, 1.0, 0.0, 0.0, 0.0])
+        scale_6 = anp.array([2.0, 2.0, 2.0, 1.0, 1.0, 1.0])
+        C6 = lam * anp.outer(delta_6, delta_6) + mu * anp.diag(scale_6)
+        idx4 = anp.array([0, 1, 2, 3])
+        C4 = C6[anp.ix_(idx4, idx4)]
+        retain = anp.array([0, 1, 3])
+        C_rr = C4[anp.ix_(retain, retain)]
+        C_rc = C4[retain, 2]
+        C_cc = C4[2, 2]
+        return C_rr - anp.outer(C_rc, C_rc) / C_cc
+
+    def I_vol(self):
+        delta = self.identity_np
+        return anp.outer(delta, delta) / 3.0
+
+    def I_dev(self):
+        return anp.eye(self.ntens) - self.I_vol()
+
+    def missing_dev_components(self, s):
+        return anp.array([-(s[0] + s[1])])
+
+    def vonmises_norm(self, s):
+        s33 = -(s[0] + s[1])
+        return smooth_sqrt(1.5 * (s[0]*s[0] + s[1]*s[1] + s33*s33 + 2.0*s[2]*s[2]))
+
+
+@dataclass(frozen=True)
+class _Uniaxial1DDimension(StressDimension):
+    """Uniaxial 1D dimension (UNIAXIAL_1D): ntens=1."""
+
+    def __post_init__(self):
+        super().__post_init__()
+        if self.ntens != 1:
+            raise ValueError(
+                f"_Uniaxial1DDimension '{self.name}' requires ntens=1 "
+                f"(got ntens={self.ntens})."
+            )
+
+    def hydrostatic(self, stress):
+        return stress[0] / 3.0
+
+    def dev(self, stress):
+        return stress - self.hydrostatic(stress) * self.identity_np
+
+    def isotropic_C(self, lam, mu):
+        E = mu * (3.0 * lam + 2.0 * mu) / (lam + mu)
+        return anp.array([[E]])
+
+    def I_vol(self):
+        delta = self.identity_np
+        return anp.outer(delta, delta) / 3.0
+
+    def I_dev(self):
+        return anp.eye(1) - self.I_vol()
+
+    def missing_dev_components(self, s):
+        half = s[0] / 2.0
+        return anp.array([-half, -half])
+
+    def vonmises_norm(self, s):
+        return smooth_abs(1.5 * s[0])
+
 
 # ---------------------------------------------------------------------------
 # Pre-built instances
@@ -75,7 +236,7 @@ class StressDimension:
 
 _sqrt2 = math.sqrt(2.0)
 
-SOLID_3D = StressDimension(
+SOLID_3D = _Solid3DLikeDimension(
     name="3D_SOLID",
     ntens=6,
     ndi=3,
@@ -84,7 +245,7 @@ SOLID_3D = StressDimension(
     mandel_factors=(1.0, 1.0, 1.0, _sqrt2, _sqrt2, _sqrt2),
 )
 
-PLANE_STRAIN = StressDimension(
+PLANE_STRAIN = _Solid3DLikeDimension(
     name="PLANE_STRAIN",
     ntens=4,
     ndi=3,
@@ -93,7 +254,7 @@ PLANE_STRAIN = StressDimension(
     mandel_factors=(1.0, 1.0, 1.0, _sqrt2),
 )
 
-PLANE_STRESS = StressDimension(
+PLANE_STRESS = _PlaneStressDimension(
     name="PLANE_STRESS",
     ntens=3,
     ndi=2,
@@ -103,7 +264,7 @@ PLANE_STRESS = StressDimension(
     is_plane_stress=True,
 )
 
-UNIAXIAL_1D = StressDimension(
+UNIAXIAL_1D = _Uniaxial1DDimension(
     name="UNIAXIAL_1D",
     ntens=1,
     ndi=1,

--- a/src/manforge/core/material/base.py
+++ b/src/manforge/core/material/base.py
@@ -82,7 +82,7 @@ class MaterialModel(ABC):
     param_names: list[str]
     dimension: StressDimension = SOLID_3D
 
-    def __init__(self, *, dimension: StressDimension = SOLID_3D, **kwargs):
+    def __init__(self, *, dimension: StressDimension = SOLID_3D):
         self.dimension = dimension
 
     # Derived by __init_subclass__ from StateField descriptors:
@@ -481,24 +481,31 @@ class MaterialModel(ABC):
         return anp.dot(a * mf, b * mf)
 
     def hydrostatic(self, stress: StressVec) -> "Scalar":
+        """Mean normal stress; delegates to :meth:`StressDimension.hydrostatic`."""
         return self.dimension.hydrostatic(stress)
 
     def dev(self, stress: StressVec) -> StressVec:
+        """Deviatoric stress; delegates to :meth:`StressDimension.dev`."""
         return self.dimension.dev(stress)
 
     def isotropic_C(self, lam: float, mu: float) -> "Stiffness":
+        """Isotropic elastic stiffness; delegates to :meth:`StressDimension.isotropic_C`."""
         return self.dimension.isotropic_C(lam, mu)
 
     def I_vol(self) -> "Stiffness":
+        """Volumetric projection tensor; delegates to :meth:`StressDimension.I_vol`."""
         return self.dimension.I_vol()
 
     def I_dev(self) -> "Stiffness":
+        """Deviatoric projection tensor; delegates to :meth:`StressDimension.I_dev`."""
         return self.dimension.I_dev()
 
     def vonmises_norm(self, s: StressVec) -> "Scalar":
+        """Von Mises norm of a deviatoric tensor; delegates to :meth:`StressDimension.vonmises_norm`."""
         return self.dimension.vonmises_norm(s)
 
     def _missing_dev_components(self, s: StressVec) -> StressVec:
+        """Unstored deviatoric direct components; delegates to :meth:`StressDimension.missing_dev_components`."""
         return self.dimension.missing_dev_components(s)
 
     def deviatoric_inner_product(self, s: StressVec, t: StressVec) -> Scalar:

--- a/src/manforge/core/material/base.py
+++ b/src/manforge/core/material/base.py
@@ -82,6 +82,9 @@ class MaterialModel(ABC):
     param_names: list[str]
     dimension: StressDimension = SOLID_3D
 
+    def __init__(self, *, dimension: StressDimension = SOLID_3D, **kwargs):
+        self.dimension = dimension
+
     # Derived by __init_subclass__ from StateField descriptors:
     state_fields: dict[str, StateField] = {}
     state_names: list[str] = []
@@ -477,14 +480,26 @@ class MaterialModel(ABC):
         mf = self.dimension.mandel_factors_np
         return anp.dot(a * mf, b * mf)
 
-    def _missing_dev_components(self, s: StressVec) -> StressVec:
-        """Deviatoric direct components not stored in the Voigt vector.
+    def hydrostatic(self, stress: StressVec) -> "Scalar":
+        return self.dimension.hydrostatic(stress)
 
-        Returns an empty array for states where all direct components are
-        stored (SOLID_3D, PLANE_STRAIN).  Overridden in MaterialModelPS and
-        MaterialModel1D to reconstruct the missing component(s) from tr s = 0.
-        """
-        return anp.zeros(self.dimension.n_missing)
+    def dev(self, stress: StressVec) -> StressVec:
+        return self.dimension.dev(stress)
+
+    def isotropic_C(self, lam: float, mu: float) -> "Stiffness":
+        return self.dimension.isotropic_C(lam, mu)
+
+    def I_vol(self) -> "Stiffness":
+        return self.dimension.I_vol()
+
+    def I_dev(self) -> "Stiffness":
+        return self.dimension.I_dev()
+
+    def vonmises_norm(self, s: StressVec) -> "Scalar":
+        return self.dimension.vonmises_norm(s)
+
+    def _missing_dev_components(self, s: StressVec) -> StressVec:
+        return self.dimension.missing_dev_components(s)
 
     def deviatoric_inner_product(self, s: StressVec, t: StressVec) -> Scalar:
         """Double contraction s:t for stress-like deviatoric tensors.

--- a/src/manforge/core/material/bases.py
+++ b/src/manforge/core/material/bases.py
@@ -1,42 +1,22 @@
-"""Stress-state base classes for 3D / plane-stress / 1D elements."""
+"""Stress-state base classes for 3D / plane-stress / 1D elements.
 
-import autograd.numpy as anp
+These classes are thin shims that set the default ``dimension`` and validate
+that an appropriate ``StressDimension`` is passed.  Operator implementations
+now live in the ``StressDimension`` derived classes; ``MaterialModel`` delegates
+to them.  These shims will be removed in Step 2 of the refactor (#77).
+"""
 
 from manforge.core.material.base import MaterialModel
-from manforge._typing import FloatArray, Scalar, Stiffness, StressVec
 from manforge.core.dimension import (
     SOLID_3D,
     PLANE_STRESS,
     UNIAXIAL_1D,
     StressDimension,
 )
-from manforge.utils.smooth import smooth_sqrt, smooth_abs
 
 
 class MaterialModel3D(MaterialModel):
-    """Stress-state base class for full-rank stress states (ndi == ndi_phys).
-
-    Valid for ``SOLID_3D`` (ntens=6) and ``PLANE_STRAIN`` (ntens=4), and any
-    future stress state that stores all direct components (e.g. axisymmetric).
-    For these states the three physical direct stresses σ11, σ22, σ33 are all
-    stored explicitly, so deviatoric and von Mises operators need no
-    missing-component corrections.
-
-    Provides concrete implementations of the operator methods used by concrete
-    material models:
-
-    * :meth:`hydrostatic` — p = (σ11 + σ22 + σ33) / 3
-    * :meth:`dev`         — s = σ − p δ
-    * :meth:`isotropic_C`  — submatrix extraction from the full 6×6 tensor
-    * :meth:`I_vol`       — δ⊗δ / 3
-    * :meth:`I_dev`       — I − P_vol
-
-    :meth:`vonmises` is inherited from :class:`MaterialModel` (uses
-    ``smooth_sqrt`` with n_missing=0, equivalent to √(3/2 s:s)).
-
-    Subclasses still must implement the required material methods:
-    :meth:`elastic_stiffness`, :meth:`yield_function`, and either
-    :meth:`update_state` (reduced) or :meth:`state_residual` (augmented).
+    """Shim for full-rank stress states (SOLID_3D, PLANE_STRAIN).
 
     Parameters
     ----------
@@ -58,87 +38,11 @@ class MaterialModel3D(MaterialModel):
                 f"Got '{dimension.name}' with ndi={dimension.ndi}, "
                 f"ndi_phys={dimension.ndi_phys}."
             )
-        self.dimension = dimension
-
-    # ------------------------------------------------------------------
-    # Operator methods — concrete for full-rank stress states
-    # ------------------------------------------------------------------
-
-    def hydrostatic(self, stress: StressVec) -> Scalar:
-        """Mean normal stress p = (σ11 + σ22 + σ33) / 3.
-
-        All three direct components are stored, so no correction is needed.
-        """
-        return (stress[0] + stress[1] + stress[2]) / 3.0
-
-    def dev(self, stress: StressVec) -> StressVec:
-        """Deviatoric stress s = σ − p δ."""
-        p = self.hydrostatic(stress)
-        return stress - p * self.dimension.identity_np
-
-    def isotropic_C(self, lam: float, mu: float) -> Stiffness:
-        """Isotropic elastic stiffness via submatrix extraction.
-
-        Builds the full 6×6 tensor, then extracts the ntens×ntens subblock
-        for components [11, 22, 33, 12, ...].  No condensation is required
-        because all direct stress components are free.
-
-        Parameters
-        ----------
-        lam : float
-            First Lamé constant λ.
-        mu : float
-            Shear modulus μ.
-
-        Returns
-        -------
-        anp.ndarray, shape (ntens, ntens)
-        """
-        delta_6 = anp.array([1.0, 1.0, 1.0, 0.0, 0.0, 0.0])
-        scale_6 = anp.array([2.0, 2.0, 2.0, 1.0, 1.0, 1.0])
-        C6 = lam * anp.outer(delta_6, delta_6) + mu * anp.diag(scale_6)
-        if self.ntens == 6:
-            return C6
-        # PLANE_STRAIN / AXISYMMETRIC: components [11, 22, 33, 12]
-        idx = anp.array([0, 1, 2, 3])
-        return C6[anp.ix_(idx, idx)]
-
-    def I_vol(self) -> Stiffness:
-        """Volumetric projection tensor P_vol = δ⊗δ / 3."""
-        delta = self.dimension.identity_np
-        return anp.outer(delta, delta) / 3.0
-
-    def I_dev(self) -> Stiffness:
-        """Deviatoric projection tensor P_dev = I − P_vol."""
-        return anp.eye(self.ntens) - self.I_vol()
-
-    def vonmises_norm(self, s: StressVec) -> Scalar:
-        """Von Mises norm of a deviatoric tensor s: √(3/2 s:s).
-
-        Caller guarantees tr s = 0.  For 3D/PE all components are stored,
-        so this delegates to :meth:`vonmises` with n_missing=0.
-        """
-        return self.vonmises(s)
+        super().__init__(dimension=dimension)
 
 
 class MaterialModelPS(MaterialModel):
-    """Stress-state base class for plane-stress elements (PLANE_STRESS).
-
-    For plane stress, σ33 = 0 is enforced by static condensation of the
-    elastic stiffness.  Only two direct components (σ11, σ22) are stored,
-    so the von Mises computation must account for the physically-present
-    but unstored deviatoric contribution of σ33 = 0.
-
-    Provides concrete implementations of the operator methods:
-
-    * :meth:`hydrostatic` — p = (σ11 + σ22) / 3  (σ33 = 0)
-    * :meth:`dev`         — s = σ − p δ  (stored components only)
-    * :meth:`isotropic_C`  — Schur complement (static condensation of σ33)
-    * :meth:`I_vol`       — δ⊗δ / 3  (δ = [1, 1, 0] for ntens=3)
-    * :meth:`I_dev`       — I − P_vol
-
-    :meth:`vonmises` is inherited from :class:`MaterialModel` (uses
-    ``smooth_sqrt`` with n_missing=1, giving √(3/2 (s:s + p²))).
+    """Shim for plane-stress elements (PLANE_STRESS).
 
     Parameters
     ----------
@@ -159,96 +63,11 @@ class MaterialModelPS(MaterialModel):
                 f"(is_plane_stress=True). "
                 f"Got '{dimension.name}'."
             )
-        self.dimension = dimension
-
-    # ------------------------------------------------------------------
-    # Operator methods — concrete for PLANE_STRESS
-    # ------------------------------------------------------------------
-
-    def hydrostatic(self, stress: StressVec) -> Scalar:
-        """Mean normal stress p = (σ11 + σ22) / 3.
-
-        σ33 = 0 is enforced externally; ndi_phys = 3 so we divide by 3.
-        """
-        return (stress[0] + stress[1]) / 3.0
-
-    def dev(self, stress: StressVec) -> StressVec:
-        """Deviatoric stress of the stored components, s = σ − p δ."""
-        p = self.hydrostatic(stress)
-        return stress - p * self.dimension.identity_np  # δ = [1, 1, 0]
-
-    def isotropic_C(self, lam: float, mu: float) -> Stiffness:
-        """Plane-stress isotropic stiffness via static condensation.
-
-        Starts from the 4×4 plane-strain submatrix and applies the Schur
-        complement to enforce σ33 = 0, yielding a 3×3 matrix for
-        components [11, 22, 12].
-
-        Parameters
-        ----------
-        lam : float
-        mu : float
-
-        Returns
-        -------
-        anp.ndarray, shape (3, 3)
-        """
-        delta_6 = anp.array([1.0, 1.0, 1.0, 0.0, 0.0, 0.0])
-        scale_6 = anp.array([2.0, 2.0, 2.0, 1.0, 1.0, 1.0])
-        C6 = lam * anp.outer(delta_6, delta_6) + mu * anp.diag(scale_6)
-        # 4×4 plane-strain sub-block
-        idx4 = anp.array([0, 1, 2, 3])
-        C4 = C6[anp.ix_(idx4, idx4)]
-        # Schur complement: eliminate σ33 (index 2 of C4)
-        retain = anp.array([0, 1, 3])
-        C_rr = C4[anp.ix_(retain, retain)]
-        C_rc = C4[retain, 2]
-        C_cc = C4[2, 2]
-        return C_rr - anp.outer(C_rc, C_rc) / C_cc
-
-    def I_vol(self) -> Stiffness:
-        """Volumetric projection tensor P_vol = δ⊗δ / 3."""
-        delta = self.dimension.identity_np  # [1, 1, 0]
-        return anp.outer(delta, delta) / 3.0
-
-    def I_dev(self) -> Stiffness:
-        """Deviatoric projection tensor P_dev = I − P_vol."""
-        return anp.eye(self.ntens) - self.I_vol()
-
-    def _missing_dev_components(self, s: StressVec) -> StressVec:
-        """Reconstruct missing deviatoric direct component from tr s = 0.
-
-        For plane stress (ndi=2, n_missing=1): s33 = −(s11 + s22).
-        """
-        return anp.array([-(s[0] + s[1])])
-
-    def vonmises_norm(self, s: StressVec) -> Scalar:
-        """Von Mises norm of a deviatoric tensor s: √(3/2 s:s).
-
-        Caller guarantees tr s = 0.  For plane stress the unstored component
-        s33 = −(s11 + s22) is reconstructed from the deviatoric identity.
-        """
-        s33 = -(s[0] + s[1])
-        return smooth_sqrt(1.5 * (s[0]*s[0] + s[1]*s[1] + s33*s33 + 2.0*s[2]*s[2]))
+        super().__init__(dimension=dimension)
 
 
 class MaterialModel1D(MaterialModel):
-    """Stress-state base class for uniaxial (1D) elements (UNIAXIAL_1D).
-
-    Only σ11 is stored; σ22 = σ33 = 0 are enforced by the element
-    formulation.  The von Mises computation must account for two missing
-    deviatoric components (n_missing = 2).
-
-    Provides concrete implementations of the operator methods:
-
-    * :meth:`hydrostatic` — p = σ11 / 3  (σ22 = σ33 = 0)
-    * :meth:`dev`         — s = σ − p δ  (stored component only)
-    * :meth:`isotropic_C`  — [[E]] where E = μ(3λ + 2μ) / (λ + μ)
-    * :meth:`I_vol`       — [[1/3]]
-    * :meth:`I_dev`       — [[2/3]]
-
-    :meth:`vonmises` is inherited from :class:`MaterialModel` (uses
-    ``smooth_sqrt`` with n_missing=2, giving √(3/2 (s11² + 2p²)) ≈ |σ11|).
+    """Shim for uniaxial (1D) elements (UNIAXIAL_1D).
 
     Parameters
     ----------
@@ -267,61 +86,4 @@ class MaterialModel1D(MaterialModel):
                 f"MaterialModel1D requires a 1D StressDimension (ntens=1). "
                 f"Got '{dimension.name}' with ntens={dimension.ntens}."
             )
-        self.dimension = dimension
-
-    # ------------------------------------------------------------------
-    # Operator methods — concrete for UNIAXIAL_1D
-    # ------------------------------------------------------------------
-
-    def hydrostatic(self, stress: StressVec) -> Scalar:
-        """Mean normal stress p = σ11 / 3.
-
-        σ22 = σ33 = 0 are enforced externally; ndi_phys = 3 so we divide by 3.
-        """
-        return stress[0] / 3.0
-
-    def dev(self, stress: StressVec) -> StressVec:
-        """Deviatoric stress of the stored component, s = σ − p δ."""
-        p = self.hydrostatic(stress)
-        return stress - p * self.dimension.identity_np  # δ = [1.0]
-
-    def isotropic_C(self, lam: float, mu: float) -> Stiffness:
-        """1D elastic stiffness [[E]] where E = μ(3λ + 2μ) / (λ + μ).
-
-        Parameters
-        ----------
-        lam : float
-        mu : float
-
-        Returns
-        -------
-        anp.ndarray, shape (1, 1)
-        """
-        E = mu * (3.0 * lam + 2.0 * mu) / (lam + mu)
-        return anp.array([[E]])
-
-    def I_vol(self) -> Stiffness:
-        """Volumetric projection tensor [[1/3]] for ntens=1."""
-        delta = self.dimension.identity_np  # [1.0]
-        return anp.outer(delta, delta) / 3.0
-
-    def I_dev(self) -> Stiffness:
-        """Deviatoric projection tensor [[2/3]] for ntens=1."""
-        return anp.eye(1) - self.I_vol()
-
-    def _missing_dev_components(self, s: StressVec) -> StressVec:
-        """Reconstruct missing deviatoric direct components from tr s = 0.
-
-        For uniaxial 1D (ndi=1, n_missing=2): s22 = s33 = −s11/2.
-        """
-        half = s[0] / 2.0
-        return anp.array([-half, -half])
-
-    def vonmises_norm(self, s: StressVec) -> Scalar:
-        """Von Mises norm of a deviatoric tensor s: √(3/2 s:s).
-
-        Caller guarantees tr s = 0.  For 1D the stored component is the
-        deviatoric value s11_dev; missing components s22 = s33 = −s11_dev/2
-        contribute so that √(3/2 s:s) = (3/2)|s11_dev|.
-        """
-        return smooth_abs(1.5 * s[0])
+        super().__init__(dimension=dimension)


### PR DESCRIPTION
Closes #76
Parent: #75

## Summary

- `StressDimension` を ABC 継承 + 派生クラス構造に再構築し、応力状態ごとの operator を次元クラス側に集約
- `_Solid3DLikeDimension` / `_PlaneStressDimension` / `_Uniaxial1DDimension` を新設し各 operator (`dev`, `hydrostatic`, `isotropic_C`, `I_vol`, `I_dev`, `vonmises_norm`, `missing_dev_components`) を実装
- pre-built インスタンス (`SOLID_3D` / `PLANE_STRAIN` / `PLANE_STRESS` / `UNIAXIAL_1D`) を派生クラスのインスタンスに振り替え (外部 API 不変)
- `MaterialModel` に `__init__(*, dimension, **kwargs)` を新設し、operator delegate 群を追加
- `MaterialModel{3D,PS,1D}` は operator override を全削除し、検証 + `super().__init__()` のみの薄いシムに縮約 (削除は Step 2 の #77 で実施)

## Design decisions

- `StressDimension` の `@abstractmethod` は**使わない**: `test_dimension.py` が `StressDimension("bad", ntens=5, ...)` を直接生成して `__post_init__` の構造検証を assert するため。base operator は `raise NotImplementedError` stub で対応。
- `MaterialModel{3D,PS,1D}.__init__` の検証ロジックはシム側に維持: 「有効だが用途違いの dimension を渡す」シナリオ (`_Stub3D(PLANE_STRESS)`) は派生 `__post_init__` では検出できないため。

## Test plan

- [x] `make test` — 617 passed, 37 deselected
- [x] `tests/unit/test_dimension.py` — `StressDimension("bad", ...)` 直接生成の構造検証が緑
- [x] `tests/unit/test_material_bases.py` — operator 契約テストと `__init__` 検証メッセージが緑
- [x] integration テスト全般 — J2/AF/OW × 3D/PS/1D の数値結果が不変

🤖 Generated with [Claude Code](https://claude.com/claude-code)