### PR TITLE
feat(fortran): YUKinematic3D Jacobian + Residual Fortran移植 (Step 0+1+2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # manforge Makefile
 # Provides shortcuts for Fortran compilation and test execution.
 
-.PHONY: fortran-build fortran-build-umat test test-unit test-integration test-e2e test-e2e-slow test-slow test-benchmarks test-benchmarks-fortran test-all docker-build docker-test clean
+.PHONY: fortran-build fortran-build-umat fortran-build-yu test test-unit test-integration test-e2e test-e2e-slow test-slow test-benchmarks test-benchmarks-fortran test-all docker-build docker-test clean
 
 # ---------------------------------------------------------------------------
 # Fortran build (host)
@@ -14,6 +14,10 @@ fortran-build:
 ## Compile UMAT sources (abaqus_stubs + j2_isotropic_3d) into a Python extension via f2py
 fortran-build-umat:
 	cd fortran && uv run python -m numpy.f2py -c abaqus_stubs.f90 j2_isotropic_3d.f90 -m j2_isotropic_3d
+
+## Compile YU kinematic UMAT sources into a Python extension via f2py
+fortran-build-yu:
+	cd fortran && uv run python -m numpy.f2py -c abaqus_stubs.f90 yu_kinematic_3d.f90 -m yu_kinematic_3d
 
 # ---------------------------------------------------------------------------
 # Test targets

--- a/fortran/yu_kinematic_3d.f90
+++ b/fortran/yu_kinematic_3d.f90
@@ -1,0 +1,1006 @@
+! =============================================================================
+! manforge -- YUKinematic3D UMAT (Yoshida-Uemori 2-surface + stagnation surface)
+!
+! Fortran port of YUKinematic3D (src/manforge/models/yu_kinematic.py).
+! Algorithm: fully-implicit Newton-Raphson on [stress(6), dlambda(1),
+!            theta(6), beta(6)] = 19 unknowns.
+!
+! NOTE on naming:
+!   - Fortran is case-insensitive.  The Python model has two parameters:
+!       B    (bound surface size, self.B)
+!       b    (backstress parameter, self.b)
+!     These would collide in Fortran argument lists.  To resolve this,
+!     "B" (bound surface size) is named "B_bnd" throughout this file.
+!   - The output array argument "J" in Python is named "jmat" (6x6), "jvec"
+!     (6-vector), or "jval" (scalar) to avoid collision with the Fortran loop
+!     variable j.
+!
+! Material properties (PROPS, 12 parameters, matches model.param_names):
+!   PROPS(1)  = E        Young's modulus
+!   PROPS(2)  = nu       Poisson's ratio
+!   PROPS(3)  = Y        initial yield stress
+!   PROPS(4)  = B_bnd    bound surface size  (Python: self.B)
+!   PROPS(5)  = C_1      kinematic hardening rate (theta, pre-reversal)
+!   PROPS(6)  = C_2      kinematic hardening rate (theta, post-reversal)
+!   PROPS(7)  = Rsat     saturation value of R
+!   PROPS(8)  = k        boundary surface hardening rate
+!   PROPS(9)  = b        backstress (beta) hardening rate  (Python: self.b)
+!   PROPS(10) = h        stagnation surface parameter
+!   PROPS(11) = Ea       asymptotic modulus (nonlinear elasticity)
+!   PROPS(12) = xi_param nonlinear elasticity decay parameter (Python: self.xi)
+!
+! State variables (STATEV, 22 slots, model.state_names without "stress"):
+!   STATEV(1..6)   = theta(1..6)     relative backstress of yield surface
+!   STATEV(7..12)  = beta(1..6)      relative backstress of boundary surface
+!   STATEV(13)     = R               radius increment of boundary surface
+!   STATEV(14..19) = q(1..6)         center of stagnation surface
+!   STATEV(20)     = r               radius of stagnation surface
+!   STATEV(21)     = eps_eq          equivalent plastic strain
+!   STATEV(22)     = theta_max       max ||theta|| in history
+!
+! Voigt convention: [s11, s22, s33, s12, s13, s23]
+!   Stress components: physical shear (sigma_12 = tensor shear)
+!   Strain components: engineering shear (gamma_12 = 2 * tensor shear)
+!
+! NR unknown vector layout (19 components):
+!   x = [stress(6), dlambda(1), theta(6), beta(6)]
+! Residual vector layout (matching x):
+!   r = [R_stress(6), R_yield(1), R_theta(6), R_beta(6)]
+!
+! Build (from fortran/ directory):
+!   uv run python -m numpy.f2py -c abaqus_stubs.f90 yu_kinematic_3d.f90 -m yu_kinematic_3d
+! =============================================================================
+
+
+! =============================================================================
+! yu_kinematic_3d_elastic_stiffness
+!
+! Returns the secant elastic stiffness tensor C_e = f(eps_eq) * C_iso
+! where f = 1 - (1 - Ea/E) * (1 - exp(-xi_param * eps_eq)).
+!
+! Parameters
+! ----------
+! E         [in]  : Young's modulus
+! nu        [in]  : Poisson's ratio
+! eps_eq    [in]  : equivalent plastic strain (from state)
+! Ea        [in]  : asymptotic modulus
+! xi_param  [in]  : decay parameter (self.xi in Python)
+! C         [out] : 6x6 Voigt stiffness (Fortran column-major order)
+! =============================================================================
+subroutine yu_kinematic_3d_elastic_stiffness(E, nu, eps_eq, Ea, xi_param, C)
+    implicit none
+    double precision, intent(in)  :: E, nu, eps_eq, Ea, xi_param
+    double precision, intent(out) :: C(6,6)
+
+    double precision :: lam, mu, factor
+    integer :: ii, jj
+
+    mu     = E / (2.0d0 * (1.0d0 + nu))
+    lam    = E * nu / ((1.0d0 + nu) * (1.0d0 - 2.0d0 * nu))
+    factor = 1.0d0 - (1.0d0 - Ea / E) * (1.0d0 - exp(-xi_param * eps_eq))
+
+    do jj = 1, 6
+        do ii = 1, 6
+            C(ii,jj) = 0.0d0
+        end do
+    end do
+
+    do ii = 1, 3
+        do jj = 1, 3
+            C(ii,jj) = lam
+        end do
+        C(ii,ii) = lam + 2.0d0 * mu
+    end do
+    do ii = 4, 6
+        C(ii,ii) = mu
+    end do
+
+    do jj = 1, 6
+        do ii = 1, 6
+            C(ii,jj) = factor * C(ii,jj)
+        end do
+    end do
+
+end subroutine yu_kinematic_3d_elastic_stiffness
+
+
+! =============================================================================
+! yu_vonmises_norm  (internal helper, not f2py-callable)
+!
+! Von Mises equivalent norm for a physical-shear deviatoric vector:
+!   ||xi||_vm = sqrt(1.5 * (xi(1)^2 + xi(2)^2 + xi(3)^2
+!                          + 2*(xi(4)^2 + xi(5)^2 + xi(6)^2)))
+! =============================================================================
+subroutine yu_vonmises_norm(xi, xi_norm)
+    implicit none
+    double precision, intent(in)  :: xi(6)
+    double precision, intent(out) :: xi_norm
+
+    double precision :: sss
+    integer :: ii
+
+    sss = 0.0d0
+    do ii = 1, 3
+        sss = sss + xi(ii)**2
+    end do
+    do ii = 4, 6
+        sss = sss + 2.0d0 * xi(ii)**2
+    end do
+    xi_norm = sqrt(1.5d0 * sss)
+
+end subroutine yu_vonmises_norm
+
+
+! =============================================================================
+! yu_deviatoric  (internal helper, not f2py-callable)
+!
+! Deviatoric part of a stress vector:
+!   dev(s)_i = s_i - (s_11+s_22+s_33)/3  for i=1..3
+!   dev(s)_i = s_i                         for i=4..6
+! =============================================================================
+subroutine yu_deviatoric(s, s_dev)
+    implicit none
+    double precision, intent(in)  :: s(6)
+    double precision, intent(out) :: s_dev(6)
+
+    double precision :: p_mean
+    integer :: ii
+
+    p_mean = (s(1) + s(2) + s(3)) / 3.0d0
+    do ii = 1, 6
+        s_dev(ii) = s(ii)
+    end do
+    do ii = 1, 3
+        s_dev(ii) = s_dev(ii) - p_mean
+    end do
+
+end subroutine yu_deviatoric
+
+
+! =============================================================================
+! yu_calc_norm_n_flow
+!
+! Computes the von Mises norm of xi and the plastic flow direction.
+!   xi_norm = ||xi||_vm
+!   flow_i  = 1.5 * T_i * xi_i / xi_norm
+!           = 1.5 * xi_i / xi_norm   for i=1..3 (normal)
+!           = 3.0 * xi_i / xi_norm   for i=4..6 (shear, T_i=2)
+!
+! Parameters
+! ----------
+! xi      [in]  : 6-component deviatoric driving stress
+! xi_norm [out] : von Mises norm of xi
+! flow    [out] : plastic flow direction (6,)
+! =============================================================================
+subroutine yu_calc_norm_n_flow(xi, xi_norm, flow)
+    implicit none
+    double precision, intent(in)  :: xi(6)
+    double precision, intent(out) :: xi_norm, flow(6)
+
+    integer :: ii
+
+    call yu_vonmises_norm(xi, xi_norm)
+
+    do ii = 1, 3
+        flow(ii) = 1.5d0 * xi(ii) / xi_norm
+    end do
+    do ii = 4, 6
+        flow(ii) = 3.0d0 * xi(ii) / xi_norm
+    end do
+
+end subroutine yu_calc_norm_n_flow
+
+
+! =============================================================================
+! yu_prepare_rstress
+!
+! Computes the partial derivative of the plastic flow direction n with respect
+! to stress: dn/dsig = 1.5/xi_norm * (T @ I_dev - outer(n_hat, n_hat))
+! where n_hat = flow / sqrt(1.5).
+!
+! Parameters
+! ----------
+! xi       [in]  : 6-component deviatoric driving stress
+! dn_dsig  [out] : (6,6) partial derivative matrix
+! =============================================================================
+subroutine yu_prepare_rstress(xi, dn_dsig)
+    implicit none
+    double precision, intent(in)  :: xi(6)
+    double precision, intent(out) :: dn_dsig(6,6)
+
+    double precision :: xi_norm, flow(6)
+    double precision :: n_hat(6), T_I_dev(6,6), P_ij
+    double precision, parameter :: SQRT15 = 1.2247448713915890d0  ! sqrt(1.5)
+    integer :: ii, jj
+
+    call yu_calc_norm_n_flow(xi, xi_norm, flow)
+
+    ! n_hat = flow / sqrt(1.5)
+    do ii = 1, 6
+        n_hat(ii) = flow(ii) / SQRT15
+    end do
+
+    ! T_I_dev = T @ I_dev
+    ! T = diag(1,1,1,2,2,2)
+    ! I_dev_ij = delta_ij - 1/3 * [i<=3 and j<=3]
+    do ii = 1, 6
+        do jj = 1, 6
+            P_ij = 0.0d0
+            if (ii == jj) P_ij = 1.0d0
+            if (ii <= 3 .and. jj <= 3) P_ij = P_ij - 1.0d0/3.0d0
+            if (ii > 3) then
+                T_I_dev(ii,jj) = 2.0d0 * P_ij
+            else
+                T_I_dev(ii,jj) = P_ij
+            end if
+        end do
+    end do
+
+    do ii = 1, 6
+        do jj = 1, 6
+            dn_dsig(ii,jj) = 1.5d0 / xi_norm * (T_I_dev(ii,jj) - n_hat(ii) * n_hat(jj))
+        end do
+    end do
+
+end subroutine yu_prepare_rstress
+
+
+! =============================================================================
+! yu_prepare_rtheta
+!
+! Computes auxiliary scalars used by the theta-residual Jacobian blocks.
+! Contains two hard branches identical to the Python reference:
+!   (1) C_k is C_1 if B_bnd-Y > theta_max, else C_2
+!   (2) a_prime = 0 when R == R_n (floating-point equality)
+!
+! Parameters (input)
+! ------------------
+! B_bnd, Y, k, Rsat, C_1, C_2  : material parameters
+! theta(6)                      : current theta iterate
+! theta_max                     : max ||theta|| at step start
+! R                             : current R iterate
+! R_n                           : R at step start
+! dlambda                       : current delta-lambda iterate
+!
+! Parameters (output)
+! -------------------
+! theta_bar   : von Mises norm of theta
+! theta_flow  : flow direction for theta (6,)
+! C_k         : selected kinematic hardening coefficient
+! s           : 1 / (1 + k * dlambda)
+! a           : B_bnd + R - Y
+! a_prime     : dR/d(dlambda) if R != R_n, else 0
+! =============================================================================
+subroutine yu_prepare_rtheta(B_bnd, Y, k, Rsat, C_1, C_2, &
+                              theta, theta_max, R, R_n, dlambda, &
+                              theta_bar, theta_flow, C_k, s, a, a_prime)
+    implicit none
+    double precision, intent(in)  :: B_bnd, Y, k, Rsat, C_1, C_2
+    double precision, intent(in)  :: theta(6), theta_max, R, R_n, dlambda
+    double precision, intent(out) :: theta_bar, theta_flow(6), C_k, s, a, a_prime
+
+    integer :: ii
+
+    call yu_vonmises_norm(theta, theta_bar)
+
+    do ii = 1, 3
+        theta_flow(ii) = 1.5d0 * theta(ii) / theta_bar
+    end do
+    do ii = 4, 6
+        theta_flow(ii) = 3.0d0 * theta(ii) / theta_bar
+    end do
+
+    ! Hard step (Jacobian side): matches Python _prepare_Rtheta line 224
+    if (B_bnd - Y > theta_max) then
+        C_k = C_1
+    else
+        C_k = C_2
+    end if
+
+    s = 1.0d0 / (1.0d0 + k * dlambda)
+    a = B_bnd + R - Y
+
+    ! Floating-point equality: matches Python _prepare_Rtheta line 227
+    if (R /= R_n) then
+        a_prime = -k * s * s * (R_n + k * Rsat * dlambda) + s * k * Rsat
+    else
+        a_prime = 0.0d0
+    end if
+
+end subroutine yu_prepare_rtheta
+
+
+! =============================================================================
+! yu_dRs_dstress
+!
+! dR_stress / d_stress = I + dlambda * C @ dn_dsig
+!
+! Parameters
+! ----------
+! C(6,6)  [in]  : elastic stiffness
+! xi(6)   [in]  : deviatoric driving stress
+! dlambda [in]  : consistency parameter
+! jmat    [out] : result (6,6)
+! =============================================================================
+subroutine yu_dRs_dstress(C, xi, dlambda, jmat)
+    implicit none
+    double precision, intent(in)  :: C(6,6), xi(6), dlambda
+    double precision, intent(out) :: jmat(6,6)
+
+    double precision :: dn_dsig(6,6)
+    integer :: ii, jj, kk
+
+    call yu_prepare_rstress(xi, dn_dsig)
+
+    do ii = 1, 6
+        do jj = 1, 6
+            jmat(ii,jj) = 0.0d0
+            if (ii == jj) jmat(ii,jj) = 1.0d0
+            do kk = 1, 6
+                jmat(ii,jj) = jmat(ii,jj) + dlambda * C(ii,kk) * dn_dsig(kk,jj)
+            end do
+        end do
+    end do
+
+end subroutine yu_dRs_dstress
+
+
+! =============================================================================
+! yu_dRs_dbeta
+!
+! dR_stress / d_beta = -dlambda * C @ dn_dsig
+! =============================================================================
+subroutine yu_dRs_dbeta(C, xi, dlambda, jmat)
+    implicit none
+    double precision, intent(in)  :: C(6,6), xi(6), dlambda
+    double precision, intent(out) :: jmat(6,6)
+
+    double precision :: dn_dsig(6,6)
+    integer :: ii, jj, kk
+
+    call yu_prepare_rstress(xi, dn_dsig)
+
+    do ii = 1, 6
+        do jj = 1, 6
+            jmat(ii,jj) = 0.0d0
+            do kk = 1, 6
+                jmat(ii,jj) = jmat(ii,jj) - dlambda * C(ii,kk) * dn_dsig(kk,jj)
+            end do
+        end do
+    end do
+
+end subroutine yu_dRs_dbeta
+
+
+! =============================================================================
+! yu_dRs_dtheta
+!
+! dR_stress / d_theta = -dlambda * C @ dn_dsig  (identical to dRs_dbeta)
+! =============================================================================
+subroutine yu_dRs_dtheta(C, xi, dlambda, jmat)
+    implicit none
+    double precision, intent(in)  :: C(6,6), xi(6), dlambda
+    double precision, intent(out) :: jmat(6,6)
+
+    call yu_dRs_dbeta(C, xi, dlambda, jmat)
+
+end subroutine yu_dRs_dtheta
+
+
+! =============================================================================
+! yu_dRs_dlambda
+!
+! dR_stress / d_lambda = C @ flow
+!     - xi_param * (1 - Ea/E) * exp(-xi_param*eps_eq) / factor * dlambda * (C @ flow)
+! where factor = Ea/E + (1 - Ea/E) * exp(-xi_param * eps_eq).
+!
+! Parameters
+! ----------
+! E, Ea, xi_param  : material parameters
+! C(6,6)           : elastic stiffness
+! xi(6)            : deviatoric driving stress
+! eps_eq           : equivalent plastic strain
+! dlambda          : consistency parameter
+! jvec(6)          : result vector
+! =============================================================================
+subroutine yu_dRs_dlambda(E, Ea, xi_param, C, xi, eps_eq, dlambda, jvec)
+    implicit none
+    double precision, intent(in)  :: E, Ea, xi_param
+    double precision, intent(in)  :: C(6,6), xi(6), eps_eq, dlambda
+    double precision, intent(out) :: jvec(6)
+
+    double precision :: xi_norm, flow(6), Cn(6), factor, exp_term
+    integer :: ii, kk
+
+    call yu_calc_norm_n_flow(xi, xi_norm, flow)
+
+    do ii = 1, 6
+        Cn(ii) = 0.0d0
+        do kk = 1, 6
+            Cn(ii) = Cn(ii) + C(ii,kk) * flow(kk)
+        end do
+    end do
+
+    exp_term = exp(-xi_param * eps_eq)
+    factor = Ea / E + (1.0d0 - Ea / E) * exp_term
+
+    do ii = 1, 6
+        jvec(ii) = Cn(ii) - xi_param * (1.0d0 - Ea / E) * exp_term / factor * dlambda * Cn(ii)
+    end do
+
+end subroutine yu_dRs_dlambda
+
+
+! =============================================================================
+! yu_dRb_dstress
+!
+! dR_beta / d_stress = -k*b_kin*dlambda/Y * I_dev
+!
+! Parameters
+! ----------
+! k, b_kin, Y  : material parameters (b_kin is Python self.b)
+! dlambda      : consistency parameter
+! jmat(6,6)    : result
+! =============================================================================
+subroutine yu_dRb_dstress(k, b_kin, Y, dlambda, jmat)
+    implicit none
+    double precision, intent(in)  :: k, b_kin, Y, dlambda
+    double precision, intent(out) :: jmat(6,6)
+
+    double precision :: coeff, P_ij
+    integer :: ii, jj
+
+    coeff = -k * b_kin * dlambda / Y
+
+    do ii = 1, 6
+        do jj = 1, 6
+            P_ij = 0.0d0
+            if (ii == jj) P_ij = 1.0d0
+            if (ii <= 3 .and. jj <= 3) P_ij = P_ij - 1.0d0/3.0d0
+            jmat(ii,jj) = coeff * P_ij
+        end do
+    end do
+
+end subroutine yu_dRb_dstress
+
+
+! =============================================================================
+! yu_dRb_dbeta
+!
+! dR_beta / d_beta = (1 + k*b_kin*dlambda/Y + k*dlambda) * I
+! =============================================================================
+subroutine yu_dRb_dbeta(k, b_kin, Y, dlambda, jmat)
+    implicit none
+    double precision, intent(in)  :: k, b_kin, Y, dlambda
+    double precision, intent(out) :: jmat(6,6)
+
+    double precision :: coeff
+    integer :: ii, jj
+
+    coeff = 1.0d0 + k * b_kin / Y * dlambda + k * dlambda
+
+    do ii = 1, 6
+        do jj = 1, 6
+            jmat(ii,jj) = 0.0d0
+        end do
+        jmat(ii,ii) = coeff
+    end do
+
+end subroutine yu_dRb_dbeta
+
+
+! =============================================================================
+! yu_dRb_dtheta
+!
+! dR_beta / d_theta = k*b_kin*dlambda/Y * I
+! =============================================================================
+subroutine yu_dRb_dtheta(k, b_kin, Y, dlambda, jmat)
+    implicit none
+    double precision, intent(in)  :: k, b_kin, Y, dlambda
+    double precision, intent(out) :: jmat(6,6)
+
+    double precision :: coeff
+    integer :: ii, jj
+
+    coeff = k * b_kin / Y * dlambda
+
+    do ii = 1, 6
+        do jj = 1, 6
+            jmat(ii,jj) = 0.0d0
+        end do
+        jmat(ii,ii) = coeff
+    end do
+
+end subroutine yu_dRb_dtheta
+
+
+! =============================================================================
+! yu_dRb_dlambda
+!
+! dR_beta / d_lambda = -k*b_kin/Y * xi + k * beta
+! =============================================================================
+subroutine yu_dRb_dlambda(k, b_kin, Y, xi, beta, dlambda, jvec)
+    implicit none
+    double precision, intent(in)  :: k, b_kin, Y
+    double precision, intent(in)  :: xi(6), beta(6), dlambda
+    double precision, intent(out) :: jvec(6)
+
+    integer :: ii
+
+    do ii = 1, 6
+        jvec(ii) = -k * b_kin / Y * xi(ii) + k * beta(ii)
+    end do
+
+end subroutine yu_dRb_dlambda
+
+
+! =============================================================================
+! yu_dRt_dstress
+!
+! dR_theta / d_stress = -a*C_k*dlambda/Y * I_dev
+! =============================================================================
+subroutine yu_dRt_dstress(B_bnd, Y, k, Rsat, C_1, C_2, &
+                           theta, theta_max, R, R_n, dlambda, jmat)
+    implicit none
+    double precision, intent(in)  :: B_bnd, Y, k, Rsat, C_1, C_2
+    double precision, intent(in)  :: theta(6), theta_max, R, R_n, dlambda
+    double precision, intent(out) :: jmat(6,6)
+
+    double precision :: theta_bar, theta_flow(6), C_k, s, a, a_prime
+    double precision :: coeff, P_ij
+    integer :: ii, jj
+
+    call yu_prepare_rtheta(B_bnd, Y, k, Rsat, C_1, C_2, &
+                           theta, theta_max, R, R_n, dlambda, &
+                           theta_bar, theta_flow, C_k, s, a, a_prime)
+
+    coeff = -a * C_k * dlambda / Y
+
+    do ii = 1, 6
+        do jj = 1, 6
+            P_ij = 0.0d0
+            if (ii == jj) P_ij = 1.0d0
+            if (ii <= 3 .and. jj <= 3) P_ij = P_ij - 1.0d0/3.0d0
+            jmat(ii,jj) = coeff * P_ij
+        end do
+    end do
+
+end subroutine yu_dRt_dstress
+
+
+! =============================================================================
+! yu_dRt_dbeta
+!
+! dR_theta / d_beta = a*C_k*dlambda/Y * I
+! =============================================================================
+subroutine yu_dRt_dbeta(B_bnd, Y, k, Rsat, C_1, C_2, &
+                         theta, theta_max, R, R_n, dlambda, jmat)
+    implicit none
+    double precision, intent(in)  :: B_bnd, Y, k, Rsat, C_1, C_2
+    double precision, intent(in)  :: theta(6), theta_max, R, R_n, dlambda
+    double precision, intent(out) :: jmat(6,6)
+
+    double precision :: theta_bar, theta_flow(6), C_k, s, a, a_prime
+    double precision :: coeff
+    integer :: ii, jj
+
+    call yu_prepare_rtheta(B_bnd, Y, k, Rsat, C_1, C_2, &
+                           theta, theta_max, R, R_n, dlambda, &
+                           theta_bar, theta_flow, C_k, s, a, a_prime)
+
+    coeff = a * C_k * dlambda / Y
+
+    do ii = 1, 6
+        do jj = 1, 6
+            jmat(ii,jj) = 0.0d0
+        end do
+        jmat(ii,ii) = coeff
+    end do
+
+end subroutine yu_dRt_dbeta
+
+
+! =============================================================================
+! yu_dRt_dtheta
+!
+! dR_theta / d_theta.
+! Has a theta_bar < 1e-14 guard to avoid division by zero (Python line 275).
+! =============================================================================
+subroutine yu_dRt_dtheta(B_bnd, Y, k, Rsat, C_1, C_2, &
+                          theta, theta_max, R, R_n, dlambda, jmat)
+    implicit none
+    double precision, intent(in)  :: B_bnd, Y, k, Rsat, C_1, C_2
+    double precision, intent(in)  :: theta(6), theta_max, R, R_n, dlambda
+    double precision, intent(out) :: jmat(6,6)
+
+    double precision :: theta_bar, theta_flow(6), C_k, s, a, a_prime
+    double precision :: diag_coeff, outer_coeff
+    double precision, parameter :: SQRT15 = 1.2247448713915890d0
+    integer :: ii, jj
+
+    call yu_prepare_rtheta(B_bnd, Y, k, Rsat, C_1, C_2, &
+                           theta, theta_max, R, R_n, dlambda, &
+                           theta_bar, theta_flow, C_k, s, a, a_prime)
+
+    do ii = 1, 6
+        do jj = 1, 6
+            jmat(ii,jj) = 0.0d0
+        end do
+    end do
+
+    if (theta_bar < 1.0d-14) then
+        ! Degenerate case: only diagonal term (Python line 276)
+        diag_coeff = 1.0d0 + a * C_k * dlambda / Y
+        do ii = 1, 6
+            jmat(ii,ii) = diag_coeff
+        end do
+    else
+        diag_coeff  = 1.0d0 + a * C_k * dlambda / Y &
+                      + C_k * dlambda * sqrt(a / theta_bar)
+        outer_coeff = SQRT15 * C_k * dlambda * sqrt(a / theta_bar) / (2.0d0 * theta_bar)
+        do ii = 1, 6
+            do jj = 1, 6
+                ! outer product: (theta_flow/sqrt(1.5))_i * theta_j
+                jmat(ii,jj) = -outer_coeff * (theta_flow(ii) / SQRT15) * theta(jj)
+            end do
+            jmat(ii,ii) = jmat(ii,ii) + diag_coeff
+        end do
+    end if
+
+end subroutine yu_dRt_dtheta
+
+
+! =============================================================================
+! yu_dRt_dlambda
+!
+! dR_theta / d_lambda.
+! Has a theta_bar < 1e-14 guard (Python line 283).
+! =============================================================================
+subroutine yu_dRt_dlambda(B_bnd, Y, k, Rsat, C_1, C_2, &
+                           xi, theta, theta_max, R, R_n, dlambda, jvec)
+    implicit none
+    double precision, intent(in)  :: B_bnd, Y, k, Rsat, C_1, C_2
+    double precision, intent(in)  :: xi(6), theta(6), theta_max, R, R_n, dlambda
+    double precision, intent(out) :: jvec(6)
+
+    double precision :: theta_bar, theta_flow(6), C_k, s, a, a_prime
+    integer :: ii
+
+    call yu_prepare_rtheta(B_bnd, Y, k, Rsat, C_1, C_2, &
+                           theta, theta_max, R, R_n, dlambda, &
+                           theta_bar, theta_flow, C_k, s, a, a_prime)
+
+    if (theta_bar < 1.0d-14) then
+        ! Degenerate case (Python line 284)
+        do ii = 1, 6
+            jvec(ii) = (-a * C_k / Y - C_k * dlambda / Y * a_prime) * xi(ii)
+        end do
+    else
+        do ii = 1, 6
+            jvec(ii) = - a * C_k / Y * xi(ii) &
+                       - C_k * dlambda / Y * a_prime * xi(ii) &
+                       + C_k * sqrt(a / theta_bar) * theta(ii) &
+                       + C_k * dlambda * sqrt(1.0d0 / (theta_bar * a)) * a_prime / 2.0d0 * theta(ii)
+        end do
+    end if
+
+end subroutine yu_dRt_dlambda
+
+
+! =============================================================================
+! yu_dRl_dstress
+!
+! dR_yield / d_stress = flow
+! =============================================================================
+subroutine yu_dRl_dstress(xi, jvec)
+    implicit none
+    double precision, intent(in)  :: xi(6)
+    double precision, intent(out) :: jvec(6)
+
+    double precision :: xi_norm, flow(6)
+
+    call yu_calc_norm_n_flow(xi, xi_norm, flow)
+
+    jvec = flow
+
+end subroutine yu_dRl_dstress
+
+
+! =============================================================================
+! yu_dRl_dbeta
+!
+! dR_yield / d_beta = -flow
+! =============================================================================
+subroutine yu_dRl_dbeta(xi, jvec)
+    implicit none
+    double precision, intent(in)  :: xi(6)
+    double precision, intent(out) :: jvec(6)
+
+    double precision :: xi_norm, flow(6)
+    integer :: ii
+
+    call yu_calc_norm_n_flow(xi, xi_norm, flow)
+
+    do ii = 1, 6
+        jvec(ii) = -flow(ii)
+    end do
+
+end subroutine yu_dRl_dbeta
+
+
+! =============================================================================
+! yu_dRl_dtheta
+!
+! dR_yield / d_theta = -flow
+! =============================================================================
+subroutine yu_dRl_dtheta(xi, jvec)
+    implicit none
+    double precision, intent(in)  :: xi(6)
+    double precision, intent(out) :: jvec(6)
+
+    call yu_dRl_dbeta(xi, jvec)
+
+end subroutine yu_dRl_dtheta
+
+
+! =============================================================================
+! yu_dRl_dlambda
+!
+! dR_yield / d_lambda = 0
+! =============================================================================
+subroutine yu_dRl_dlambda(jval)
+    implicit none
+    double precision, intent(out) :: jval
+
+    jval = 0.0d0
+
+end subroutine yu_dRl_dlambda
+
+
+! =============================================================================
+! yu_smooth_heaviside (internal helper for residual)
+!
+! Smooth Heaviside: 0.5 * (1 + tanh(beta * x / 2))
+! with beta=50.0, matching Python smooth_heaviside default.
+! =============================================================================
+subroutine yu_smooth_heaviside(x, hv)
+    implicit none
+    double precision, intent(in)  :: x
+    double precision, intent(out) :: hv
+
+    double precision, parameter :: BETA_H = 50.0d0
+
+    hv = 0.5d0 * (1.0d0 + tanh(0.5d0 * BETA_H * x))
+
+end subroutine yu_smooth_heaviside
+
+
+! =============================================================================
+! yu_smooth_sqrt (internal helper for residual)
+!
+! Smooth square root: sqrt(x + eps^2) with eps = 1e-30 (Python default).
+! =============================================================================
+subroutine yu_smooth_sqrt(x, result)
+    implicit none
+    double precision, intent(in)  :: x
+    double precision, intent(out) :: result
+
+    double precision, parameter :: EPS_SQRT = 1.0d-30
+
+    result = sqrt(x + EPS_SQRT**2)
+
+end subroutine yu_smooth_sqrt
+
+
+! =============================================================================
+! yu_calc_residual
+!
+! Computes the full 19-element residual vector for the Newton-Raphson system.
+! r = [R_stress(6), R_yield(1), R_theta(6), R_beta(6)]
+!
+! Note on C_k: uses smooth_heaviside (residual side), unlike the Jacobian
+! which uses a hard step via _prepare_Rtheta. Matches Python calc_residual.
+!
+! Parameters
+! ----------
+! E, nu, Y, B_bnd, C_1, C_2, Rsat, k, b_kin, h, Ea, xi_param
+!             : 12 material parameters (order = model.param_names)
+! stress_new(6), theta_new(6), beta_new(6)  : NR iterates (Implicit states)
+! R_new       : current R NR iterate
+! eps_eq_new  : equivalent plastic strain at current iterate
+! theta_n(6), beta_n(6)  : states at step start
+! theta_max_n : theta_max at step start
+! stress_trial(6) : elastic predictor stress
+! dlambda     : current delta-lambda iterate
+! r_vec(19)   : output residual vector
+! =============================================================================
+subroutine yu_calc_residual(E, nu, Y, B_bnd, C_1, C_2, Rsat, k, b_kin, h, Ea, xi_param, &
+                             stress_new, theta_new, beta_new, R_new, eps_eq_new, &
+                             theta_n, beta_n, theta_max_n, &
+                             stress_trial, dlambda, &
+                             r_vec)
+    implicit none
+    double precision, intent(in)  :: E, nu, Y, B_bnd, C_1, C_2, Rsat, k, b_kin, h, Ea, xi_param
+    double precision, intent(in)  :: stress_new(6), theta_new(6), beta_new(6)
+    double precision, intent(in)  :: R_new, eps_eq_new
+    double precision, intent(in)  :: theta_n(6), beta_n(6), theta_max_n
+    double precision, intent(in)  :: stress_trial(6), dlambda
+    double precision, intent(out) :: r_vec(19)
+
+    double precision :: C(6,6), dev_stress(6), xi(6)
+    double precision :: xi_norm, flow(6), theta_norm
+    double precision :: C_k, hv, a, sm_sqrt_result
+    double precision :: R_stress(6), R_theta(6), R_beta(6), R_yield
+    integer :: ii, kk
+
+    ! Elastic stiffness
+    call yu_kinematic_3d_elastic_stiffness(E, nu, eps_eq_new, Ea, xi_param, C)
+
+    ! C_k via smooth_heaviside (residual side)
+    call yu_smooth_heaviside(theta_max_n - (B_bnd - Y), hv)
+    C_k = C_1 - (C_1 - C_2) * hv
+
+    a = B_bnd + R_new - Y
+
+    ! xi = dev(stress_new) - theta_new - beta_new
+    call yu_deviatoric(stress_new, dev_stress)
+    do ii = 1, 6
+        xi(ii) = dev_stress(ii) - theta_new(ii) - beta_new(ii)
+    end do
+
+    call yu_calc_norm_n_flow(xi, xi_norm, flow)
+    call yu_vonmises_norm(theta_new, theta_norm)
+
+    ! R_stress = stress_new - stress_trial + dlambda * C @ flow
+    do ii = 1, 6
+        R_stress(ii) = stress_new(ii) - stress_trial(ii)
+        do kk = 1, 6
+            R_stress(ii) = R_stress(ii) + dlambda * C(ii,kk) * flow(kk)
+        end do
+    end do
+
+    ! R_theta = theta_new - theta_n
+    !         - (C_k*a/Y*xi - C_k*smooth_sqrt(a/theta_norm)*theta_new)*dlambda
+    call yu_smooth_sqrt(a / theta_norm, sm_sqrt_result)
+    do ii = 1, 6
+        R_theta(ii) = theta_new(ii) - theta_n(ii) &
+                    - (C_k * a / Y * xi(ii) - C_k * sm_sqrt_result * theta_new(ii)) * dlambda
+    end do
+
+    ! R_beta = beta_new - beta_n - (k*b_kin/Y*xi - k*beta_new)*dlambda
+    do ii = 1, 6
+        R_beta(ii) = beta_new(ii) - beta_n(ii) &
+                   - (k * b_kin / Y * xi(ii) - k * beta_new(ii)) * dlambda
+    end do
+
+    ! R_yield = vonmises_norm(xi) - Y
+    R_yield = xi_norm - Y
+
+    ! r_vec = [R_stress(6), R_yield(1), R_theta(6), R_beta(6)]
+    do ii = 1, 6
+        r_vec(ii)    = R_stress(ii)
+        r_vec(7+ii)  = R_theta(ii)
+        r_vec(13+ii) = R_beta(ii)
+    end do
+    r_vec(7) = R_yield
+
+end subroutine yu_calc_residual
+
+
+! =============================================================================
+! yu_calc_jacobian
+!
+! Computes the full 19x19 Jacobian matrix of the NR system.
+! Column order: stress(1..6), dlambda(7), theta(8..13), beta(14..19)
+! Row order:    R_stress(1..6), R_yield(7), R_theta(8..13), R_beta(14..19)
+!
+! Parameters
+! ----------
+! E, nu, Y, B_bnd, C_1, C_2, Rsat, k, b_kin, h, Ea, xi_param
+!             : 12 material parameters
+! stress_new(6), theta_new(6), beta_new(6)  : NR iterates
+! R_new       : current R iterate
+! eps_eq_new  : equivalent plastic strain at current iterate
+! theta_max_new : theta_max (= state_n["theta_max"] used for Jacobian)
+! R_n         : R at step start
+! dlambda     : current delta-lambda iterate
+! jac(19,19)  : output Jacobian
+! =============================================================================
+subroutine yu_calc_jacobian(E, nu, Y, B_bnd, C_1, C_2, Rsat, k, b_kin, h, Ea, xi_param, &
+                             stress_new, theta_new, beta_new, R_new, eps_eq_new, &
+                             theta_max_new, R_n, dlambda, &
+                             jac)
+    implicit none
+    double precision, intent(in)  :: E, nu, Y, B_bnd, C_1, C_2, Rsat, k, b_kin, h, Ea, xi_param
+    double precision, intent(in)  :: stress_new(6), theta_new(6), beta_new(6)
+    double precision, intent(in)  :: R_new, eps_eq_new, theta_max_new, R_n, dlambda
+    double precision, intent(out) :: jac(19,19)
+
+    double precision :: C(6,6), dev_stress(6), xi(6)
+    double precision :: Rs_s(6,6), Rs_b(6,6), Rs_t(6,6), Rs_l(6)
+    double precision :: Rb_s(6,6), Rb_b(6,6), Rb_t(6,6), Rb_l(6)
+    double precision :: Rt_s(6,6), Rt_b(6,6), Rt_t(6,6), Rt_l(6)
+    double precision :: Rl_s(6), Rl_b(6), Rl_t(6), Rl_l
+    integer :: ii, jj
+
+    call yu_kinematic_3d_elastic_stiffness(E, nu, eps_eq_new, Ea, xi_param, C)
+
+    call yu_deviatoric(stress_new, dev_stress)
+    do ii = 1, 6
+        xi(ii) = dev_stress(ii) - theta_new(ii) - beta_new(ii)
+    end do
+
+    ! Rstress blocks
+    call yu_dRs_dstress(C, xi, dlambda, Rs_s)
+    call yu_dRs_dbeta(C, xi, dlambda, Rs_b)
+    call yu_dRs_dtheta(C, xi, dlambda, Rs_t)
+    call yu_dRs_dlambda(E, Ea, xi_param, C, xi, eps_eq_new, dlambda, Rs_l)
+
+    ! Rbeta blocks
+    call yu_dRb_dstress(k, b_kin, Y, dlambda, Rb_s)
+    call yu_dRb_dbeta(k, b_kin, Y, dlambda, Rb_b)
+    call yu_dRb_dtheta(k, b_kin, Y, dlambda, Rb_t)
+    call yu_dRb_dlambda(k, b_kin, Y, xi, beta_new, dlambda, Rb_l)
+
+    ! Rtheta blocks
+    call yu_dRt_dstress(B_bnd, Y, k, Rsat, C_1, C_2, &
+                        theta_new, theta_max_new, R_new, R_n, dlambda, Rt_s)
+    call yu_dRt_dbeta(B_bnd, Y, k, Rsat, C_1, C_2, &
+                      theta_new, theta_max_new, R_new, R_n, dlambda, Rt_b)
+    call yu_dRt_dtheta(B_bnd, Y, k, Rsat, C_1, C_2, &
+                       theta_new, theta_max_new, R_new, R_n, dlambda, Rt_t)
+    call yu_dRt_dlambda(B_bnd, Y, k, Rsat, C_1, C_2, &
+                        xi, theta_new, theta_max_new, R_new, R_n, dlambda, Rt_l)
+
+    ! Ryield blocks
+    call yu_dRl_dstress(xi, Rl_s)
+    call yu_dRl_dbeta(xi, Rl_b)
+    call yu_dRl_dtheta(xi, Rl_t)
+    call yu_dRl_dlambda(Rl_l)
+
+    ! Assemble 19x19
+    do jj = 1, 19
+        do ii = 1, 19
+            jac(ii,jj) = 0.0d0
+        end do
+    end do
+
+    ! Rows 1..6: R_stress; cols: stress(1..6), dlambda(7), theta(8..13), beta(14..19)
+    do ii = 1, 6
+        do jj = 1, 6
+            jac(ii, jj)    = Rs_s(ii,jj)
+            jac(ii, 7+jj)  = Rs_t(ii,jj)
+            jac(ii, 13+jj) = Rs_b(ii,jj)
+        end do
+        jac(ii, 7) = Rs_l(ii)
+    end do
+
+    ! Row 7: R_yield
+    do jj = 1, 6
+        jac(7, jj)    = Rl_s(jj)
+        jac(7, 7+jj)  = Rl_t(jj)
+        jac(7, 13+jj) = Rl_b(jj)
+    end do
+    jac(7,7) = Rl_l
+
+    ! Rows 8..13: R_theta
+    do ii = 1, 6
+        do jj = 1, 6
+            jac(7+ii, jj)    = Rt_s(ii,jj)
+            jac(7+ii, 7+jj)  = Rt_t(ii,jj)
+            jac(7+ii, 13+jj) = Rt_b(ii,jj)
+        end do
+        jac(7+ii, 7) = Rt_l(ii)
+    end do
+
+    ! Rows 14..19: R_beta
+    do ii = 1, 6
+        do jj = 1, 6
+            jac(13+ii, jj)    = Rb_s(ii,jj)
+            jac(13+ii, 7+jj)  = Rb_t(ii,jj)
+            jac(13+ii, 13+jj) = Rb_b(ii,jj)
+        end do
+        jac(13+ii, 7) = Rb_l(ii)
+    end do
+
+end subroutine yu_calc_jacobian

--- a/src/manforge/models/yu_kinematic.py
+++ b/src/manforge/models/yu_kinematic.py
@@ -255,7 +255,7 @@ class YUKinematic3D(YUKinematic):
 
     @verified_against_fortran(
         "yu_drs_dstress",
-        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestJacobianBlocks::test_jacobian_blocks_match_fortran",
+        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestJacobianBlocks::test_dRstress_dstress",
     )
     def dRstress_dstress(self, C, xi, dlambda):
         dn_dsig = self._prepare_Rstress(xi)
@@ -263,7 +263,7 @@ class YUKinematic3D(YUKinematic):
 
     @verified_against_fortran(
         "yu_drs_dbeta",
-        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestJacobianBlocks::test_jacobian_blocks_match_fortran",
+        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestJacobianBlocks::test_dRstress_dbeta",
     )
     def dRstress_dbeta(self, C, xi, dlambda):
         dn_dsig = self._prepare_Rstress(xi)
@@ -271,7 +271,7 @@ class YUKinematic3D(YUKinematic):
 
     @verified_against_fortran(
         "yu_drs_dtheta",
-        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestJacobianBlocks::test_jacobian_blocks_match_fortran",
+        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestJacobianBlocks::test_dRstress_dtheta",
     )
     def dRstress_dtheta(self, C, xi, dlambda):
         dn_dsig = self._prepare_Rstress(xi)
@@ -279,7 +279,7 @@ class YUKinematic3D(YUKinematic):
 
     @verified_against_fortran(
         "yu_drs_dlambda",
-        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestJacobianBlocks::test_jacobian_blocks_match_fortran",
+        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestJacobianBlocks::test_dRstress_dlambda",
     )
     def dRstress_dlambda(self, C, xi, eps_eq, dlambda):
         _, flow = self.calc_norm_n_flow(xi)
@@ -288,35 +288,35 @@ class YUKinematic3D(YUKinematic):
 
     @verified_against_fortran(
         "yu_drb_dstress",
-        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestJacobianBlocks::test_jacobian_blocks_match_fortran",
+        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestJacobianBlocks::test_dRbeta_dstress",
     )
     def dRbeta_dstress(self, dlambda):
         return -self.k * self.b * dlambda / self.Y * self.I_dev()
 
     @verified_against_fortran(
         "yu_drb_dbeta",
-        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestJacobianBlocks::test_jacobian_blocks_match_fortran",
+        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestJacobianBlocks::test_dRbeta_dbeta",
     )
     def dRbeta_dbeta(self, dlambda):
         return (1.0 + self.k * self.b / self.Y * dlambda + self.k * dlambda) * self.I
 
     @verified_against_fortran(
         "yu_drb_dtheta",
-        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestJacobianBlocks::test_jacobian_blocks_match_fortran",
+        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestJacobianBlocks::test_dRbeta_dtheta",
     )
     def dRbeta_dtheta(self, dlambda):
         return self.k * self.b * dlambda / self.Y * self.I
 
     @verified_against_fortran(
         "yu_drb_dlambda",
-        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestJacobianBlocks::test_jacobian_blocks_match_fortran",
+        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestJacobianBlocks::test_dRbeta_dlambda",
     )
     def dRbeta_dlambda(self, xi, beta, dlambda):
         return -self.k * self.b / self.Y * xi + self.k * beta
 
     @verified_against_fortran(
         "yu_drt_dstress",
-        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestJacobianBlocks::test_jacobian_blocks_match_fortran",
+        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestJacobianBlocks::test_dRtheta_dstress",
     )
     def dRtheta_dstress(self, theta, theta_max, R, R_n, dlambda):
         _, _, C_k, _, a, _ = self._prepare_Rtheta(theta, theta_max, R, R_n, dlambda)
@@ -324,7 +324,7 @@ class YUKinematic3D(YUKinematic):
 
     @verified_against_fortran(
         "yu_drt_dbeta",
-        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestJacobianBlocks::test_jacobian_blocks_match_fortran",
+        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestJacobianBlocks::test_dRtheta_dbeta",
     )
     def dRtheta_dbeta(self, theta, theta_max, R, R_n, dlambda):
         _, _, C_k, _, a, _ = self._prepare_Rtheta(theta, theta_max, R, R_n, dlambda)
@@ -332,7 +332,7 @@ class YUKinematic3D(YUKinematic):
 
     @verified_against_fortran(
         "yu_drt_dtheta",
-        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestJacobianBlocks::test_jacobian_blocks_match_fortran",
+        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestJacobianBlocks::test_dRtheta_dtheta",
     )
     def dRtheta_dtheta(self, theta, theta_max, R, R_n, dlambda):
         theta_bar, theta_flow, C_k, _, a, _ = self._prepare_Rtheta(theta, theta_max, R, R_n, dlambda)
@@ -344,7 +344,7 @@ class YUKinematic3D(YUKinematic):
     
     @verified_against_fortran(
         "yu_drt_dlambda",
-        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestJacobianBlocks::test_jacobian_blocks_match_fortran",
+        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestJacobianBlocks::test_dRtheta_dlambda",
     )
     def dRtheta_dlambda(self, xi, theta, theta_max, R, R_n, dlambda):
         theta_bar, _, C_k, _, a, a_prime = self._prepare_Rtheta(theta, theta_max, R, R_n, dlambda)
@@ -360,7 +360,7 @@ class YUKinematic3D(YUKinematic):
 
     @verified_against_fortran(
         "yu_drl_dstress",
-        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestJacobianBlocks::test_jacobian_blocks_match_fortran",
+        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestJacobianBlocks::test_dRyield_dstress",
     )
     def dRyield_dstress(self, xi):
         _, flow = self.calc_norm_n_flow(xi)
@@ -368,7 +368,7 @@ class YUKinematic3D(YUKinematic):
 
     @verified_against_fortran(
         "yu_drl_dbeta",
-        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestJacobianBlocks::test_jacobian_blocks_match_fortran",
+        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestJacobianBlocks::test_dRyield_dbeta",
     )
     def dRyield_dbeta(self, xi):
         _, flow = self.calc_norm_n_flow(xi)
@@ -376,7 +376,7 @@ class YUKinematic3D(YUKinematic):
 
     @verified_against_fortran(
         "yu_drl_dtheta",
-        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestJacobianBlocks::test_jacobian_blocks_match_fortran",
+        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestJacobianBlocks::test_dRyield_dtheta",
     )
     def dRyield_dtheta(self, xi):
         _, flow = self.calc_norm_n_flow(xi)
@@ -384,7 +384,7 @@ class YUKinematic3D(YUKinematic):
 
     @verified_against_fortran(
         "yu_drl_dlambda",
-        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestJacobianBlocks::test_jacobian_blocks_match_fortran",
+        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestJacobianBlocks::test_dRyield_dlambda",
     )
     def dRyield_dlambda(self):
         return np.array([0.0])

--- a/src/manforge/models/yu_kinematic.py
+++ b/src/manforge/models/yu_kinematic.py
@@ -204,7 +204,7 @@ class YUKinematic3D(YUKinematic):
 
     @verified_against_fortran(
         "yu_calc_residual",
-        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestResidualAndJacobian",
+        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestResidualAndJacobian::test_residual_and_jacobian_match_fortran",
     )
     def calc_residual(self, state_new, state_n, stress_trial, dlambda):
         C = self.elastic_stiffness(state_new)
@@ -391,7 +391,7 @@ class YUKinematic3D(YUKinematic):
 
     @verified_against_fortran(
         "yu_calc_jacobian",
-        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestResidualAndJacobian",
+        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestResidualAndJacobian::test_residual_and_jacobian_match_fortran",
     )
     def calc_jacobian(self, state_new, state_n, stress_trial, dlambda):
         C = self.elastic_stiffness(state_new)

--- a/src/manforge/models/yu_kinematic.py
+++ b/src/manforge/models/yu_kinematic.py
@@ -202,6 +202,10 @@ class YUKinematic3D(YUKinematic):
         flow = self.T @ xi / xi_norm * 1.5
         return xi_norm, flow
 
+    @verified_against_fortran(
+        "yu_calc_residual",
+        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestResidualAndJacobian",
+    )
     def calc_residual(self, state_new, state_n, stress_trial, dlambda):
         C = self.elastic_stiffness(state_new)
         C_k = self.C_1 - (self.C_1 - self.C_2) * smooth_heaviside(state_n["theta_max"] - (self.B - self.Y))
@@ -385,6 +389,10 @@ class YUKinematic3D(YUKinematic):
     def dRyield_dlambda(self):
         return np.array([0.0])
 
+    @verified_against_fortran(
+        "yu_calc_jacobian",
+        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestResidualAndJacobian",
+    )
     def calc_jacobian(self, state_new, state_n, stress_trial, dlambda):
         C = self.elastic_stiffness(state_new)
         xi = self.dev(state_new["stress"]) - state_new["theta"] - state_new["beta"]

--- a/src/manforge/models/yu_kinematic.py
+++ b/src/manforge/models/yu_kinematic.py
@@ -40,7 +40,7 @@ class YUKinematic(MaterialModel):
 
     @verified_against_fortran(
         "yu_kinematic_3d_elastic_stiffness",
-        test="tests/integration/verification/test_yu_fortran_bindings.py::test_check_bindings",
+        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestHelpers::test_elastic_stiffness",
     )
     def elastic_stiffness(self, state):
         eps_eq = state["eps_eq"]
@@ -195,7 +195,7 @@ class YUKinematic3D(YUKinematic):
 
     @verified_against_fortran(
         "yu_calc_norm_n_flow",
-        test="tests/integration/verification/test_yu_fortran_bindings.py::test_check_bindings",
+        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestHelpers::test_calc_norm_n_flow",
     )
     def calc_norm_n_flow(self, xi):
         xi_norm = self.vonmises_norm(xi)
@@ -223,7 +223,7 @@ class YUKinematic3D(YUKinematic):
 
     @verified_against_fortran(
         "yu_prepare_rstress",
-        test="tests/integration/verification/test_yu_fortran_bindings.py::test_check_bindings",
+        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestHelpers::test_prepare_rstress",
     )
     def _prepare_Rstress(self, xi):
         xi_norm, flow = self.calc_norm_n_flow(xi)
@@ -236,7 +236,7 @@ class YUKinematic3D(YUKinematic):
 
     @verified_against_fortran(
         "yu_prepare_rtheta",
-        test="tests/integration/verification/test_yu_fortran_bindings.py::test_check_bindings",
+        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestHelpers::test_prepare_rtheta",
     )
     def _prepare_Rtheta(self, theta, theta_max, R, R_n, dlambda):
         theta_bar = self.vonmises_norm(theta)
@@ -255,7 +255,7 @@ class YUKinematic3D(YUKinematic):
 
     @verified_against_fortran(
         "yu_drs_dstress",
-        test="tests/integration/verification/test_yu_fortran_bindings.py::test_check_bindings",
+        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestJacobianBlocks::test_jacobian_blocks_match_fortran",
     )
     def dRstress_dstress(self, C, xi, dlambda):
         dn_dsig = self._prepare_Rstress(xi)
@@ -263,7 +263,7 @@ class YUKinematic3D(YUKinematic):
 
     @verified_against_fortran(
         "yu_drs_dbeta",
-        test="tests/integration/verification/test_yu_fortran_bindings.py::test_check_bindings",
+        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestJacobianBlocks::test_jacobian_blocks_match_fortran",
     )
     def dRstress_dbeta(self, C, xi, dlambda):
         dn_dsig = self._prepare_Rstress(xi)
@@ -271,7 +271,7 @@ class YUKinematic3D(YUKinematic):
 
     @verified_against_fortran(
         "yu_drs_dtheta",
-        test="tests/integration/verification/test_yu_fortran_bindings.py::test_check_bindings",
+        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestJacobianBlocks::test_jacobian_blocks_match_fortran",
     )
     def dRstress_dtheta(self, C, xi, dlambda):
         dn_dsig = self._prepare_Rstress(xi)
@@ -279,7 +279,7 @@ class YUKinematic3D(YUKinematic):
 
     @verified_against_fortran(
         "yu_drs_dlambda",
-        test="tests/integration/verification/test_yu_fortran_bindings.py::test_check_bindings",
+        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestJacobianBlocks::test_jacobian_blocks_match_fortran",
     )
     def dRstress_dlambda(self, C, xi, eps_eq, dlambda):
         _, flow = self.calc_norm_n_flow(xi)
@@ -288,35 +288,35 @@ class YUKinematic3D(YUKinematic):
 
     @verified_against_fortran(
         "yu_drb_dstress",
-        test="tests/integration/verification/test_yu_fortran_bindings.py::test_check_bindings",
+        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestJacobianBlocks::test_jacobian_blocks_match_fortran",
     )
     def dRbeta_dstress(self, dlambda):
         return -self.k * self.b * dlambda / self.Y * self.I_dev()
 
     @verified_against_fortran(
         "yu_drb_dbeta",
-        test="tests/integration/verification/test_yu_fortran_bindings.py::test_check_bindings",
+        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestJacobianBlocks::test_jacobian_blocks_match_fortran",
     )
     def dRbeta_dbeta(self, dlambda):
         return (1.0 + self.k * self.b / self.Y * dlambda + self.k * dlambda) * self.I
 
     @verified_against_fortran(
         "yu_drb_dtheta",
-        test="tests/integration/verification/test_yu_fortran_bindings.py::test_check_bindings",
+        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestJacobianBlocks::test_jacobian_blocks_match_fortran",
     )
     def dRbeta_dtheta(self, dlambda):
         return self.k * self.b * dlambda / self.Y * self.I
 
     @verified_against_fortran(
         "yu_drb_dlambda",
-        test="tests/integration/verification/test_yu_fortran_bindings.py::test_check_bindings",
+        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestJacobianBlocks::test_jacobian_blocks_match_fortran",
     )
     def dRbeta_dlambda(self, xi, beta, dlambda):
         return -self.k * self.b / self.Y * xi + self.k * beta
 
     @verified_against_fortran(
         "yu_drt_dstress",
-        test="tests/integration/verification/test_yu_fortran_bindings.py::test_check_bindings",
+        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestJacobianBlocks::test_jacobian_blocks_match_fortran",
     )
     def dRtheta_dstress(self, theta, theta_max, R, R_n, dlambda):
         _, _, C_k, _, a, _ = self._prepare_Rtheta(theta, theta_max, R, R_n, dlambda)
@@ -324,7 +324,7 @@ class YUKinematic3D(YUKinematic):
 
     @verified_against_fortran(
         "yu_drt_dbeta",
-        test="tests/integration/verification/test_yu_fortran_bindings.py::test_check_bindings",
+        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestJacobianBlocks::test_jacobian_blocks_match_fortran",
     )
     def dRtheta_dbeta(self, theta, theta_max, R, R_n, dlambda):
         _, _, C_k, _, a, _ = self._prepare_Rtheta(theta, theta_max, R, R_n, dlambda)
@@ -332,7 +332,7 @@ class YUKinematic3D(YUKinematic):
 
     @verified_against_fortran(
         "yu_drt_dtheta",
-        test="tests/integration/verification/test_yu_fortran_bindings.py::test_check_bindings",
+        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestJacobianBlocks::test_jacobian_blocks_match_fortran",
     )
     def dRtheta_dtheta(self, theta, theta_max, R, R_n, dlambda):
         theta_bar, theta_flow, C_k, _, a, _ = self._prepare_Rtheta(theta, theta_max, R, R_n, dlambda)
@@ -344,7 +344,7 @@ class YUKinematic3D(YUKinematic):
     
     @verified_against_fortran(
         "yu_drt_dlambda",
-        test="tests/integration/verification/test_yu_fortran_bindings.py::test_check_bindings",
+        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestJacobianBlocks::test_jacobian_blocks_match_fortran",
     )
     def dRtheta_dlambda(self, xi, theta, theta_max, R, R_n, dlambda):
         theta_bar, _, C_k, _, a, a_prime = self._prepare_Rtheta(theta, theta_max, R, R_n, dlambda)
@@ -360,7 +360,7 @@ class YUKinematic3D(YUKinematic):
 
     @verified_against_fortran(
         "yu_drl_dstress",
-        test="tests/integration/verification/test_yu_fortran_bindings.py::test_check_bindings",
+        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestJacobianBlocks::test_jacobian_blocks_match_fortran",
     )
     def dRyield_dstress(self, xi):
         _, flow = self.calc_norm_n_flow(xi)
@@ -368,7 +368,7 @@ class YUKinematic3D(YUKinematic):
 
     @verified_against_fortran(
         "yu_drl_dbeta",
-        test="tests/integration/verification/test_yu_fortran_bindings.py::test_check_bindings",
+        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestJacobianBlocks::test_jacobian_blocks_match_fortran",
     )
     def dRyield_dbeta(self, xi):
         _, flow = self.calc_norm_n_flow(xi)
@@ -376,7 +376,7 @@ class YUKinematic3D(YUKinematic):
 
     @verified_against_fortran(
         "yu_drl_dtheta",
-        test="tests/integration/verification/test_yu_fortran_bindings.py::test_check_bindings",
+        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestJacobianBlocks::test_jacobian_blocks_match_fortran",
     )
     def dRyield_dtheta(self, xi):
         _, flow = self.calc_norm_n_flow(xi)
@@ -384,7 +384,7 @@ class YUKinematic3D(YUKinematic):
 
     @verified_against_fortran(
         "yu_drl_dlambda",
-        test="tests/integration/verification/test_yu_fortran_bindings.py::test_check_bindings",
+        test="tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py::TestJacobianBlocks::test_jacobian_blocks_match_fortran",
     )
     def dRyield_dlambda(self):
         return np.array([0.0])

--- a/src/manforge/models/yu_kinematic.py
+++ b/src/manforge/models/yu_kinematic.py
@@ -2,7 +2,7 @@ from copy import deepcopy
 import numpy as np
 import autograd.numpy as anp
 from manforge.utils.smooth import smooth_sqrt, smooth_max, smooth_heaviside
-from manforge.core.material import MaterialModel
+from manforge.core.material import MaterialModel, verified_against_fortran
 from manforge.core.result import ReturnMappingResult
 from manforge.core.state import Explicit, Implicit, NTENS, SCALAR
 from manforge.core.dimension import SOLID_3D, PLANE_STRESS, UNIAXIAL_1D, StressDimension
@@ -38,6 +38,10 @@ class YUKinematic(MaterialModel):
         self.Ea = Ea
         self.xi = xi
 
+    @verified_against_fortran(
+        "yu_kinematic_3d_elastic_stiffness",
+        test="tests/integration/verification/test_yu_fortran_bindings.py::test_check_bindings",
+    )
     def elastic_stiffness(self, state):
         eps_eq = state["eps_eq"]
         mu = self.E / (2.0 * (1.0 + self.nu))
@@ -189,6 +193,10 @@ class YUKinematic3D(YUKinematic):
         ddsdde = self.calc_ddsdde(state, state_n, stress_trial, dlambda)
         return ddsdde
 
+    @verified_against_fortran(
+        "yu_calc_norm_n_flow",
+        test="tests/integration/verification/test_yu_fortran_bindings.py::test_check_bindings",
+    )
     def calc_norm_n_flow(self, xi):
         xi_norm = self.vonmises_norm(xi)
         flow = self.T @ xi / xi_norm * 1.5
@@ -209,6 +217,10 @@ class YUKinematic3D(YUKinematic):
         r_vector = anp.hstack((R_stress, R_yield, R_theta, R_beta))
         return r_vector
 
+    @verified_against_fortran(
+        "yu_prepare_rstress",
+        test="tests/integration/verification/test_yu_fortran_bindings.py::test_check_bindings",
+    )
     def _prepare_Rstress(self, xi):
         xi_norm, flow = self.calc_norm_n_flow(xi)
         dn_dsig = (
@@ -218,6 +230,10 @@ class YUKinematic3D(YUKinematic):
         )
         return dn_dsig
 
+    @verified_against_fortran(
+        "yu_prepare_rtheta",
+        test="tests/integration/verification/test_yu_fortran_bindings.py::test_check_bindings",
+    )
     def _prepare_Rtheta(self, theta, theta_max, R, R_n, dlambda):
         theta_bar = self.vonmises_norm(theta)
         theta_flow = self.T @ theta / theta_bar * 1.5
@@ -233,43 +249,87 @@ class YUKinematic3D(YUKinematic):
             a_prime = 0.0
         return theta_bar, theta_flow, C_k, s, a, a_prime
 
+    @verified_against_fortran(
+        "yu_drs_dstress",
+        test="tests/integration/verification/test_yu_fortran_bindings.py::test_check_bindings",
+    )
     def dRstress_dstress(self, C, xi, dlambda):
         dn_dsig = self._prepare_Rstress(xi)
         return self.I + dlambda * C @ dn_dsig
 
+    @verified_against_fortran(
+        "yu_drs_dbeta",
+        test="tests/integration/verification/test_yu_fortran_bindings.py::test_check_bindings",
+    )
     def dRstress_dbeta(self, C, xi, dlambda):
         dn_dsig = self._prepare_Rstress(xi)
         return - dlambda * C @ dn_dsig
 
+    @verified_against_fortran(
+        "yu_drs_dtheta",
+        test="tests/integration/verification/test_yu_fortran_bindings.py::test_check_bindings",
+    )
     def dRstress_dtheta(self, C, xi, dlambda):
         dn_dsig = self._prepare_Rstress(xi)
         return - dlambda * C @ dn_dsig
 
+    @verified_against_fortran(
+        "yu_drs_dlambda",
+        test="tests/integration/verification/test_yu_fortran_bindings.py::test_check_bindings",
+    )
     def dRstress_dlambda(self, C, xi, eps_eq, dlambda):
         _, flow = self.calc_norm_n_flow(xi)
         factor = self.Ea / self.E + (1 - self.Ea / self.E) * anp.exp(-self.xi * eps_eq)
         return C @ flow - self.xi * (1 - self.Ea / self.E) * anp.exp(-self.xi * eps_eq) / factor * dlambda * (C @ flow)
 
+    @verified_against_fortran(
+        "yu_drb_dstress",
+        test="tests/integration/verification/test_yu_fortran_bindings.py::test_check_bindings",
+    )
     def dRbeta_dstress(self, dlambda):
         return -self.k * self.b * dlambda / self.Y * self.I_dev()
 
+    @verified_against_fortran(
+        "yu_drb_dbeta",
+        test="tests/integration/verification/test_yu_fortran_bindings.py::test_check_bindings",
+    )
     def dRbeta_dbeta(self, dlambda):
         return (1.0 + self.k * self.b / self.Y * dlambda + self.k * dlambda) * self.I
 
+    @verified_against_fortran(
+        "yu_drb_dtheta",
+        test="tests/integration/verification/test_yu_fortran_bindings.py::test_check_bindings",
+    )
     def dRbeta_dtheta(self, dlambda):
         return self.k * self.b * dlambda / self.Y * self.I
 
+    @verified_against_fortran(
+        "yu_drb_dlambda",
+        test="tests/integration/verification/test_yu_fortran_bindings.py::test_check_bindings",
+    )
     def dRbeta_dlambda(self, xi, beta, dlambda):
         return -self.k * self.b / self.Y * xi + self.k * beta
 
+    @verified_against_fortran(
+        "yu_drt_dstress",
+        test="tests/integration/verification/test_yu_fortran_bindings.py::test_check_bindings",
+    )
     def dRtheta_dstress(self, theta, theta_max, R, R_n, dlambda):
         _, _, C_k, _, a, _ = self._prepare_Rtheta(theta, theta_max, R, R_n, dlambda)
         return -a * C_k * dlambda / self.Y * self.I_dev()
 
+    @verified_against_fortran(
+        "yu_drt_dbeta",
+        test="tests/integration/verification/test_yu_fortran_bindings.py::test_check_bindings",
+    )
     def dRtheta_dbeta(self, theta, theta_max, R, R_n, dlambda):
         _, _, C_k, _, a, _ = self._prepare_Rtheta(theta, theta_max, R, R_n, dlambda)
         return a * C_k * dlambda / self.Y * self.I
 
+    @verified_against_fortran(
+        "yu_drt_dtheta",
+        test="tests/integration/verification/test_yu_fortran_bindings.py::test_check_bindings",
+    )
     def dRtheta_dtheta(self, theta, theta_max, R, R_n, dlambda):
         theta_bar, theta_flow, C_k, _, a, _ = self._prepare_Rtheta(theta, theta_max, R, R_n, dlambda)
         if theta_bar < 1e-14:
@@ -278,6 +338,10 @@ class YUKinematic3D(YUKinematic):
             np.sqrt(1.5) * C_k * dlambda * np.sqrt(a / theta_bar) / (2 * theta_bar)
         ) * np.outer(theta_flow / np.sqrt(1.5), theta)
     
+    @verified_against_fortran(
+        "yu_drt_dlambda",
+        test="tests/integration/verification/test_yu_fortran_bindings.py::test_check_bindings",
+    )
     def dRtheta_dlambda(self, xi, theta, theta_max, R, R_n, dlambda):
         theta_bar, _, C_k, _, a, a_prime = self._prepare_Rtheta(theta, theta_max, R, R_n, dlambda)
         if theta_bar < 1e-14:
@@ -290,18 +354,34 @@ class YUKinematic3D(YUKinematic):
         )
         return fr
 
+    @verified_against_fortran(
+        "yu_drl_dstress",
+        test="tests/integration/verification/test_yu_fortran_bindings.py::test_check_bindings",
+    )
     def dRyield_dstress(self, xi):
         _, flow = self.calc_norm_n_flow(xi)
         return flow
 
+    @verified_against_fortran(
+        "yu_drl_dbeta",
+        test="tests/integration/verification/test_yu_fortran_bindings.py::test_check_bindings",
+    )
     def dRyield_dbeta(self, xi):
         _, flow = self.calc_norm_n_flow(xi)
         return -flow
 
+    @verified_against_fortran(
+        "yu_drl_dtheta",
+        test="tests/integration/verification/test_yu_fortran_bindings.py::test_check_bindings",
+    )
     def dRyield_dtheta(self, xi):
         _, flow = self.calc_norm_n_flow(xi)
         return -flow
 
+    @verified_against_fortran(
+        "yu_drl_dlambda",
+        test="tests/integration/verification/test_yu_fortran_bindings.py::test_check_bindings",
+    )
     def dRyield_dlambda(self):
         return np.array([0.0])
 

--- a/src/manforge/verification/fortran_check.py
+++ b/src/manforge/verification/fortran_check.py
@@ -75,9 +75,8 @@ def check_bindings(
                 f"Python returned size {py_arr.size}, Fortran returned size {f_arr.size}"
             )
 
+        ok = bool(np.allclose(py_arr, f_arr, rtol=rtol, atol=atol))
         abs_diff = np.abs(py_arr - f_arr)
-        # numpy allclose semantics: |a-b| <= atol + rtol*|b|
-        ok = bool(np.all(abs_diff <= atol + rtol * np.abs(f_arr)))
         max_rel_err = float(np.max(abs_diff / (np.abs(f_arr) + 1e-14)))
         results[method_name] = (ok, max_rel_err)
 

--- a/src/manforge/verification/fortran_check.py
+++ b/src/manforge/verification/fortran_check.py
@@ -24,6 +24,7 @@ def check_bindings(
     cases: dict[str, tuple[tuple, tuple]],
     *,
     rtol: float = 1e-10,
+    atol: float = 0.0,
 ) -> dict[str, tuple[bool, float]]:
     """Compare registered Python methods against their Fortran counterparts.
 
@@ -42,8 +43,9 @@ def check_bindings(
         *py_args* is passed to ``getattr(model, method_name)(*py_args)``.
         *fortran_args* is passed to ``fortran.call(subroutine, *fortran_args)``.
     rtol:
-        Relative tolerance threshold.  A result is ``ok`` when
-        ``max_rel_err < rtol``.
+        Relative tolerance threshold (numpy ``allclose`` semantics).
+    atol:
+        Absolute tolerance threshold (numpy ``allclose`` semantics).
 
     Returns
     -------
@@ -73,7 +75,10 @@ def check_bindings(
                 f"Python returned size {py_arr.size}, Fortran returned size {f_arr.size}"
             )
 
-        max_rel_err = float(np.max(np.abs(py_arr - f_arr) / (np.abs(f_arr) + 1e-14)))
-        results[method_name] = (max_rel_err < rtol, max_rel_err)
+        abs_diff = np.abs(py_arr - f_arr)
+        # numpy allclose semantics: |a-b| <= atol + rtol*|b|
+        ok = bool(np.all(abs_diff <= atol + rtol * np.abs(f_arr)))
+        max_rel_err = float(np.max(abs_diff / (np.abs(f_arr) + 1e-14)))
+        results[method_name] = (ok, max_rel_err)
 
     return results

--- a/tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py
+++ b/tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py
@@ -1,0 +1,164 @@
+"""Path B benchmarks: YUKinematic3D Python NR vs Fortran UMAT.
+
+Requires the compiled yu_kinematic_3d Fortran extension:
+    make fortran-build-yu
+or:
+    uv run manforge build fortran/abaqus_stubs.f90 fortran/yu_kinematic_3d.f90 --name yu_kinematic_3d
+
+Test classes added incrementally per implementation step:
+    TestJacobianBlocks       -- Step 1: 16 dRxx_dyy blocks + helpers
+    TestResidualAndJacobian  -- Step 2: integrated residual + Jacobian
+"""
+
+import numpy as np
+import pytest
+
+pytest.importorskip(
+    "yu_kinematic_3d",
+    reason=(
+        "yu_kinematic_3d not compiled -- run: "
+        "make fortran-build-yu"
+    ),
+)
+
+pytestmark = pytest.mark.fortran
+
+from manforge.simulation.integrator import FortranModule, PythonNumericalIntegrator
+from manforge.models import YUKinematic3D
+from manforge.verification import check_bindings
+
+from .conftest import PARAMS
+
+
+@pytest.fixture
+def fortran_mod():
+    return FortranModule("yu_kinematic_3d")
+
+
+@pytest.fixture
+def model():
+    return YUKinematic3D(**PARAMS)
+
+
+# ---------------------------------------------------------------------------
+# Helper: build check_bindings cases from a converged plastic step state
+# ---------------------------------------------------------------------------
+
+def _build_cases(m, state, state_n, dlambda):
+    """Return check_bindings cases dict for all 16 dRxx_dyy blocks."""
+    C = m.elastic_stiffness(state)
+    stress = state["stress"]
+    theta = state["theta"]
+    beta = state["beta"]
+    xi = m.dev(stress) - theta - beta
+    eps_eq = float(state["eps_eq"])
+    R = float(state["R"])
+    R_n = float(state_n["R"])
+    theta_max = float(state["theta_max"])
+    dl = float(dlambda)
+
+    return {
+        "dRstress_dstress": (
+            (C, xi, dl),
+            (C, xi, dl),
+        ),
+        "dRstress_dbeta": (
+            (C, xi, dl),
+            (C, xi, dl),
+        ),
+        "dRstress_dtheta": (
+            (C, xi, dl),
+            (C, xi, dl),
+        ),
+        "dRstress_dlambda": (
+            (C, xi, eps_eq, dl),
+            (m.E, m.Ea, m.xi, C, xi, eps_eq, dl),
+        ),
+        "dRbeta_dstress": (
+            (dl,),
+            (m.k, m.b, m.Y, dl),
+        ),
+        "dRbeta_dbeta": (
+            (dl,),
+            (m.k, m.b, m.Y, dl),
+        ),
+        "dRbeta_dtheta": (
+            (dl,),
+            (m.k, m.b, m.Y, dl),
+        ),
+        "dRbeta_dlambda": (
+            (xi, beta, dl),
+            (m.k, m.b, m.Y, xi, beta, dl),
+        ),
+        "dRtheta_dstress": (
+            (theta, theta_max, R, R_n, dl),
+            (m.B, m.Y, m.k, m.Rsat, m.C_1, m.C_2,
+             theta, theta_max, R, R_n, dl),
+        ),
+        "dRtheta_dbeta": (
+            (theta, theta_max, R, R_n, dl),
+            (m.B, m.Y, m.k, m.Rsat, m.C_1, m.C_2,
+             theta, theta_max, R, R_n, dl),
+        ),
+        "dRtheta_dtheta": (
+            (theta, theta_max, R, R_n, dl),
+            (m.B, m.Y, m.k, m.Rsat, m.C_1, m.C_2,
+             theta, theta_max, R, R_n, dl),
+        ),
+        "dRtheta_dlambda": (
+            (xi, theta, theta_max, R, R_n, dl),
+            (m.B, m.Y, m.k, m.Rsat, m.C_1, m.C_2,
+             xi, theta, theta_max, R, R_n, dl),
+        ),
+        "dRyield_dstress": (
+            (xi,),
+            (xi,),
+        ),
+        "dRyield_dbeta": (
+            (xi,),
+            (xi,),
+        ),
+        "dRyield_dtheta": (
+            (xi,),
+            (xi,),
+        ),
+        "dRyield_dlambda": (
+            (),
+            (),
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# TestJacobianBlocks: per-step comparison over full trajectories
+# ---------------------------------------------------------------------------
+
+class TestJacobianBlocks:
+    """Compare all 16 Jacobian blocks Python vs Fortran over trajectory steps."""
+
+    def test_jacobian_blocks_match_fortran(self, yu_3d_scenario, fortran_mod):
+        m, history = yu_3d_scenario
+        integrator = PythonNumericalIntegrator(m)
+
+        stress_n = np.zeros(6)
+        state_n = m.initial_state()
+        n_plastic = 0
+
+        for strain_total_n, strain_total_np1 in zip(history[:-1], history[1:]):
+            strain_inc = strain_total_np1 - strain_total_n
+            result = integrator.stress_update(strain_inc, stress_n, state_n)
+
+            if result.is_plastic:
+                n_plastic += 1
+                cases = _build_cases(m, result.state, state_n, result.dlambda)
+                res = check_bindings(m, fortran_mod, cases, rtol=1e-10, atol=1e-12)
+                for name, (ok, err) in res.items():
+                    assert ok, (
+                        f"step {n_plastic}: {name}: max_rel_err={err:.3e}"
+                    )
+
+            stress_n = result.stress
+            state_n = result.state
+
+        if n_plastic == 0:
+            pytest.skip("No plastic steps in this scenario — Jacobian blocks not exercised")

--- a/tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py
+++ b/tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py
@@ -162,3 +162,76 @@ class TestJacobianBlocks:
 
         if n_plastic == 0:
             pytest.skip("No plastic steps in this scenario — Jacobian blocks not exercised")
+
+
+# ---------------------------------------------------------------------------
+# TestResidualAndJacobian: compare Python calc_residual/calc_jacobian vs Fortran
+# ---------------------------------------------------------------------------
+
+class TestResidualAndJacobian:
+    """Compare calc_residual and calc_jacobian Python vs Fortran over trajectories."""
+
+    def _run_and_check(self, m, history, fortran_mod):
+        integrator = PythonNumericalIntegrator(m)
+        stress_n = np.zeros(6)
+        state_n = m.initial_state()
+        n_plastic = 0
+
+        for strain_total_n, strain_total_np1 in zip(history[:-1], history[1:]):
+            strain_inc = strain_total_np1 - strain_total_n
+            result = integrator.stress_update(strain_inc, stress_n, state_n)
+
+            if result.is_plastic:
+                n_plastic += 1
+                state = result.state
+                dl = float(result.dlambda)
+
+                # Reconstruct stress_trial (σ_trial = σ_n + C·Δε, elastic)
+                C0 = m.elastic_stiffness(state_n)
+                stress_trial = stress_n + C0 @ strain_inc
+
+                props = (
+                    m.E, m.nu, m.Y, m.B, m.C_1, m.C_2,
+                    m.Rsat, m.k, m.b, m.h, m.Ea, m.xi,
+                )
+
+                # --- calc_residual ---
+                py_r = m.calc_residual(state, state_n, stress_trial, dl)
+                f_r = fortran_mod.call(
+                    "yu_calc_residual",
+                    *props,
+                    state["stress"], state["theta"], state["beta"],
+                    float(state["R"]), float(state["eps_eq"]),
+                    state_n["theta"], state_n["beta"], float(state_n["theta_max"]),
+                    stress_trial, dl,
+                )
+                np.testing.assert_allclose(
+                    np.asarray(py_r), np.asarray(f_r),
+                    rtol=1e-12, atol=1e-12,
+                    err_msg=f"calc_residual mismatch at plastic step {n_plastic}",
+                )
+
+                # --- calc_jacobian ---
+                py_j = m.calc_jacobian(state, state_n, stress_trial, dl)
+                f_j = fortran_mod.call(
+                    "yu_calc_jacobian",
+                    *props,
+                    state["stress"], state["theta"], state["beta"],
+                    float(state["R"]), float(state["eps_eq"]),
+                    float(state["theta_max"]), float(state_n["R"]), dl,
+                )
+                np.testing.assert_allclose(
+                    np.asarray(py_j), np.asarray(f_j),
+                    rtol=1e-10, atol=1e-12,
+                    err_msg=f"calc_jacobian mismatch at plastic step {n_plastic}",
+                )
+
+            stress_n = result.stress
+            state_n = result.state
+
+        if n_plastic == 0:
+            pytest.skip("No plastic steps in this scenario")
+
+    def test_residual_and_jacobian_match_fortran(self, yu_3d_scenario, fortran_mod):
+        m, history = yu_3d_scenario
+        self._run_and_check(m, history, fortran_mod)

--- a/tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py
+++ b/tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py
@@ -1,13 +1,15 @@
-"""Path B benchmarks: YUKinematic3D Python NR vs Fortran UMAT.
+"""Path B benchmarks: YUKinematic3D Python vs Fortran subroutines.
 
 Requires the compiled yu_kinematic_3d Fortran extension:
     make fortran-build-yu
 or:
     uv run manforge build fortran/abaqus_stubs.f90 fortran/yu_kinematic_3d.f90 --name yu_kinematic_3d
 
-Test classes added incrementally per implementation step:
-    TestJacobianBlocks       -- Step 1: 16 dRxx_dyy blocks + helpers
-    TestResidualAndJacobian  -- Step 2: integrated residual + Jacobian
+Test classes:
+    TestHelpers              -- helper subroutines: elastic_stiffness, calc_norm_n_flow,
+                                _prepare_Rstress, _prepare_Rtheta  (single plastic step)
+    TestJacobianBlocks       -- 16 dRxx_dyy blocks over full trajectories
+    TestResidualAndJacobian  -- integrated calc_residual + calc_jacobian over full trajectories
 """
 
 import numpy as np
@@ -30,6 +32,10 @@ from manforge.verification import check_bindings
 from .conftest import PARAMS
 
 
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
 @pytest.fixture
 def fortran_mod():
     return FortranModule("yu_kinematic_3d")
@@ -40,17 +46,27 @@ def model():
     return YUKinematic3D(**PARAMS)
 
 
+@pytest.fixture
+def plastic_state(model):
+    """Run one plastic step and return (model, state, state_n, dlambda)."""
+    integrator = PythonNumericalIntegrator(model)
+    stress_n = np.zeros(6)
+    state_n = model.initial_state()
+    strain_inc = np.array([2e-3, -6e-4, -6e-4, 0.0, 0.0, 0.0])
+    result = integrator.stress_update(strain_inc, stress_n, state_n)
+    assert result.is_plastic
+    return model, result.state, state_n, float(result.dlambda)
+
+
 # ---------------------------------------------------------------------------
-# Helper: build check_bindings cases from a converged plastic step state
+# Helper: build check_bindings cases for all 16 dRxx_dyy blocks
 # ---------------------------------------------------------------------------
 
-def _build_cases(m, state, state_n, dlambda):
-    """Return check_bindings cases dict for all 16 dRxx_dyy blocks."""
+def _build_jacobian_cases(m, state, state_n, dlambda):
     C = m.elastic_stiffness(state)
-    stress = state["stress"]
+    xi = m.dev(state["stress"]) - state["theta"] - state["beta"]
     theta = state["theta"]
     beta = state["beta"]
-    xi = m.dev(stress) - theta - beta
     eps_eq = float(state["eps_eq"])
     R = float(state["R"])
     R_n = float(state_n["R"])
@@ -130,6 +146,59 @@ def _build_cases(m, state, state_n, dlambda):
 
 
 # ---------------------------------------------------------------------------
+# TestHelpers: helper subroutines compared at a single plastic step
+# ---------------------------------------------------------------------------
+
+class TestHelpers:
+    """Compare helper subroutines Python vs Fortran at a single plastic step."""
+
+    def test_elastic_stiffness(self, plastic_state, fortran_mod):
+        m, state, _, _ = plastic_state
+        py = m.elastic_stiffness(state)
+        f = fortran_mod.call(
+            "yu_kinematic_3d_elastic_stiffness",
+            m.E, m.nu, float(state["eps_eq"]), m.Ea, m.xi,
+        )
+        np.testing.assert_allclose(py, f, rtol=1e-12, atol=1e-12)
+
+    def test_calc_norm_n_flow(self, plastic_state, fortran_mod):
+        m, state, _, _ = plastic_state
+        xi = m.dev(state["stress"]) - state["theta"] - state["beta"]
+        xi_norm_py, flow_py = m.calc_norm_n_flow(xi)
+        xi_norm_f, flow_f = fortran_mod.call("yu_calc_norm_n_flow", xi)
+        np.testing.assert_allclose(xi_norm_py, xi_norm_f, rtol=1e-12)
+        np.testing.assert_allclose(flow_py, flow_f, rtol=1e-12)
+
+    def test_prepare_rstress(self, plastic_state, fortran_mod):
+        m, state, _, _ = plastic_state
+        xi = m.dev(state["stress"]) - state["theta"] - state["beta"]
+        py = m._prepare_Rstress(xi)
+        f = fortran_mod.call("yu_prepare_rstress", xi)
+        np.testing.assert_allclose(py, f, atol=1e-12)
+
+    def test_prepare_rtheta(self, plastic_state, fortran_mod):
+        m, state, state_n, dlambda = plastic_state
+        theta = state["theta"]
+        theta_max = float(state["theta_max"])
+        R = float(state["R"])
+        R_n = float(state_n["R"])
+        py = m._prepare_Rtheta(theta, theta_max, R, R_n, dlambda)
+        theta_bar_py, theta_flow_py, C_k_py, s_py, a_py, a_prime_py = py
+        f = fortran_mod.call(
+            "yu_prepare_rtheta",
+            m.B, m.Y, m.k, m.Rsat, m.C_1, m.C_2,
+            theta, theta_max, R, R_n, dlambda,
+        )
+        theta_bar_f, theta_flow_f, C_k_f, s_f, a_f, a_prime_f = f
+        np.testing.assert_allclose(theta_bar_py, theta_bar_f, rtol=1e-12)
+        np.testing.assert_allclose(theta_flow_py, theta_flow_f, rtol=1e-12)
+        np.testing.assert_allclose(C_k_py, C_k_f, rtol=1e-12)
+        np.testing.assert_allclose(s_py, s_f, rtol=1e-12)
+        np.testing.assert_allclose(a_py, a_f, rtol=1e-12)
+        np.testing.assert_allclose(a_prime_py, a_prime_f, rtol=1e-12)
+
+
+# ---------------------------------------------------------------------------
 # TestJacobianBlocks: per-step comparison over full trajectories
 # ---------------------------------------------------------------------------
 
@@ -150,12 +219,10 @@ class TestJacobianBlocks:
 
             if result.is_plastic:
                 n_plastic += 1
-                cases = _build_cases(m, result.state, state_n, result.dlambda)
+                cases = _build_jacobian_cases(m, result.state, state_n, result.dlambda)
                 res = check_bindings(m, fortran_mod, cases, rtol=1e-10, atol=1e-12)
                 for name, (ok, err) in res.items():
-                    assert ok, (
-                        f"step {n_plastic}: {name}: max_rel_err={err:.3e}"
-                    )
+                    assert ok, f"step {n_plastic}: {name}: max_rel_err={err:.3e}"
 
             stress_n = result.stress
             state_n = result.state
@@ -165,7 +232,7 @@ class TestJacobianBlocks:
 
 
 # ---------------------------------------------------------------------------
-# TestResidualAndJacobian: compare Python calc_residual/calc_jacobian vs Fortran
+# TestResidualAndJacobian: integrated residual + Jacobian over full trajectories
 # ---------------------------------------------------------------------------
 
 class TestResidualAndJacobian:
@@ -186,7 +253,6 @@ class TestResidualAndJacobian:
                 state = result.state
                 dl = float(result.dlambda)
 
-                # Reconstruct stress_trial (σ_trial = σ_n + C·Δε, elastic)
                 C0 = m.elastic_stiffness(state_n)
                 stress_trial = stress_n + C0 @ strain_inc
 
@@ -195,7 +261,6 @@ class TestResidualAndJacobian:
                     m.Rsat, m.k, m.b, m.h, m.Ea, m.xi,
                 )
 
-                # --- calc_residual ---
                 py_r = m.calc_residual(state, state_n, stress_trial, dl)
                 f_r = fortran_mod.call(
                     "yu_calc_residual",
@@ -211,7 +276,6 @@ class TestResidualAndJacobian:
                     err_msg=f"calc_residual mismatch at plastic step {n_plastic}",
                 )
 
-                # --- calc_jacobian ---
                 py_j = m.calc_jacobian(state, state_n, stress_trial, dl)
                 f_j = fortran_mod.call(
                     "yu_calc_jacobian",

--- a/tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py
+++ b/tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py
@@ -6,10 +6,10 @@ or:
     uv run manforge build fortran/abaqus_stubs.f90 fortran/yu_kinematic_3d.f90 --name yu_kinematic_3d
 
 Test classes:
-    TestHelpers              -- helper subroutines: elastic_stiffness, calc_norm_n_flow,
-                                _prepare_Rstress, _prepare_Rtheta  (single plastic step)
-    TestJacobianBlocks       -- 16 dRxx_dyy blocks over full trajectories
-    TestResidualAndJacobian  -- integrated calc_residual + calc_jacobian over full trajectories
+    TestHelpers              -- elastic_stiffness, calc_norm_n_flow,
+                                _prepare_Rstress, _prepare_Rtheta
+    TestJacobianBlocks       -- one test per dRxx_dyy block (16 total)
+    TestResidualAndJacobian  -- calc_residual + calc_jacobian over trajectories
 """
 
 import numpy as np
@@ -27,7 +27,6 @@ pytestmark = pytest.mark.fortran
 
 from manforge.simulation.integrator import FortranModule, PythonNumericalIntegrator
 from manforge.models import YUKinematic3D
-from manforge.verification import check_bindings
 
 from .conftest import PARAMS
 
@@ -48,7 +47,7 @@ def model():
 
 @pytest.fixture
 def plastic_state(model):
-    """Run one plastic step and return (model, state, state_n, dlambda)."""
+    """Run one plastic step; return (model, state, state_n, dlambda)."""
     integrator = PythonNumericalIntegrator(model)
     stress_n = np.zeros(6)
     state_n = model.initial_state()
@@ -59,94 +58,7 @@ def plastic_state(model):
 
 
 # ---------------------------------------------------------------------------
-# Helper: build check_bindings cases for all 16 dRxx_dyy blocks
-# ---------------------------------------------------------------------------
-
-def _build_jacobian_cases(m, state, state_n, dlambda):
-    C = m.elastic_stiffness(state)
-    xi = m.dev(state["stress"]) - state["theta"] - state["beta"]
-    theta = state["theta"]
-    beta = state["beta"]
-    eps_eq = float(state["eps_eq"])
-    R = float(state["R"])
-    R_n = float(state_n["R"])
-    theta_max = float(state["theta_max"])
-    dl = float(dlambda)
-
-    return {
-        "dRstress_dstress": (
-            (C, xi, dl),
-            (C, xi, dl),
-        ),
-        "dRstress_dbeta": (
-            (C, xi, dl),
-            (C, xi, dl),
-        ),
-        "dRstress_dtheta": (
-            (C, xi, dl),
-            (C, xi, dl),
-        ),
-        "dRstress_dlambda": (
-            (C, xi, eps_eq, dl),
-            (m.E, m.Ea, m.xi, C, xi, eps_eq, dl),
-        ),
-        "dRbeta_dstress": (
-            (dl,),
-            (m.k, m.b, m.Y, dl),
-        ),
-        "dRbeta_dbeta": (
-            (dl,),
-            (m.k, m.b, m.Y, dl),
-        ),
-        "dRbeta_dtheta": (
-            (dl,),
-            (m.k, m.b, m.Y, dl),
-        ),
-        "dRbeta_dlambda": (
-            (xi, beta, dl),
-            (m.k, m.b, m.Y, xi, beta, dl),
-        ),
-        "dRtheta_dstress": (
-            (theta, theta_max, R, R_n, dl),
-            (m.B, m.Y, m.k, m.Rsat, m.C_1, m.C_2,
-             theta, theta_max, R, R_n, dl),
-        ),
-        "dRtheta_dbeta": (
-            (theta, theta_max, R, R_n, dl),
-            (m.B, m.Y, m.k, m.Rsat, m.C_1, m.C_2,
-             theta, theta_max, R, R_n, dl),
-        ),
-        "dRtheta_dtheta": (
-            (theta, theta_max, R, R_n, dl),
-            (m.B, m.Y, m.k, m.Rsat, m.C_1, m.C_2,
-             theta, theta_max, R, R_n, dl),
-        ),
-        "dRtheta_dlambda": (
-            (xi, theta, theta_max, R, R_n, dl),
-            (m.B, m.Y, m.k, m.Rsat, m.C_1, m.C_2,
-             xi, theta, theta_max, R, R_n, dl),
-        ),
-        "dRyield_dstress": (
-            (xi,),
-            (xi,),
-        ),
-        "dRyield_dbeta": (
-            (xi,),
-            (xi,),
-        ),
-        "dRyield_dtheta": (
-            (xi,),
-            (xi,),
-        ),
-        "dRyield_dlambda": (
-            (),
-            (),
-        ),
-    }
-
-
-# ---------------------------------------------------------------------------
-# TestHelpers: helper subroutines compared at a single plastic step
+# TestHelpers: helper subroutines at a single plastic step
 # ---------------------------------------------------------------------------
 
 class TestHelpers:
@@ -199,40 +111,166 @@ class TestHelpers:
 
 
 # ---------------------------------------------------------------------------
-# TestJacobianBlocks: per-step comparison over full trajectories
+# TestJacobianBlocks: one test per dRxx_dyy block (16 total)
 # ---------------------------------------------------------------------------
 
 class TestJacobianBlocks:
-    """Compare all 16 Jacobian blocks Python vs Fortran over trajectory steps."""
+    """Compare each Jacobian block Python vs Fortran at a single plastic step."""
 
-    def test_jacobian_blocks_match_fortran(self, yu_3d_scenario, fortran_mod):
-        m, history = yu_3d_scenario
-        integrator = PythonNumericalIntegrator(m)
+    # --- R_stress blocks ---
 
-        stress_n = np.zeros(6)
-        state_n = m.initial_state()
-        n_plastic = 0
+    def test_dRstress_dstress(self, plastic_state, fortran_mod):
+        m, state, _, dlambda = plastic_state
+        C = m.elastic_stiffness(state)
+        xi = m.dev(state["stress"]) - state["theta"] - state["beta"]
+        py = m.dRstress_dstress(C, xi, dlambda)
+        f = fortran_mod.call("yu_drs_dstress", C, xi, dlambda)
+        np.testing.assert_allclose(py, f, rtol=1e-10, atol=1e-12)
 
-        for strain_total_n, strain_total_np1 in zip(history[:-1], history[1:]):
-            strain_inc = strain_total_np1 - strain_total_n
-            result = integrator.stress_update(strain_inc, stress_n, state_n)
+    def test_dRstress_dbeta(self, plastic_state, fortran_mod):
+        m, state, _, dlambda = plastic_state
+        C = m.elastic_stiffness(state)
+        xi = m.dev(state["stress"]) - state["theta"] - state["beta"]
+        py = m.dRstress_dbeta(C, xi, dlambda)
+        f = fortran_mod.call("yu_drs_dbeta", C, xi, dlambda)
+        np.testing.assert_allclose(py, f, rtol=1e-10, atol=1e-12)
 
-            if result.is_plastic:
-                n_plastic += 1
-                cases = _build_jacobian_cases(m, result.state, state_n, result.dlambda)
-                res = check_bindings(m, fortran_mod, cases, rtol=1e-10, atol=1e-12)
-                for name, (ok, err) in res.items():
-                    assert ok, f"step {n_plastic}: {name}: max_rel_err={err:.3e}"
+    def test_dRstress_dtheta(self, plastic_state, fortran_mod):
+        m, state, _, dlambda = plastic_state
+        C = m.elastic_stiffness(state)
+        xi = m.dev(state["stress"]) - state["theta"] - state["beta"]
+        py = m.dRstress_dtheta(C, xi, dlambda)
+        f = fortran_mod.call("yu_drs_dtheta", C, xi, dlambda)
+        np.testing.assert_allclose(py, f, rtol=1e-10, atol=1e-12)
 
-            stress_n = result.stress
-            state_n = result.state
+    def test_dRstress_dlambda(self, plastic_state, fortran_mod):
+        m, state, _, dlambda = plastic_state
+        C = m.elastic_stiffness(state)
+        xi = m.dev(state["stress"]) - state["theta"] - state["beta"]
+        eps_eq = float(state["eps_eq"])
+        py = m.dRstress_dlambda(C, xi, eps_eq, dlambda)
+        f = fortran_mod.call("yu_drs_dlambda", m.E, m.Ea, m.xi, C, xi, eps_eq, dlambda)
+        np.testing.assert_allclose(py, f, rtol=1e-10, atol=1e-12)
 
-        if n_plastic == 0:
-            pytest.skip("No plastic steps in this scenario — Jacobian blocks not exercised")
+    # --- R_beta blocks ---
+
+    def test_dRbeta_dstress(self, plastic_state, fortran_mod):
+        m, state, _, dlambda = plastic_state
+        py = m.dRbeta_dstress(dlambda)
+        f = fortran_mod.call("yu_drb_dstress", m.k, m.b, m.Y, dlambda)
+        np.testing.assert_allclose(py, f, rtol=1e-10, atol=1e-12)
+
+    def test_dRbeta_dbeta(self, plastic_state, fortran_mod):
+        m, state, _, dlambda = plastic_state
+        py = m.dRbeta_dbeta(dlambda)
+        f = fortran_mod.call("yu_drb_dbeta", m.k, m.b, m.Y, dlambda)
+        np.testing.assert_allclose(py, f, rtol=1e-10, atol=1e-12)
+
+    def test_dRbeta_dtheta(self, plastic_state, fortran_mod):
+        m, state, _, dlambda = plastic_state
+        py = m.dRbeta_dtheta(dlambda)
+        f = fortran_mod.call("yu_drb_dtheta", m.k, m.b, m.Y, dlambda)
+        np.testing.assert_allclose(py, f, rtol=1e-10, atol=1e-12)
+
+    def test_dRbeta_dlambda(self, plastic_state, fortran_mod):
+        m, state, _, dlambda = plastic_state
+        xi = m.dev(state["stress"]) - state["theta"] - state["beta"]
+        beta = state["beta"]
+        py = m.dRbeta_dlambda(xi, beta, dlambda)
+        f = fortran_mod.call("yu_drb_dlambda", m.k, m.b, m.Y, xi, beta, dlambda)
+        np.testing.assert_allclose(py, f, rtol=1e-10, atol=1e-12)
+
+    # --- R_theta blocks ---
+
+    def test_dRtheta_dstress(self, plastic_state, fortran_mod):
+        m, state, state_n, dlambda = plastic_state
+        theta = state["theta"]
+        theta_max = float(state["theta_max"])
+        R = float(state["R"])
+        R_n = float(state_n["R"])
+        py = m.dRtheta_dstress(theta, theta_max, R, R_n, dlambda)
+        f = fortran_mod.call(
+            "yu_drt_dstress",
+            m.B, m.Y, m.k, m.Rsat, m.C_1, m.C_2,
+            theta, theta_max, R, R_n, dlambda,
+        )
+        np.testing.assert_allclose(py, f, rtol=1e-10, atol=1e-12)
+
+    def test_dRtheta_dbeta(self, plastic_state, fortran_mod):
+        m, state, state_n, dlambda = plastic_state
+        theta = state["theta"]
+        theta_max = float(state["theta_max"])
+        R = float(state["R"])
+        R_n = float(state_n["R"])
+        py = m.dRtheta_dbeta(theta, theta_max, R, R_n, dlambda)
+        f = fortran_mod.call(
+            "yu_drt_dbeta",
+            m.B, m.Y, m.k, m.Rsat, m.C_1, m.C_2,
+            theta, theta_max, R, R_n, dlambda,
+        )
+        np.testing.assert_allclose(py, f, rtol=1e-10, atol=1e-12)
+
+    def test_dRtheta_dtheta(self, plastic_state, fortran_mod):
+        m, state, state_n, dlambda = plastic_state
+        theta = state["theta"]
+        theta_max = float(state["theta_max"])
+        R = float(state["R"])
+        R_n = float(state_n["R"])
+        py = m.dRtheta_dtheta(theta, theta_max, R, R_n, dlambda)
+        f = fortran_mod.call(
+            "yu_drt_dtheta",
+            m.B, m.Y, m.k, m.Rsat, m.C_1, m.C_2,
+            theta, theta_max, R, R_n, dlambda,
+        )
+        np.testing.assert_allclose(py, f, rtol=1e-10, atol=1e-12)
+
+    def test_dRtheta_dlambda(self, plastic_state, fortran_mod):
+        m, state, state_n, dlambda = plastic_state
+        xi = m.dev(state["stress"]) - state["theta"] - state["beta"]
+        theta = state["theta"]
+        theta_max = float(state["theta_max"])
+        R = float(state["R"])
+        R_n = float(state_n["R"])
+        py = m.dRtheta_dlambda(xi, theta, theta_max, R, R_n, dlambda)
+        f = fortran_mod.call(
+            "yu_drt_dlambda",
+            m.B, m.Y, m.k, m.Rsat, m.C_1, m.C_2,
+            xi, theta, theta_max, R, R_n, dlambda,
+        )
+        np.testing.assert_allclose(py, f, rtol=1e-10, atol=1e-12)
+
+    # --- R_yield blocks ---
+
+    def test_dRyield_dstress(self, plastic_state, fortran_mod):
+        m, state, _, _ = plastic_state
+        xi = m.dev(state["stress"]) - state["theta"] - state["beta"]
+        py = m.dRyield_dstress(xi)
+        f = fortran_mod.call("yu_drl_dstress", xi)
+        np.testing.assert_allclose(py, f, rtol=1e-12)
+
+    def test_dRyield_dbeta(self, plastic_state, fortran_mod):
+        m, state, _, _ = plastic_state
+        xi = m.dev(state["stress"]) - state["theta"] - state["beta"]
+        py = m.dRyield_dbeta(xi)
+        f = fortran_mod.call("yu_drl_dbeta", xi)
+        np.testing.assert_allclose(py, f, rtol=1e-12)
+
+    def test_dRyield_dtheta(self, plastic_state, fortran_mod):
+        m, state, _, _ = plastic_state
+        xi = m.dev(state["stress"]) - state["theta"] - state["beta"]
+        py = m.dRyield_dtheta(xi)
+        f = fortran_mod.call("yu_drl_dtheta", xi)
+        np.testing.assert_allclose(py, f, rtol=1e-12)
+
+    def test_dRyield_dlambda(self, plastic_state, fortran_mod):
+        m, _, _, _ = plastic_state
+        py = m.dRyield_dlambda()
+        f = fortran_mod.call("yu_drl_dlambda")
+        np.testing.assert_allclose(py, f, rtol=1e-12)
 
 
 # ---------------------------------------------------------------------------
-# TestResidualAndJacobian: integrated residual + Jacobian over full trajectories
+# TestResidualAndJacobian: integrated residual + Jacobian over trajectories
 # ---------------------------------------------------------------------------
 
 class TestResidualAndJacobian:

--- a/tests/integration/verification/test_yu_fortran_bindings.py
+++ b/tests/integration/verification/test_yu_fortran_bindings.py
@@ -1,0 +1,238 @@
+"""Integration tests: YUKinematic3D Fortran binding registry + check_bindings.
+
+Requires the compiled yu_kinematic_3d Fortran extension:
+    make fortran-build-yu
+"""
+
+import numpy as np
+import pytest
+
+from manforge.verification import FortranModule
+
+_PARAMS = dict(
+    E=206_000, nu=0.3, Y=360.0, C_1=2000.0, C_2=200.0,
+    B=435.0, Rsat=255.0, k=26.0, b=66.0, h=0.4, Ea=159_000, xi=61.0,
+)
+
+_SKIP_MSG = "yu_kinematic_3d not compiled -- run: make fortran-build-yu"
+
+
+@pytest.fixture
+def yu_model():
+    from manforge.models import YUKinematic3D
+    return YUKinematic3D(**_PARAMS)
+
+
+@pytest.fixture
+def fortran():
+    pytest.importorskip("yu_kinematic_3d", reason=_SKIP_MSG)
+    return FortranModule("yu_kinematic_3d")
+
+
+@pytest.fixture
+def plastic_args(yu_model):
+    """Run one plastic step and return convenient argument bundles."""
+    from manforge.simulation.integrator import PythonNumericalIntegrator
+    integrator = PythonNumericalIntegrator(yu_model)
+    stress_n = np.zeros(6)
+    state_n = yu_model.initial_state()
+    strain_inc = np.array([2e-3, -6e-4, -6e-4, 0.0, 0.0, 0.0])
+    result = integrator.stress_update(strain_inc, stress_n, state_n)
+    assert result.is_plastic
+
+    state = result.state
+    m = yu_model
+    C = m.elastic_stiffness(state)
+    stress = state["stress"]
+    theta = state["theta"]
+    beta = state["beta"]
+    xi = m.dev(stress) - theta - beta
+    eps_eq = float(state["eps_eq"])
+    R = float(state["R"])
+    R_n = float(state_n["R"])
+    theta_max = float(state["theta_max"])
+    dlambda = float(result.dlambda)
+
+    return dict(
+        state=state, state_n=state_n,
+        C=C, xi=xi, stress=stress,
+        theta=theta, beta=beta,
+        eps_eq=eps_eq, R=R, R_n=R_n,
+        theta_max=theta_max, dlambda=dlambda,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registry checks
+# ---------------------------------------------------------------------------
+
+@pytest.mark.fortran
+def test_all_bindings_registered():
+    pytest.importorskip("yu_kinematic_3d", reason=_SKIP_MSG)
+    from manforge.models import YUKinematic3D
+    bindings = YUKinematic3D._fortran_bindings
+    expected = {
+        "elastic_stiffness":    "yu_kinematic_3d_elastic_stiffness",
+        "calc_norm_n_flow":     "yu_calc_norm_n_flow",
+        "_prepare_Rstress":     "yu_prepare_rstress",
+        "_prepare_Rtheta":      "yu_prepare_rtheta",
+        "dRstress_dstress":     "yu_drs_dstress",
+        "dRstress_dbeta":       "yu_drs_dbeta",
+        "dRstress_dtheta":      "yu_drs_dtheta",
+        "dRstress_dlambda":     "yu_drs_dlambda",
+        "dRbeta_dstress":       "yu_drb_dstress",
+        "dRbeta_dbeta":         "yu_drb_dbeta",
+        "dRbeta_dtheta":        "yu_drb_dtheta",
+        "dRbeta_dlambda":       "yu_drb_dlambda",
+        "dRtheta_dstress":      "yu_drt_dstress",
+        "dRtheta_dbeta":        "yu_drt_dbeta",
+        "dRtheta_dtheta":       "yu_drt_dtheta",
+        "dRtheta_dlambda":      "yu_drt_dlambda",
+        "dRyield_dstress":      "yu_drl_dstress",
+        "dRyield_dbeta":        "yu_drl_dbeta",
+        "dRyield_dtheta":       "yu_drl_dtheta",
+        "dRyield_dlambda":      "yu_drl_dlambda",
+    }
+    for method, subroutine in expected.items():
+        assert method in bindings, f"{method} not in _fortran_bindings"
+        assert bindings[method].subroutine == subroutine, (
+            f"{method}: expected subroutine={subroutine!r}, got {bindings[method].subroutine!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# check_bindings: single-array-output methods (14 matrix / vector blocks)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.fortran
+def test_check_bindings(yu_model, fortran, plastic_args):
+    from manforge.verification import check_bindings
+    m = yu_model
+    a = plastic_args
+
+    cases = {
+        "elastic_stiffness": (
+            (a["state"],),
+            (m.E, m.nu, a["eps_eq"], m.Ea, m.xi),
+        ),
+        "dRstress_dstress": (
+            (a["C"], a["xi"], a["dlambda"]),
+            (a["C"], a["xi"], a["dlambda"]),
+        ),
+        "dRstress_dbeta": (
+            (a["C"], a["xi"], a["dlambda"]),
+            (a["C"], a["xi"], a["dlambda"]),
+        ),
+        "dRstress_dtheta": (
+            (a["C"], a["xi"], a["dlambda"]),
+            (a["C"], a["xi"], a["dlambda"]),
+        ),
+        "dRstress_dlambda": (
+            (a["C"], a["xi"], a["eps_eq"], a["dlambda"]),
+            (m.E, m.Ea, m.xi, a["C"], a["xi"], a["eps_eq"], a["dlambda"]),
+        ),
+        "dRbeta_dstress": (
+            (a["dlambda"],),
+            (m.k, m.b, m.Y, a["dlambda"]),
+        ),
+        "dRbeta_dbeta": (
+            (a["dlambda"],),
+            (m.k, m.b, m.Y, a["dlambda"]),
+        ),
+        "dRbeta_dtheta": (
+            (a["dlambda"],),
+            (m.k, m.b, m.Y, a["dlambda"]),
+        ),
+        "dRbeta_dlambda": (
+            (a["xi"], a["beta"], a["dlambda"]),
+            (m.k, m.b, m.Y, a["xi"], a["beta"], a["dlambda"]),
+        ),
+        "dRtheta_dstress": (
+            (a["theta"], a["theta_max"], a["R"], a["R_n"], a["dlambda"]),
+            (m.B, m.Y, m.k, m.Rsat, m.C_1, m.C_2,
+             a["theta"], a["theta_max"], a["R"], a["R_n"], a["dlambda"]),
+        ),
+        "dRtheta_dbeta": (
+            (a["theta"], a["theta_max"], a["R"], a["R_n"], a["dlambda"]),
+            (m.B, m.Y, m.k, m.Rsat, m.C_1, m.C_2,
+             a["theta"], a["theta_max"], a["R"], a["R_n"], a["dlambda"]),
+        ),
+        "dRtheta_dtheta": (
+            (a["theta"], a["theta_max"], a["R"], a["R_n"], a["dlambda"]),
+            (m.B, m.Y, m.k, m.Rsat, m.C_1, m.C_2,
+             a["theta"], a["theta_max"], a["R"], a["R_n"], a["dlambda"]),
+        ),
+        "dRtheta_dlambda": (
+            (a["xi"], a["theta"], a["theta_max"], a["R"], a["R_n"], a["dlambda"]),
+            (m.B, m.Y, m.k, m.Rsat, m.C_1, m.C_2,
+             a["xi"], a["theta"], a["theta_max"], a["R"], a["R_n"], a["dlambda"]),
+        ),
+        "dRyield_dstress": (
+            (a["xi"],),
+            (a["xi"],),
+        ),
+        "dRyield_dbeta": (
+            (a["xi"],),
+            (a["xi"],),
+        ),
+        "dRyield_dtheta": (
+            (a["xi"],),
+            (a["xi"],),
+        ),
+        "dRyield_dlambda": (
+            (),
+            (),
+        ),
+    }
+
+    results = check_bindings(yu_model, fortran, cases, rtol=1e-10, atol=1e-12)
+    for name, (ok, err) in results.items():
+        assert ok, f"{name}: max_rel_err={err:.3e}"
+
+
+# ---------------------------------------------------------------------------
+# Individual tests for tuple-return helpers
+# ---------------------------------------------------------------------------
+
+@pytest.mark.fortran
+def test_prepare_rstress(yu_model, fortran, plastic_args):
+    a = plastic_args
+    py_out = yu_model._prepare_Rstress(a["xi"])
+    f_out = fortran.call("yu_prepare_rstress", a["xi"])
+    np.testing.assert_allclose(py_out, f_out, atol=1e-12,
+                               err_msg="_prepare_Rstress: matrix mismatch")
+
+
+@pytest.mark.fortran
+def test_calc_norm_n_flow(yu_model, fortran, plastic_args):
+    a = plastic_args
+    xi_norm_py, flow_py = yu_model.calc_norm_n_flow(a["xi"])
+    xi_norm_f, flow_f = fortran.call("yu_calc_norm_n_flow", a["xi"])
+    np.testing.assert_allclose(xi_norm_py, xi_norm_f, rtol=1e-12,
+                               err_msg="calc_norm_n_flow: xi_norm mismatch")
+    np.testing.assert_allclose(flow_py, flow_f, rtol=1e-12,
+                               err_msg="calc_norm_n_flow: flow mismatch")
+
+
+@pytest.mark.fortran
+def test_prepare_rtheta(yu_model, fortran, plastic_args):
+    a = plastic_args
+    m = yu_model
+    py_out = m._prepare_Rtheta(
+        a["theta"], a["theta_max"], a["R"], a["R_n"], a["dlambda"]
+    )
+    theta_bar_py, theta_flow_py, C_k_py, s_py, a_py, a_prime_py = py_out
+
+    f_out = fortran.call(
+        "yu_prepare_rtheta",
+        m.B, m.Y, m.k, m.Rsat, m.C_1, m.C_2,
+        a["theta"], a["theta_max"], a["R"], a["R_n"], a["dlambda"],
+    )
+    theta_bar_f, theta_flow_f, C_k_f, s_f, a_f, a_prime_f = f_out
+
+    np.testing.assert_allclose(theta_bar_py, theta_bar_f, rtol=1e-12)
+    np.testing.assert_allclose(theta_flow_py, theta_flow_f, rtol=1e-12)
+    np.testing.assert_allclose(C_k_py, C_k_f, rtol=1e-12)
+    np.testing.assert_allclose(s_py, s_f, rtol=1e-12)
+    np.testing.assert_allclose(a_py, a_f, rtol=1e-12)
+    np.testing.assert_allclose(a_prime_py, a_prime_f, rtol=1e-12)

--- a/tests/integration/verification/test_yu_fortran_bindings.py
+++ b/tests/integration/verification/test_yu_fortran_bindings.py
@@ -1,74 +1,13 @@
-"""Integration tests: YUKinematic3D Fortran binding registry + check_bindings.
+"""Integration tests: YUKinematic3D Fortran binding registry.
 
-Requires the compiled yu_kinematic_3d Fortran extension:
-    make fortran-build-yu
+Checks that @verified_against_fortran decorators are correctly registered
+on YUKinematic3D._fortran_bindings.  Does not require the compiled .so.
 """
 
-import numpy as np
 import pytest
 
-from manforge.verification import FortranModule
 
-_PARAMS = dict(
-    E=206_000, nu=0.3, Y=360.0, C_1=2000.0, C_2=200.0,
-    B=435.0, Rsat=255.0, k=26.0, b=66.0, h=0.4, Ea=159_000, xi=61.0,
-)
-
-_SKIP_MSG = "yu_kinematic_3d not compiled -- run: make fortran-build-yu"
-
-
-@pytest.fixture
-def yu_model():
-    from manforge.models import YUKinematic3D
-    return YUKinematic3D(**_PARAMS)
-
-
-@pytest.fixture
-def fortran():
-    pytest.importorskip("yu_kinematic_3d", reason=_SKIP_MSG)
-    return FortranModule("yu_kinematic_3d")
-
-
-@pytest.fixture
-def plastic_args(yu_model):
-    """Run one plastic step and return convenient argument bundles."""
-    from manforge.simulation.integrator import PythonNumericalIntegrator
-    integrator = PythonNumericalIntegrator(yu_model)
-    stress_n = np.zeros(6)
-    state_n = yu_model.initial_state()
-    strain_inc = np.array([2e-3, -6e-4, -6e-4, 0.0, 0.0, 0.0])
-    result = integrator.stress_update(strain_inc, stress_n, state_n)
-    assert result.is_plastic
-
-    state = result.state
-    m = yu_model
-    C = m.elastic_stiffness(state)
-    stress = state["stress"]
-    theta = state["theta"]
-    beta = state["beta"]
-    xi = m.dev(stress) - theta - beta
-    eps_eq = float(state["eps_eq"])
-    R = float(state["R"])
-    R_n = float(state_n["R"])
-    theta_max = float(state["theta_max"])
-    dlambda = float(result.dlambda)
-
-    return dict(
-        state=state, state_n=state_n,
-        C=C, xi=xi, stress=stress,
-        theta=theta, beta=beta,
-        eps_eq=eps_eq, R=R, R_n=R_n,
-        theta_max=theta_max, dlambda=dlambda,
-    )
-
-
-# ---------------------------------------------------------------------------
-# Registry checks
-# ---------------------------------------------------------------------------
-
-@pytest.mark.fortran
 def test_all_bindings_registered():
-    pytest.importorskip("yu_kinematic_3d", reason=_SKIP_MSG)
     from manforge.models import YUKinematic3D
     bindings = YUKinematic3D._fortran_bindings
     expected = {
@@ -76,6 +15,8 @@ def test_all_bindings_registered():
         "calc_norm_n_flow":     "yu_calc_norm_n_flow",
         "_prepare_Rstress":     "yu_prepare_rstress",
         "_prepare_Rtheta":      "yu_prepare_rtheta",
+        "calc_residual":        "yu_calc_residual",
+        "calc_jacobian":        "yu_calc_jacobian",
         "dRstress_dstress":     "yu_drs_dstress",
         "dRstress_dbeta":       "yu_drs_dbeta",
         "dRstress_dtheta":      "yu_drs_dtheta",
@@ -98,141 +39,3 @@ def test_all_bindings_registered():
         assert bindings[method].subroutine == subroutine, (
             f"{method}: expected subroutine={subroutine!r}, got {bindings[method].subroutine!r}"
         )
-
-
-# ---------------------------------------------------------------------------
-# check_bindings: single-array-output methods (14 matrix / vector blocks)
-# ---------------------------------------------------------------------------
-
-@pytest.mark.fortran
-def test_check_bindings(yu_model, fortran, plastic_args):
-    from manforge.verification import check_bindings
-    m = yu_model
-    a = plastic_args
-
-    cases = {
-        "elastic_stiffness": (
-            (a["state"],),
-            (m.E, m.nu, a["eps_eq"], m.Ea, m.xi),
-        ),
-        "dRstress_dstress": (
-            (a["C"], a["xi"], a["dlambda"]),
-            (a["C"], a["xi"], a["dlambda"]),
-        ),
-        "dRstress_dbeta": (
-            (a["C"], a["xi"], a["dlambda"]),
-            (a["C"], a["xi"], a["dlambda"]),
-        ),
-        "dRstress_dtheta": (
-            (a["C"], a["xi"], a["dlambda"]),
-            (a["C"], a["xi"], a["dlambda"]),
-        ),
-        "dRstress_dlambda": (
-            (a["C"], a["xi"], a["eps_eq"], a["dlambda"]),
-            (m.E, m.Ea, m.xi, a["C"], a["xi"], a["eps_eq"], a["dlambda"]),
-        ),
-        "dRbeta_dstress": (
-            (a["dlambda"],),
-            (m.k, m.b, m.Y, a["dlambda"]),
-        ),
-        "dRbeta_dbeta": (
-            (a["dlambda"],),
-            (m.k, m.b, m.Y, a["dlambda"]),
-        ),
-        "dRbeta_dtheta": (
-            (a["dlambda"],),
-            (m.k, m.b, m.Y, a["dlambda"]),
-        ),
-        "dRbeta_dlambda": (
-            (a["xi"], a["beta"], a["dlambda"]),
-            (m.k, m.b, m.Y, a["xi"], a["beta"], a["dlambda"]),
-        ),
-        "dRtheta_dstress": (
-            (a["theta"], a["theta_max"], a["R"], a["R_n"], a["dlambda"]),
-            (m.B, m.Y, m.k, m.Rsat, m.C_1, m.C_2,
-             a["theta"], a["theta_max"], a["R"], a["R_n"], a["dlambda"]),
-        ),
-        "dRtheta_dbeta": (
-            (a["theta"], a["theta_max"], a["R"], a["R_n"], a["dlambda"]),
-            (m.B, m.Y, m.k, m.Rsat, m.C_1, m.C_2,
-             a["theta"], a["theta_max"], a["R"], a["R_n"], a["dlambda"]),
-        ),
-        "dRtheta_dtheta": (
-            (a["theta"], a["theta_max"], a["R"], a["R_n"], a["dlambda"]),
-            (m.B, m.Y, m.k, m.Rsat, m.C_1, m.C_2,
-             a["theta"], a["theta_max"], a["R"], a["R_n"], a["dlambda"]),
-        ),
-        "dRtheta_dlambda": (
-            (a["xi"], a["theta"], a["theta_max"], a["R"], a["R_n"], a["dlambda"]),
-            (m.B, m.Y, m.k, m.Rsat, m.C_1, m.C_2,
-             a["xi"], a["theta"], a["theta_max"], a["R"], a["R_n"], a["dlambda"]),
-        ),
-        "dRyield_dstress": (
-            (a["xi"],),
-            (a["xi"],),
-        ),
-        "dRyield_dbeta": (
-            (a["xi"],),
-            (a["xi"],),
-        ),
-        "dRyield_dtheta": (
-            (a["xi"],),
-            (a["xi"],),
-        ),
-        "dRyield_dlambda": (
-            (),
-            (),
-        ),
-    }
-
-    results = check_bindings(yu_model, fortran, cases, rtol=1e-10, atol=1e-12)
-    for name, (ok, err) in results.items():
-        assert ok, f"{name}: max_rel_err={err:.3e}"
-
-
-# ---------------------------------------------------------------------------
-# Individual tests for tuple-return helpers
-# ---------------------------------------------------------------------------
-
-@pytest.mark.fortran
-def test_prepare_rstress(yu_model, fortran, plastic_args):
-    a = plastic_args
-    py_out = yu_model._prepare_Rstress(a["xi"])
-    f_out = fortran.call("yu_prepare_rstress", a["xi"])
-    np.testing.assert_allclose(py_out, f_out, atol=1e-12,
-                               err_msg="_prepare_Rstress: matrix mismatch")
-
-
-@pytest.mark.fortran
-def test_calc_norm_n_flow(yu_model, fortran, plastic_args):
-    a = plastic_args
-    xi_norm_py, flow_py = yu_model.calc_norm_n_flow(a["xi"])
-    xi_norm_f, flow_f = fortran.call("yu_calc_norm_n_flow", a["xi"])
-    np.testing.assert_allclose(xi_norm_py, xi_norm_f, rtol=1e-12,
-                               err_msg="calc_norm_n_flow: xi_norm mismatch")
-    np.testing.assert_allclose(flow_py, flow_f, rtol=1e-12,
-                               err_msg="calc_norm_n_flow: flow mismatch")
-
-
-@pytest.mark.fortran
-def test_prepare_rtheta(yu_model, fortran, plastic_args):
-    a = plastic_args
-    m = yu_model
-    py_out = m._prepare_Rtheta(
-        a["theta"], a["theta_max"], a["R"], a["R_n"], a["dlambda"]
-    )
-    theta_bar_py, theta_flow_py, C_k_py, s_py, a_py, a_prime_py = py_out
-
-    f_out = fortran.call(
-        "yu_prepare_rtheta",
-        m.B, m.Y, m.k, m.Rsat, m.C_1, m.C_2,
-        a["theta"], a["theta_max"], a["R"], a["R_n"], a["dlambda"],
-    )
-    theta_bar_f, theta_flow_f, C_k_f, s_f, a_f, a_prime_f = f_out
-
-    np.testing.assert_allclose(theta_bar_py, theta_bar_f, rtol=1e-12)
-    np.testing.assert_allclose(theta_flow_py, theta_flow_f, rtol=1e-12)
-    np.testing.assert_allclose(C_k_py, C_k_f, rtol=1e-12)
-    np.testing.assert_allclose(s_py, s_f, rtol=1e-12)
-    np.testing.assert_allclose(a_py, a_f, rtol=1e-12)
-    np.testing.assert_allclose(a_prime_py, a_prime_f, rtol=1e-12)


### PR DESCRIPTION
## Summary

- `fortran/yu_kinematic_3d.f90` 新規作成: `yu_kinematic_3d_elastic_stiffness` / ヘルパ3つ / Jacobian 16ブロック / `yu_calc_residual` / `yu_calc_jacobian`
- `Makefile`: `fortran-build-yu` ターゲット追加
- `src/manforge/models/yu_kinematic.py`: `@verified_against_fortran` デコレータ 22個付与 (各 `test=` に対応する個別テストノード ID を記載)
- `src/manforge/verification/fortran_check.py`: `check_bindings` に `atol` パラメータ追加 (numpy allclose セマンティクス)
- `tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py`:
  - `TestHelpers` — ヘルパ4つの単点比較
  - `TestJacobianBlocks` — 16ブロックを各個別テストメソッドで比較
  - `TestResidualAndJacobian` — `calc_residual` / `calc_jacobian` を trajectory 全体で比較
- `tests/integration/verification/test_yu_fortran_bindings.py`: registry メタデータ確認のみに整理 (`.so` 不要)

## Test plan

- [x] `make fortran-build-yu`
- [x] `uv run python -m pytest tests/integration/verification/test_yu_fortran_bindings.py -v`
- [x] `uv run python -m pytest tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py -v`
- [x] `uv run python -m pytest tests/benchmarks/yu_kinematic/test_analytical_vs_numerical.py -v` (Path A 回帰なし)
- [x] `make test` (fast suite 全 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)