### PR TITLE
feat(fortran): YUKinematic3D UMAT shim 実装 (Step 4)

### DIFF
--- a/fortran/yu_kinematic_3d.f90
+++ b/fortran/yu_kinematic_3d.f90
@@ -1645,6 +1645,18 @@ subroutine umat(STRESS, STATEV, DDSDDE, SSE, SPD, SCD, &
     double precision :: ddsdde_local(6,6)
     integer :: i, j, n_iter, converged
 
+    ! Guard: this UMAT is for 3-D solid elements only (NTENS=6, NDI=3, NSHR=3)
+    if (NTENS /= 6 .or. NDI /= 3 .or. NSHR /= 3 .or. &
+        NSTATV < 22 .or. NPROPS < 12) then
+        write(*,'(A)') 'YUKinematic3D UMAT: incompatible element/material definition.'
+        write(*,'(A,I0,A,I0,A,I0)') '  Expected NTENS=6 NDI=3 NSHR=3, got NTENS=', &
+            NTENS, ' NDI=', NDI, ' NSHR=', NSHR
+        write(*,'(A,I0,A,I0)') '  Expected NSTATV>=22 NPROPS>=12, got NSTATV=', &
+            NSTATV, ' NPROPS=', NPROPS
+        PNEWDT = 0.0d0
+        return
+    end if
+
     ! STATEV unpack
     do i = 1, 6
         theta_n(i) = STATEV(i)
@@ -1685,9 +1697,10 @@ subroutine umat(STRESS, STATEV, DDSDDE, SSE, SPD, SCD, &
     STATEV(21) = eps_eq_out
     STATEV(22) = theta_max_out
 
-    ! Non-convergence: request ABAQUS to halve the time increment
+    ! Non-convergence: request ABAQUS to reduce the time increment.
+    ! Use min() to avoid accidentally relaxing a smaller cutback already in PNEWDT.
     if (converged == 0) then
-        PNEWDT = 0.5d0
+        PNEWDT = min(PNEWDT, 0.5d0)
     end if
 
     ! Zero unused output fields

--- a/fortran/yu_kinematic_3d.f90
+++ b/fortran/yu_kinematic_3d.f90
@@ -1602,3 +1602,99 @@ subroutine yu_kinematic_3d( &
     eps_eq_out = eps_eq_new
 
 end subroutine yu_kinematic_3d
+
+
+! =============================================================================
+! umat -- ABAQUS UMAT interface for YUKinematic3D
+!
+! Thin shim that unpacks PROPS(12) and STATEV(22) into named arguments
+! and calls yu_kinematic_3d.  Non-convergence is signalled to ABAQUS
+! via PNEWDT = 0.5 (request to halve the time increment).
+!
+! PROPS layout: see file header (PROPS(1)=E .. PROPS(12)=xi_param)
+! STATEV layout: see file header (STATEV(1..6)=theta .. STATEV(22)=theta_max)
+! =============================================================================
+subroutine umat(STRESS, STATEV, DDSDDE, SSE, SPD, SCD, &
+                RPL, DDSDDT, DRPLDE, DRPLDT, &
+                STRAN, DSTRAN, TIME, DTIME, TEMP, DTEMP, &
+                PREDEF, DPRED, CMNAME, NDI, NSHR, NTENS, &
+                NSTATV, PROPS, NPROPS, COORDS, DROT, PNEWDT, &
+                CELENT, DFGRD0, DFGRD1, NOEL, NPT, LAYER, &
+                KSPT, KSTEP, KINC)
+    implicit none
+    character(len=80),    intent(in)    :: CMNAME
+    integer,              intent(in)    :: NDI, NSHR, NTENS, NSTATV, NPROPS
+    integer,              intent(in)    :: NOEL, NPT, LAYER, KSPT, KSTEP, KINC
+    double precision,     intent(inout) :: STRESS(NTENS)
+    double precision,     intent(inout) :: STATEV(NSTATV)
+    double precision,     intent(out)   :: DDSDDE(NTENS, NTENS)
+    double precision,     intent(out)   :: SSE, SPD, SCD, RPL, DRPLDT
+    double precision,     intent(out)   :: DDSDDT(NTENS), DRPLDE(NTENS)
+    double precision,     intent(in)    :: STRAN(NTENS), DSTRAN(NTENS)
+    double precision,     intent(in)    :: TIME(2), DTIME, TEMP, DTEMP
+    double precision,     intent(in)    :: PREDEF(1), DPRED(1)
+    double precision,     intent(in)    :: PROPS(NPROPS), COORDS(3)
+    double precision,     intent(in)    :: DROT(3,3), DFGRD0(3,3), DFGRD1(3,3)
+    double precision,     intent(inout) :: PNEWDT
+    double precision,     intent(in)    :: CELENT
+
+    double precision :: theta_n(6), beta_n(6), Rbnd_n, q_n(6), rstag_n
+    double precision :: eps_eq_n, theta_max_n
+    double precision :: stress_out(6), theta_out(6), beta_out(6), Rbnd_out
+    double precision :: q_out(6), rstag_out, eps_eq_out, theta_max_out
+    double precision :: ddsdde_local(6,6)
+    integer :: i, j, n_iter, converged
+
+    ! STATEV unpack
+    do i = 1, 6
+        theta_n(i) = STATEV(i)
+        beta_n(i)  = STATEV(6 + i)
+        q_n(i)     = STATEV(13 + i)
+    end do
+    Rbnd_n      = STATEV(13)
+    rstag_n     = STATEV(20)
+    eps_eq_n    = STATEV(21)
+    theta_max_n = STATEV(22)
+
+    call yu_kinematic_3d( &
+        PROPS(1), PROPS(2), PROPS(3), PROPS(4), PROPS(5), PROPS(6), &
+        PROPS(7), PROPS(8), PROPS(9), PROPS(10), PROPS(11), PROPS(12), &
+        STRESS, &
+        theta_n, beta_n, Rbnd_n, q_n, rstag_n, eps_eq_n, theta_max_n, &
+        DSTRAN, &
+        stress_out, &
+        theta_out, beta_out, Rbnd_out, q_out, rstag_out, eps_eq_out, theta_max_out, &
+        ddsdde_local, n_iter, converged)
+
+    ! Write-back stress and tangent
+    do i = 1, NTENS
+        STRESS(i) = stress_out(i)
+        do j = 1, NTENS
+            DDSDDE(i, j) = ddsdde_local(i, j)
+        end do
+    end do
+
+    ! STATEV repack
+    do i = 1, 6
+        STATEV(i)      = theta_out(i)
+        STATEV(6 + i)  = beta_out(i)
+        STATEV(13 + i) = q_out(i)
+    end do
+    STATEV(13) = Rbnd_out
+    STATEV(20) = rstag_out
+    STATEV(21) = eps_eq_out
+    STATEV(22) = theta_max_out
+
+    ! Non-convergence: request ABAQUS to halve the time increment
+    if (converged == 0) then
+        PNEWDT = 0.5d0
+    end if
+
+    ! Zero unused output fields
+    SSE = 0.0d0; SPD = 0.0d0; SCD = 0.0d0; RPL = 0.0d0; DRPLDT = 0.0d0
+    do i = 1, NTENS
+        DDSDDT(i) = 0.0d0
+        DRPLDE(i) = 0.0d0
+    end do
+
+end subroutine umat

--- a/tests/benchmarks/yu_kinematic/README.md
+++ b/tests/benchmarks/yu_kinematic/README.md
@@ -122,3 +122,32 @@ uv run pytest tests/benchmarks/yu_kinematic/ -v          # slow 含む全テス�
 uv run pytest tests/benchmarks/yu_kinematic/ -m "not slow" -v  # 非 slow のみ
 uv run pytest tests/benchmarks/yu_kinematic/ -m "fortran" -v   # Fortran テストのみ（.so 必須）
 ```
+
+## ABAQUS 入力デック例
+
+Fortran UMAT (`subroutine umat` in `fortran/yu_kinematic_3d.f90`) を ABAQUS で使用する場合の
+入力デック例。`CONSTANTS=12` は `model.param_names` の 12 パラメータに対応。
+
+```
+*MATERIAL, NAME=YU_KINEMATIC
+*USER MATERIAL, CONSTANTS=12
+** E,       nu,    Y,    B,     C_1,    C_2,   Rsat,   k,    b,     h,     Ea,    xi
+  210000., 0.3, 250., 520., 35000., 14000., 180., 8.5, 14., 0.4, 2000., 250.
+*DEPVAR
+22
+```
+
+`*DEPVAR` に指定する 22 は STATEV スロット数（以下）:
+
+| スロット | 変数 | 説明 |
+|---|---|---|
+| 1–6   | theta(1–6)  | 降伏面相対バックストレステンソル (physical shear) |
+| 7–12  | beta(1–6)   | 境界面相対バックストレステンソル (physical shear) |
+| 13    | R           | 境界面半径増分 |
+| 14–19 | q(1–6)      | 停滞面中心 (physical shear) |
+| 20    | r           | 停滞面半径 |
+| 21    | eps_eq      | 相当塑性ひずみ |
+| 22    | theta_max   | theta ノルムの履歴最大値 |
+
+初期状態（弾性状態）はすべてのスロットにゼロを与えればよい。
+非収束時は `PNEWDT = 0.5` が返り、ABAQUS に時間刻みの半減を要求する。

--- a/tests/benchmarks/yu_kinematic/README.md
+++ b/tests/benchmarks/yu_kinematic/README.md
@@ -131,8 +131,8 @@ Fortran UMAT (`subroutine umat` in `fortran/yu_kinematic_3d.f90`) を ABAQUS で
 ```
 *MATERIAL, NAME=YU_KINEMATIC
 *USER MATERIAL, CONSTANTS=12
-** E,       nu,    Y,    B,     C_1,    C_2,   Rsat,   k,    b,     h,     Ea,    xi
-  210000., 0.3, 250., 520., 35000., 14000., 180., 8.5, 14., 0.4, 2000., 250.
+** E,        nu,    Y,    B,    C_1,   C_2,  Rsat,   k,   b,   h,      Ea,   xi
+  206000., 0.3, 360., 435., 2000., 200., 255., 26., 66., 0.4, 159000., 61.
 *DEPVAR
 22
 ```

--- a/tests/integration/verification/test_yu_fortran_bindings.py
+++ b/tests/integration/verification/test_yu_fortran_bindings.py
@@ -29,10 +29,12 @@ def test_all_bindings_registered():
         "dRtheta_dbeta":        "yu_drt_dbeta",
         "dRtheta_dtheta":       "yu_drt_dtheta",
         "dRtheta_dlambda":      "yu_drt_dlambda",
-        "dRyield_dstress":      "yu_drl_dstress",
-        "dRyield_dbeta":        "yu_drl_dbeta",
-        "dRyield_dtheta":       "yu_drl_dtheta",
-        "dRyield_dlambda":      "yu_drl_dlambda",
+        "dRyield_dstress":          "yu_drl_dstress",
+        "dRyield_dbeta":            "yu_drl_dbeta",
+        "dRyield_dtheta":           "yu_drl_dtheta",
+        "dRyield_dlambda":          "yu_drl_dlambda",
+        "user_defined_return_mapping": "yu_kinematic_3d",
+        "calc_ddsdde":              "yu_calc_ddsdde",
     }
     for method, subroutine in expected.items():
         assert method in bindings, f"{method} not in _fortran_bindings"


### PR DESCRIPTION
## Summary

- `fortran/yu_kinematic_3d.f90` 末尾に `subroutine umat(...)` を追加
  - ABAQUS 27 引数フルインタフェースの薄いラッパ
  - `PROPS(1..12)` → 12 パラメータ、`STATEV(1..22)` → 22 state slots を `yu_kinematic_3d` core に転送
  - 非収束時 `PNEWDT = 0.5` で ABAQUS に時間刻み半減を要求
  - `SSE/SPD/SCD/RPL/DRPLDT/DDSDDT/DRPLDE` をゼロクリア（J2 shim と同パターン）
- `tests/integration/verification/test_yu_fortran_bindings.py` の `expected` dict を 24 entries に更新（PR #91 で追加された `user_defined_return_mapping` / `calc_ddsdde` を反映）
- `tests/benchmarks/yu_kinematic/README.md` に ABAQUS 入力デック例と STATEV 22 slot レイアウト表を追記

## Test plan

- [x] `make fortran-build-yu` — ビルド成功、`umat` シンボルが `.so` に export される
- [x] `uv run pytest tests/integration/verification/test_yu_fortran_bindings.py -v` — 1 passed
- [x] `uv run pytest tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py -v` — 28 passed, 1 skipped（既存 Path B テスト回帰なし）
- [x] `make test` — 634 passed, 46 deselected（Python 側に影響なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)