### PR TITLE
fix(yu): calc_ddsdde chain-rule 係数バグ修正 + 収束性検証テスト追加

### DIFF
--- a/fortran/yu_kinematic_3d.f90
+++ b/fortran/yu_kinematic_3d.f90
@@ -1236,18 +1236,18 @@ subroutine yu_calc_ddsdde(E, nu, Y, B_bnd, C_1, C_2, Rsat, k, b_kin, h, Ea, xi_p
     call yu_vonmises_norm(g_xi, stag_norm)
     if (stag_norm > 1.0d-15) then
         g_stag = stag_norm - rstag_n
-        ! smooth_heaviside'(x) = 25 * sech^2(25*x) = 25 * (1 - tanh^2(25*x))
+        ! smooth_heaviside'(x) = 12.5 * sech^2(25*x) = 12.5 * (1 - tanh^2(25*x))
         tanh_val = tanh(25.0d0 * g_stag)
-        dg_flag_dgstag = 25.0d0 * (1.0d0 - tanh_val * tanh_val)
+        dg_flag_dgstag = 12.5d0 * (1.0d0 - tanh_val * tanh_val)
         if (abs(dg_flag_dgstag) > 1.0d-15) then
             s_fac   = 1.0d0 / (1.0d0 + k * dlambda)
             delta_R = s_fac * (R_n + k * Rsat * dlambda) - R_n
-            ! da/dbeta_j = delta_R * dg_flag/dgstag * T_j * g_xi_j / stag_norm
+            ! da/dbeta_j = delta_R * dg_flag/dgstag * 1.5 * T_j * g_xi_j / stag_norm
             do ii = 1, 3
-                da_dbeta(ii) = delta_R * dg_flag_dgstag * g_xi(ii) / stag_norm
+                da_dbeta(ii) = delta_R * dg_flag_dgstag * 1.5d0 * g_xi(ii) / stag_norm
             end do
             do ii = 4, 6
-                da_dbeta(ii) = delta_R * dg_flag_dgstag * 2.0d0 * g_xi(ii) / stag_norm
+                da_dbeta(ii) = delta_R * dg_flag_dgstag * 1.5d0 * 2.0d0 * g_xi(ii) / stag_norm
             end do
             ! dRt_da = -(C_k/Y * xi - C_k * sqrt(1/(a*theta_bar))/2 * theta) * dlambda
             call yu_smooth_heaviside(g_stag, g_flag_val)

--- a/src/manforge/models/yu_kinematic.py
+++ b/src/manforge/models/yu_kinematic.py
@@ -509,16 +509,16 @@ class YUKinematic3D(YUKinematic):
         # calc_ddsdde (consistent tangent) needs the full derivative at convergence.
         stag_norm_f = float(self.vonmises_norm(g_xi))
         if stag_norm_f > 1e-15:
-            # smooth_heaviside'(x) = 25 * sech^2(25*x) = 25 * (1 - tanh^2(25*x))
+            # smooth_heaviside'(x) = 12.5 * sech^2(25*x) = 12.5 * (1 - tanh^2(25*x))
             import math
             g_stag_f = float(g_stag)
             t = math.tanh(25.0 * g_stag_f)
-            dg_flag_dgstag = 25.0 * (1.0 - t * t)
+            dg_flag_dgstag = 12.5 * (1.0 - t * t)
             if abs(dg_flag_dgstag) > 1e-15:
                 s_val = 1.0 / (1.0 + self.k * float(dlambda))
                 delta_R = s_val * (float(R_n) + self.k * self.Rsat * float(dlambda)) - float(R_n)
                 T_vec = np.array([1.0, 1.0, 1.0, 2.0, 2.0, 2.0])
-                da_dbeta = delta_R * dg_flag_dgstag * T_vec * np.asarray(g_xi) / stag_norm_f
+                da_dbeta = delta_R * dg_flag_dgstag * 1.5 * T_vec * np.asarray(g_xi) / stag_norm_f
                 theta_bar_v, _, C_k_v, _, a_v, _ = self._prepare_Rtheta(
                     theta, t_max, R_new, R_n, dlambda, g_flag)
                 # Guard against theta_bar -> 0 or a -> 0; when theta ~ 0 the

--- a/tests/benchmarks/yu_kinematic/_diagnose_ddsdde_fd.py
+++ b/tests/benchmarks/yu_kinematic/_diagnose_ddsdde_fd.py
@@ -118,7 +118,6 @@ def _calc_ddsdde_variant(model, state_new, state_n, stress_trial, dlambda, varia
             # A1: coefficient for smooth_heaviside'
             # HEAD uses 25.0;  fixed uses 12.5  (correct: 0.5*tanh*25 → deriv = 12.5*sech²)
             coeff = 12.5 if variant == "fixed" else 25.0
-            t_val = math.tanh(coeff / 12.5 * 12.5 * g_stag_f)  # tanh(25*x) either way
             t_val = math.tanh(25.0 * g_stag_f)
             dg_flag_dgstag = coeff * (1.0 - t_val * t_val)
             if abs(dg_flag_dgstag) > 1e-15:

--- a/tests/benchmarks/yu_kinematic/_diagnose_ddsdde_fd.py
+++ b/tests/benchmarks/yu_kinematic/_diagnose_ddsdde_fd.py
@@ -1,0 +1,285 @@
+"""Stage 1 diagnostic: compare calc_ddsdde variants vs FD truth (dσ/dε).
+
+Computes the consistent tangent (ddsdde) three ways and compares each against
+the finite-difference ground truth (central differences of stress_update).
+
+Variants:
+  (a) no_correction — fe6f449 equivalent: chain-rule block skipped entirely.
+  (b) head           — HEAD current state: as returned by result.ddsdde.
+  (c) fixed          — A1 coefficient 25→12.5 and A2 factor 1.5 added.
+
+Run:
+    uv run python tests/benchmarks/yu_kinematic/_diagnose_ddsdde_fd.py 2>&1 | tee /tmp/yu_diag_ddsdde.txt
+"""
+
+import math
+import sys
+
+import numpy as np
+import autograd.numpy as anp
+
+from manforge.models import YUKinematic3D
+from manforge.simulation.integrator import PythonAnalyticalIntegrator
+from manforge.simulation.types import FieldHistory
+from manforge.utils.smooth import smooth_heaviside
+
+PARAMS = dict(
+    E=206_000, nu=0.3, Y=360.0, C_1=2000.0, C_2=200.0,
+    B=435.0, Rsat=255.0, k=26.0, b=66.0, h=0.4, Ea=159_000, xi=61.0,
+)
+B_MINUS_Y = PARAMS["B"] - PARAMS["Y"]  # 75.0 MPa
+FD_H = 1e-5  # central-difference step (verified stable for YU)
+
+
+def _build_scenarios():
+    mono = np.zeros((50, 6))
+    mono[:, 0] = np.linspace(0.0, 5e-3, 50)
+
+    rev = FieldHistory.cyclic_strain([0.01, -0.01], n_per_segment=30, ntens=6).data
+
+    cyc = FieldHistory.cyclic_strain([0.05, -0.05, 0.05, -0.05], n_per_segment=50, ntens=6).data
+
+    large = FieldHistory.cyclic_strain([0.04, -0.04], n_per_segment=30, ntens=6).data
+    small = FieldHistory.cyclic_strain([0.005, -0.005, 0.005], n_per_segment=15, ntens=6).data
+    stag = np.vstack([large, small + large[-1]])
+
+    shear_raw = FieldHistory.cyclic_strain([5e-3, -5e-3, 5e-3], n_per_segment=30, ntens=6).data
+    shear = np.zeros_like(shear_raw); shear[:, 3] = shear_raw[:, 0]
+
+    large_shear = np.zeros((60, 6))
+    large_shear[:, 3] = np.linspace(0.0, 0.04, 60)
+
+    return {
+        "uniaxial_monotonic":  mono,
+        "load_reversal":       rev,
+        "uniaxial_cyclic_big": cyc,
+        "stagnation_crossing": stag,
+        "pure_shear":          shear,
+        "pure_shear_large":    large_shear,
+    }
+
+
+def _fd_ddsdde(integrator, deps, stress_n, state_n, h=FD_H):
+    """Central-difference dσ/dε at (stress_n, state_n) for strain increment deps."""
+    ntens = len(deps)
+    D_fd = np.zeros((ntens, ntens))
+    for j in range(ntens):
+        eps_p = deps.copy(); eps_p[j] += h
+        eps_m = deps.copy(); eps_m[j] -= h
+        rp = integrator.stress_update(eps_p, stress_n, state_n)
+        rm = integrator.stress_update(eps_m, stress_n, state_n)
+        D_fd[:, j] = (np.asarray(rp.stress) - np.asarray(rm.stress)) / (2.0 * h)
+    return D_fd
+
+
+def _calc_ddsdde_variant(model, state_new, state_n, stress_trial, dlambda, variant):
+    """Re-compute calc_ddsdde with a specific variant of the chain-rule block.
+
+    This is a local copy of calc_ddsdde (yu_kinematic.py:481-540) with the
+    correction block (L506-531) controlled by `variant`.
+
+    variant:
+        'no_correction' — skip the chain-rule block entirely (fe6f449 equivalent)
+        'head'          — apply block with coefficient 25.0 (HEAD current)
+        'fixed'         — apply block with A1 fix (12.5) and A2 fix (1.5*)
+    """
+    C = model.elastic_stiffness(state_new)
+    C_inv = anp.linalg.inv(C)
+    xi = model.dev(state_new["stress"]) - state_new["theta"] - state_new["beta"]
+    g_xi   = state_new["beta"] - state_n["q"]
+    g_stag = model.vonmises_norm(g_xi) - state_n["r"]
+    g_flag = float(smooth_heaviside(g_stag))
+    theta  = state_new["theta"]
+    t_max  = state_n["theta_max"]
+    R_new  = state_new["R"]
+    R_n    = state_n["R"]
+
+    Rs_s = C_inv @ model.dRstress_dstress(C, xi, dlambda)
+    Rs_b = C_inv @ model.dRstress_dbeta(C, xi, dlambda)
+    Rs_t = C_inv @ model.dRstress_dtheta(C, xi, dlambda)
+    Rs_l = C_inv @ model.dRstress_dlambda(C, xi, state_new["eps_eq"], dlambda)
+    Rs = np.hstack((Rs_s, Rs_l[:, np.newaxis], Rs_t, Rs_b))
+
+    Rb_s = model.dRbeta_dstress(dlambda)
+    Rb_b = model.dRbeta_dbeta(dlambda)
+    Rb_t = model.dRbeta_dtheta(dlambda)
+    Rb_l = model.dRbeta_dlambda(xi, state_new["beta"], dlambda)
+    Rb = np.hstack((Rb_s, Rb_l[:, np.newaxis], Rb_t, Rb_b))
+
+    Rt_s = model.dRtheta_dstress(theta, t_max, R_new, R_n, dlambda, g_flag)
+    Rt_b = model.dRtheta_dbeta(theta, t_max, R_new, R_n, dlambda, g_flag)
+    Rt_t = model.dRtheta_dtheta(theta, t_max, R_new, R_n, dlambda, g_flag)
+    Rt_l = model.dRtheta_dlambda(xi, theta, t_max, R_new, R_n, dlambda, g_flag)
+
+    if variant != "no_correction":
+        stag_norm_f = float(model.vonmises_norm(g_xi))
+        if stag_norm_f > 1e-15:
+            g_stag_f = float(g_stag)
+            # A1: coefficient for smooth_heaviside'
+            # HEAD uses 25.0;  fixed uses 12.5  (correct: 0.5*tanh*25 → deriv = 12.5*sech²)
+            coeff = 12.5 if variant == "fixed" else 25.0
+            t_val = math.tanh(coeff / 12.5 * 12.5 * g_stag_f)  # tanh(25*x) either way
+            t_val = math.tanh(25.0 * g_stag_f)
+            dg_flag_dgstag = coeff * (1.0 - t_val * t_val)
+            if abs(dg_flag_dgstag) > 1e-15:
+                s_val = 1.0 / (1.0 + model.k * float(dlambda))
+                delta_R = s_val * (float(R_n) + model.k * model.Rsat * float(dlambda)) - float(R_n)
+                T_vec = np.array([1.0, 1.0, 1.0, 2.0, 2.0, 2.0])
+                g_xi_arr = np.asarray(g_xi)
+                # A2: missing 1.5 factor in da_dbeta for vonmises_norm derivative
+                # HEAD: no factor;  fixed: 1.5 *
+                a2_factor = 1.5 if variant == "fixed" else 1.0
+                da_dbeta = (delta_R * dg_flag_dgstag * a2_factor
+                            * T_vec * g_xi_arr / stag_norm_f)
+                theta_bar_v, _, C_k_v, _, a_v, _ = model._prepare_Rtheta(
+                    theta, t_max, R_new, R_n, dlambda, g_flag)
+                if float(theta_bar_v) > 1e-14 and float(a_v) > 1e-14:
+                    dRt_da = -(C_k_v / model.Y * xi
+                               - C_k_v * np.sqrt(1.0 / (a_v * float(theta_bar_v))) / 2.0 * theta) * dlambda
+                else:
+                    dRt_da = -C_k_v / model.Y * xi * dlambda
+                Rt_b = Rt_b + np.outer(dRt_da, da_dbeta)
+
+    Rt = np.hstack((Rt_s, Rt_l[:, np.newaxis], Rt_t, Rt_b))
+
+    Rl_s = model.dRyield_dstress(xi)
+    Rl_b = model.dRyield_dbeta(xi)
+    Rl_t = model.dRyield_dtheta(xi)
+    Rl_l = model.dRyield_dlambda()
+    Rl = np.hstack((Rl_s, Rl_l, Rl_t, Rl_b))
+
+    jac = np.vstack((Rs, Rl.reshape(1, -1), Rt, Rb))
+    jac_inv = anp.linalg.inv(jac)
+    return np.array(jac_inv[:6, :6])
+
+
+def _err(D_candidate, D_ref):
+    return float(np.max(np.abs(D_candidate - D_ref) / (np.abs(D_ref) + 1.0)))
+
+
+def _worst_block(D_candidate, D_ref):
+    ratio = np.abs(D_candidate - D_ref) / (np.abs(D_ref) + 1.0)
+    idx = np.unravel_index(np.argmax(ratio), ratio.shape)
+    return idx, float(ratio[idx])
+
+
+def _diagnose_scenario(name, history, *, top_k=12):
+    model     = YUKinematic3D(**PARAMS)
+    integrator = PythonAnalyticalIntegrator(model)
+
+    stress_n  = np.zeros(6)
+    state_n   = model.initial_state()
+    eps_prev  = np.zeros(6)
+
+    rows = []
+    for i, eps in enumerate(history):
+        deps      = eps - eps_prev
+        eps_prev  = eps.copy()
+        result    = integrator.stress_update(deps, stress_n, state_n)
+
+        if result.is_plastic:
+            rm     = result.return_mapping
+            state_new   = rm.state
+            dlambda     = float(rm.dlambda)
+            stress_trial = result.stress_trial
+
+            D_fd  = _fd_ddsdde(integrator, deps, stress_n, state_n)
+            D_a   = _calc_ddsdde_variant(model, state_new, state_n, stress_trial, dlambda, "no_correction")
+            D_b   = np.asarray(result.ddsdde)   # HEAD (sanity: should match variant b)
+            D_b2  = _calc_ddsdde_variant(model, state_new, state_n, stress_trial, dlambda, "head")
+            D_c   = _calc_ddsdde_variant(model, state_new, state_n, stress_trial, dlambda, "fixed")
+
+            g_xi   = np.asarray(state_new["beta"]) - np.asarray(state_n["q"])
+            g_stag = float(model.vonmises_norm(g_xi)) - float(state_n["r"])
+            t_max  = float(state_n["theta_max"])
+
+            rows.append({
+                "i":          i,
+                "g_stag":     g_stag,
+                "theta_max":  t_max,
+                "dist_to_75": t_max - B_MINUS_Y,
+                "err_a":      _err(D_a,  D_fd),
+                "err_b":      _err(D_b,  D_fd),
+                "err_b2":     _err(D_b2, D_fd),   # sanity vs result.ddsdde
+                "err_c":      _err(D_c,  D_fd),
+                "worst_a":    _worst_block(D_a,  D_fd),
+                "worst_c":    _worst_block(D_c,  D_fd),
+                "dlambda":    dlambda,
+            })
+
+        stress_n = np.asarray(result.stress)
+        state_n  = result.state
+
+    print(f"\n{'='*75}")
+    print(f"Scenario: {name}  ({len(rows)} plastic steps)")
+    print(f"  B-Y = {B_MINUS_Y:.1f} MPa  FD_H={FD_H:.0e}")
+    print(f"{'='*75}")
+
+    if not rows:
+        print("  (no plastic steps)")
+        return
+
+    for key, label in [("err_a", "no_correction (fe6f449)"),
+                       ("err_b", "head (result.ddsdde)"),
+                       ("err_b2","head variant local"),
+                       ("err_c", "fixed (A1+A2)")]:
+        vals = [r[key] for r in rows]
+        print(f"  max {label:28s}: {max(vals):.3e}  mean: {np.mean(vals):.3e}")
+
+    sorted_rows = sorted(rows, key=lambda r: -r["err_b"])
+    print(f"\n  Top {top_k} plastic steps by err_b (HEAD vs FD):")
+    hdr = (f"  {'step':>4}  {'g_stag':>9}  {'dist_75':>8}  "
+           f"{'err_a':>9}  {'err_b':>9}  {'err_c':>9}  "
+           f"{'best':>6}  worst_block(a)   worst_block(c)")
+    print(hdr)
+    print("  " + "-" * (len(hdr) - 2))
+    for r in sorted_rows[:top_k]:
+        # which variant wins (lowest err)
+        best = min([("a", r["err_a"]), ("b", r["err_b"]), ("c", r["err_c"])],
+                   key=lambda x: x[1])[0]
+        wa_idx, wa_val = r["worst_a"]
+        wc_idx, wc_val = r["worst_c"]
+        print(
+            f"  {r['i']:4d}  {r['g_stag']:+9.4f}  {r['dist_to_75']:+8.3f}  "
+            f"{r['err_a']:9.3e}  {r['err_b']:9.3e}  {r['err_c']:9.3e}  "
+            f"  {best:>4}   [{wa_idx[0]},{wa_idx[1]}]={wa_val:.2e}  [{wc_idx[0]},{wc_idx[1]}]={wc_val:.2e}"
+        )
+
+    # Distribution analysis: top-k steps by err_b — where are they in g_stag?
+    print(f"\n  Distribution of top-{top_k} (by err_b) in |g_stag| bands:")
+    for band in (0.01, 0.05, 0.1, 0.5, 2.0):
+        inside = sum(1 for r in sorted_rows[:top_k] if abs(r["g_stag"]) < band)
+        print(f"    |g_stag| < {band:.2f}: {inside}/{min(top_k, len(sorted_rows))}")
+
+    # Verdict
+    max_a = max(r["err_a"] for r in rows)
+    max_b = max(r["err_b"] for r in rows)
+    max_c = max(r["err_c"] for r in rows)
+    print(f"\n  VERDICT for {name}:")
+    if max_a < max_b * 0.5:
+        print("    >> (a) no_correction is BETTER than HEAD  — correction HURTS → 容疑1 有罪")
+    else:
+        print("    >> (a) and (b) are comparable — correction is neutral/beneficial")
+    if max_c < max_b * 0.9:
+        print("    >> (c) fixed is BETTER than HEAD         — A1+A2 修正が効く")
+    elif max_c < max_a * 0.9:
+        print("    >> (c) fixed is better than (a)          — A1/A2 修正で改善")
+    else:
+        print("    >> (c) fixed shows no clear improvement")
+
+
+def main():
+    scenarios = _build_scenarios()
+    for name, history in scenarios.items():
+        _diagnose_scenario(name, history)
+
+    print(f"\n{'='*75}")
+    print("OVERALL INTERPRETATION")
+    print(f"{'='*75}")
+    print("  容疑1 確定条件: err_a < err_b * 0.5 (補正項が悪化要因)")
+    print("  A1+A2 修正確定: err_c < err_b * 0.9 (12.5 + 1.5 ファクタで改善)")
+    print("  g_stag 集中確認: top-k が |g_stag| < 0.05 に偏る → 遷移帯バグ")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/benchmarks/yu_kinematic/_diagnose_ddsdde_fortran.py
+++ b/tests/benchmarks/yu_kinematic/_diagnose_ddsdde_fortran.py
@@ -1,0 +1,196 @@
+"""Stage 1 diagnostic: compare FortranIntegrator ddsdde vs FD truth (dσ/dε).
+
+Checks whether the ddsdde error seen in _diagnose_ddsdde_fd.py is shared by
+the Fortran implementation (i.e. both share the same formula).  If Python and
+Fortran show the same error pattern the bug is in the shared algorithm, not a
+translation artefact.
+
+Requires the compiled yu_kinematic_3d extension:
+    make fortran-build-yu
+
+Run:
+    uv run python tests/benchmarks/yu_kinematic/_diagnose_ddsdde_fortran.py 2>&1 | tee /tmp/yu_diag_fortran.txt
+"""
+
+import os
+import sys
+
+# Add fortran/ to sys.path so compiled .so modules are importable (mirrors tests/conftest.py)
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_FORTRAN_DIR = os.path.join(_HERE, "..", "..", "..", "fortran")
+sys.path.insert(0, os.path.abspath(_FORTRAN_DIR))
+
+import numpy as np
+
+try:
+    import yu_kinematic_3d  # noqa: F401
+except ImportError:
+    print("ERROR: yu_kinematic_3d not compiled — run: make fortran-build-yu", file=sys.stderr)
+    sys.exit(1)
+
+from manforge.models import YUKinematic3D
+from manforge.simulation.integrator import (
+    FortranModule,
+    FortranIntegrator,
+    PythonAnalyticalIntegrator,
+)
+from manforge.simulation.types import FieldHistory
+
+PARAMS = dict(
+    E=206_000, nu=0.3, Y=360.0, C_1=2000.0, C_2=200.0,
+    B=435.0, Rsat=255.0, k=26.0, b=66.0, h=0.4, Ea=159_000, xi=61.0,
+)
+B_MINUS_Y = PARAMS["B"] - PARAMS["Y"]  # 75.0 MPa
+FD_H = 1e-5
+
+
+def _build_scenarios():
+    mono = np.zeros((50, 6))
+    mono[:, 0] = np.linspace(0.0, 5e-3, 50)
+
+    rev = FieldHistory.cyclic_strain([0.01, -0.01], n_per_segment=30, ntens=6).data
+
+    cyc = FieldHistory.cyclic_strain([0.05, -0.05, 0.05, -0.05], n_per_segment=50, ntens=6).data
+
+    large = FieldHistory.cyclic_strain([0.04, -0.04], n_per_segment=30, ntens=6).data
+    small = FieldHistory.cyclic_strain([0.005, -0.005, 0.005], n_per_segment=15, ntens=6).data
+    stag = np.vstack([large, small + large[-1]])
+
+    shear_raw = FieldHistory.cyclic_strain([5e-3, -5e-3, 5e-3], n_per_segment=30, ntens=6).data
+    shear = np.zeros_like(shear_raw); shear[:, 3] = shear_raw[:, 0]
+
+    large_shear = np.zeros((60, 6))
+    large_shear[:, 3] = np.linspace(0.0, 0.04, 60)
+
+    return {
+        "uniaxial_monotonic":  mono,
+        "load_reversal":       rev,
+        "uniaxial_cyclic_big": cyc,
+        "stagnation_crossing": stag,
+        "pure_shear":          shear,
+        "pure_shear_large":    large_shear,
+    }
+
+
+def _fd_ddsdde(integrator, deps, stress_n, state_n, h=FD_H):
+    """Central-difference dσ/dε using the given integrator."""
+    ntens = len(deps)
+    D_fd = np.zeros((ntens, ntens))
+    for j in range(ntens):
+        eps_p = deps.copy(); eps_p[j] += h
+        eps_m = deps.copy(); eps_m[j] -= h
+        rp = integrator.stress_update(eps_p, stress_n, state_n)
+        rm = integrator.stress_update(eps_m, stress_n, state_n)
+        D_fd[:, j] = (np.asarray(rp.stress) - np.asarray(rm.stress)) / (2.0 * h)
+    return D_fd
+
+
+def _err(D_candidate, D_ref):
+    return float(np.max(np.abs(D_candidate - D_ref) / (np.abs(D_ref) + 1.0)))
+
+
+def _diagnose_scenario(name, history, *, fc_int, py_int, model, top_k=12):
+    stress_n  = np.zeros(6)
+    state_n   = model.initial_state()
+    eps_prev  = np.zeros(6)
+
+    rows = []
+    for i, eps in enumerate(history):
+        deps = eps - eps_prev
+        eps_prev = eps.copy()
+
+        # Run both integrators from same (stress_n, state_n)
+        r_py = py_int.stress_update(deps, stress_n, state_n)
+        r_fc = fc_int.stress_update(deps, stress_n, state_n)
+
+        if r_py.is_plastic:  # FortranIntegrator has is_plastic=None; use Python to detect
+            D_fd_py = _fd_ddsdde(py_int, deps, stress_n, state_n)
+            D_fd_fc = _fd_ddsdde(fc_int, deps, stress_n, state_n)
+            D_py    = np.asarray(r_py.ddsdde)
+            D_fc    = np.asarray(r_fc.ddsdde)
+
+            state_new = r_py.return_mapping.state
+            g_xi   = np.asarray(state_new["beta"]) - np.asarray(state_n["q"])
+            g_stag = float(model.vonmises_norm(g_xi)) - float(state_n["r"])
+            t_max  = float(state_n["theta_max"])
+
+            rows.append({
+                "i":           i,
+                "g_stag":      g_stag,
+                "theta_max":   t_max,
+                "dist_to_75":  t_max - B_MINUS_Y,
+                # Python analytical vs its own FD
+                "err_py":      _err(D_py, D_fd_py),
+                # Fortran vs Python FD (cross-check)
+                "err_fc_vs_pyfd": _err(D_fc, D_fd_py),
+                # Fortran vs its own FD
+                "err_fc":      _err(D_fc, D_fd_fc),
+                # Python vs Fortran (existing cross-check)
+                "err_py_fc":   _err(D_py, D_fc),
+            })
+
+        # Advance using Python integrator for consistent state trajectory
+        stress_n = np.asarray(r_py.stress)
+        state_n  = r_py.state
+
+    print(f"\n{'='*75}")
+    print(f"Scenario: {name}  ({len(rows)} plastic steps)")
+    print(f"  B-Y = {B_MINUS_Y:.1f} MPa  FD_H={FD_H:.0e}")
+    print(f"{'='*75}")
+
+    if not rows:
+        print("  (no plastic steps)")
+        return
+
+    for key, label in [
+        ("err_py",         "Python analytical vs Python FD"),
+        ("err_fc",         "Fortran          vs Fortran FD"),
+        ("err_fc_vs_pyfd", "Fortran          vs Python  FD"),
+        ("err_py_fc",      "Python           vs Fortran"),
+    ]:
+        vals = [r[key] for r in rows]
+        print(f"  max {label:38s}: {max(vals):.3e}  mean: {np.mean(vals):.3e}")
+
+    sorted_rows = sorted(rows, key=lambda r: -r["err_fc_vs_pyfd"])
+    print(f"\n  Top {top_k} plastic steps by err_fc_vs_pyfd:")
+    hdr = (f"  {'step':>4}  {'g_stag':>9}  {'dist_75':>8}  "
+           f"{'err_py':>9}  {'err_fc':>9}  {'fc_vs_pyfd':>10}  {'py_fc':>9}")
+    print(hdr)
+    print("  " + "-" * (len(hdr) - 2))
+    for r in sorted_rows[:top_k]:
+        print(
+            f"  {r['i']:4d}  {r['g_stag']:+9.4f}  {r['dist_to_75']:+8.3f}  "
+            f"{r['err_py']:9.3e}  {r['err_fc']:9.3e}  {r['err_fc_vs_pyfd']:10.3e}  {r['err_py_fc']:9.3e}"
+        )
+
+    # Is the Fortran error pattern the same as Python?
+    corr = np.corrcoef([r["err_py"] for r in rows],
+                       [r["err_fc_vs_pyfd"] for r in rows])[0, 1]
+    print(f"\n  Correlation(err_py, err_fc_vs_pyfd) = {corr:.4f}")
+    if corr > 0.9:
+        print("    >> High correlation — Fortran and Python share the same error pattern")
+        print("       Fixing Python formula should fix Fortran too.")
+    else:
+        print("    >> Low correlation — errors differ between Python and Fortran")
+        print("       May be a translation artefact, inspect Fortran separately.")
+
+
+def main():
+    model  = YUKinematic3D(**PARAMS)
+    fm     = FortranModule("yu_kinematic_3d")
+    fc_int = FortranIntegrator.from_model(fm, "yu_kinematic_3d", model)
+    py_int = PythonAnalyticalIntegrator(model)
+
+    scenarios = _build_scenarios()
+    for name, history in scenarios.items():
+        _diagnose_scenario(name, history, fc_int=fc_int, py_int=py_int, model=model)
+
+    print(f"\n{'='*75}")
+    print("OVERALL INTERPRETATION")
+    print(f"{'='*75}")
+    print("  共有バグ確認: err_py と err_fc_vs_pyfd の相関が高い (>0.9) → 同一アルゴリズムのバグ")
+    print("  Python 修正だけで Fortran も直る可能性が高い → Stage 2 で Python 修正後 Fortran 再検証")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/benchmarks/yu_kinematic/test_analytical_vs_numerical.py
+++ b/tests/benchmarks/yu_kinematic/test_analytical_vs_numerical.py
@@ -167,8 +167,8 @@ def test_analytical_matches_numerical(yu_3d_scenario):
     B-A2: per-state-key relative error — R/q/r < 1e-2 (stagnation state
           updated via hard g_flag=1/0 in analytical vs smooth_heaviside in
           autograd; structural O(1e-2) across all plastic steps), others < 1e-4
-    B-A4: ddsdde max_rel_err < 1e-1 (structural analytical Jacobian
-          approximation; not transition-zone dependent, see _diagnose.py)
+    B-A4: ddsdde max_rel_err < 3e-2 (measured worst: ~1.1e-2 at stagnation_crossing;
+          structural analytical Jacobian approximation, not transition-zone dependent)
     B-A5: NR iteration count difference == 0 (exact match observed)
     """
     model, history = yu_3d_scenario
@@ -185,9 +185,9 @@ def test_analytical_matches_numerical(yu_3d_scenario):
 
     # B-A4: ddsdde — analytical (calc_ddsdde) vs autograd (_consistent_tangent).
     # calc_ddsdde includes the g_flag(beta)->R->a chain rule correction for the
-    # stagnation-surface transition band. Residual ~1-5% comes from other minor
+    # stagnation-surface transition band. Residual ~1% comes from other minor
     # autograd/analytical differences (update_state path vs residual formulation).
-    assert errs["tangent"] < 1e-1, f"ddsdde rel err = {errs['tangent']:.3e}"
+    assert errs["tangent"] < 3e-2, f"ddsdde rel err = {errs['tangent']:.3e}"
 
     # B-A5: iteration count — small diff allowed since analytical Jacobian omits
     # g_flag(beta) chain rule that autograd tracks via update_state.

--- a/tests/benchmarks/yu_kinematic/test_convergence_stress.py
+++ b/tests/benchmarks/yu_kinematic/test_convergence_stress.py
@@ -1,0 +1,223 @@
+"""Stage 4 convergence stress tests for YUKinematic3D.
+
+Uses PythonNumericalIntegrator (autodiff NR) so n_iterations / residual_history
+are meaningful. PythonAnalyticalIntegrator uses a closed-form loop and always
+returns n_iterations=0, so it is not suitable here.
+
+Driver note: MixedDriver's inner Newton wraps the integrator NR, conflating two
+iteration counts and slowing execution significantly. We use a raw manual
+stepping loop (pattern from test_analytical_vs_numerical.py:95-127) instead.
+"""
+
+import numpy as np
+import pytest
+
+from manforge.simulation.integrator import PythonNumericalIntegrator
+from manforge.simulation.types import FieldHistory
+from manforge.models import YUKinematic3D
+from manforge.utils.smooth import smooth_heaviside
+
+from .conftest import PARAMS, _3d_stagnation_crossing
+
+pytestmark = pytest.mark.slow
+
+
+def _model():
+    return YUKinematic3D(**PARAMS)
+
+
+def _step_history(integrator, data):
+    """Step through a strain history; return list of (StressUpdateResult, pre_state_n).
+
+    Both stress_n and state_n are advanced from each step's result.
+    pre_state_n[i] is the state *before* step i (needed for g_flag computation).
+    """
+    import autograd.numpy as anp
+
+    model = integrator._model
+    stress_n = np.zeros(model.ntens)
+    state_n = model.initial_state()
+    eps_prev = np.zeros(model.ntens)
+    results = []
+    pre_states = []
+
+    for eps in data:
+        deps = eps - eps_prev
+        eps_prev = eps.copy()
+        pre_states.append(state_n)
+        r = integrator.stress_update(anp.array(deps), anp.array(stress_n), state_n)
+        results.append(r)
+        stress_n = np.asarray(r.stress)
+        state_n = r.state
+
+    return results, pre_states
+
+
+def _compute_g_flag(model, pre_state_n, post_state):
+    """Compute g_flag scalar for a step, mirroring update_state in yu_kinematic.py:65-68."""
+    beta_new = np.asarray(post_state["beta"])
+    q_n = np.asarray(pre_state_n["q"])
+    r_n = float(pre_state_n["r"])
+    g_xi = beta_new - q_n
+    stag_norm = float(model.vonmises_norm(g_xi))
+    g_stag = stag_norm - r_n
+    return float(smooth_heaviside(g_stag))
+
+
+# ---------------------------------------------------------------------------
+# Test 1: single large increment + 50-step ramp to 5%
+# ---------------------------------------------------------------------------
+
+def test_large_increment_converges_quickly():
+    """Single large uniaxial-strain step and 50-step ramp both converge with <= 15 NR iterations.
+
+    Convergence radius of PythonNumericalIntegrator is non-monotonic: steps of
+    1e-2/1.5e-2/2e-2 trigger autograd sqrt(negative) -> NaN, while 3e-3..8e-3
+    and 3e-2 converge.  A single 5%-in-one-step test is therefore unstable and
+    is replaced by (a) a single 5e-3 step and (b) a 50-step 1e-3/step ramp to 5%.
+    """
+    model = _model()
+    integrator = PythonNumericalIntegrator(model)
+
+    # (a) single step
+    strain_inc_single = np.array([5e-3, 0.0, 0.0, 0.0, 0.0, 0.0])
+    state_n = model.initial_state()
+    stress_n = np.zeros(6)
+    import autograd.numpy as anp
+    r = integrator.stress_update(anp.array(strain_inc_single), anp.array(stress_n), state_n)
+
+    assert r.is_plastic, "Expected plastic step at 5e-3 uniaxial strain"
+    assert r.converged, "Single 5e-3 step did not converge"
+    assert r.n_iterations <= 15, f"Too many NR iters: {r.n_iterations}"
+    assert len(r.residual_history) == r.n_iterations + 1, "residual_history length mismatch"
+    assert r.residual_history[-1] < 1e-10, f"Final residual too large: {r.residual_history[-1]}"
+
+    # (b) 50-step ramp to 5%
+    eps = np.linspace(0.0, 5e-2, 51)
+    data = np.zeros((50, 6))
+    data[:, 0] = np.diff(eps)  # incremental strains
+
+    # Rebuild cumulative data for _step_history
+    data_cumulative = np.zeros((50, 6))
+    data_cumulative[:, 0] = eps[1:]
+
+    results, _ = _step_history(integrator, data_cumulative)
+    assert all(r.converged for r in results), "Non-converged step in 50-step ramp"
+    plastic = [r for r in results if r.is_plastic]
+    assert len(plastic) > 0, "No plastic steps in ramp"
+    assert max(r.n_iterations for r in plastic) <= 15, (
+        f"Max iters in ramp: {max(r.n_iterations for r in plastic)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 2: multi-cycle iteration budget
+# ---------------------------------------------------------------------------
+
+def test_multi_cycle_iteration_budget():
+    """10 cycles of [+0.03, -0.03] all converge with bounded NR iterations."""
+    model = _model()
+    integrator = PythonNumericalIntegrator(model)
+
+    peaks = [0.03, -0.03] * 10
+    data = FieldHistory.cyclic_strain(peaks, n_per_segment=30, ntens=6).data
+    results, _ = _step_history(integrator, data)
+
+    assert all(r.converged for r in results), "Non-converged step in multi-cycle history"
+
+    plastic = [r for r in results if r.is_plastic]
+    assert len(plastic) > 0
+    mean_iters = sum(r.n_iterations for r in plastic) / len(plastic)
+    max_iters = max(r.n_iterations for r in plastic)
+
+    assert mean_iters <= 10, f"Mean plastic iters too high: {mean_iters:.2f}"
+    assert max_iters <= 15, f"Max plastic iters too high: {max_iters}"
+
+
+# ---------------------------------------------------------------------------
+# Test 3: stagnation transition — both g_flag branches covered, bounded iters
+# ---------------------------------------------------------------------------
+
+def test_stagnation_transition_iteration_count():
+    """Over the stagnation-crossing history, both g_flag branches are hit and all steps converge.
+
+    This is the regression guard for the S2 calc_ddsdde chain-rule fix (A1+A2).
+    The stagnation-crossing history alternates large then small amplitude, forcing
+    the stagnation surface to transition from active (g_flag>0.5) to inactive.
+    """
+    model = _model()
+    integrator = PythonNumericalIntegrator(model)
+
+    data = _3d_stagnation_crossing()
+    results, pre_states = _step_history(integrator, data)
+
+    assert all(r.converged for r in results), "Non-converged step in stagnation crossing"
+
+    g_flags = [
+        _compute_g_flag(model, pre_states[i], results[i].state)
+        for i in range(len(results))
+        if results[i].is_plastic
+    ]
+    assert any(g > 0.5 for g in g_flags), "No step with g_flag > 0.5 (stagnation active)"
+    assert any(g <= 0.5 for g in g_flags), "No step with g_flag <= 0.5 (stagnation inactive)"
+
+    plastic = [r for r in results if r.is_plastic]
+    assert max(r.n_iterations for r in plastic) <= 15, (
+        f"Max plastic iters in stagnation crossing: {max(r.n_iterations for r in plastic)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 4: quadratic convergence of NR residuals
+# ---------------------------------------------------------------------------
+
+def test_residual_history_quadratic_convergence():
+    """NR residuals in plastic steps exhibit quadratic convergence (r_k/r_{k-1}^2 <= 5).
+
+    Checks interior ratios only (excludes initial predictor and final tol-clamped residual).
+    Elastic steps are automatically excluded (empty residual_history).
+    """
+    model = _model()
+    integrator = PythonNumericalIntegrator(model)
+
+    data = _3d_stagnation_crossing()
+    results, _ = _step_history(integrator, data)
+
+    ratios = []
+    FLOOR = 1e-12
+    for r in results:
+        if not r.is_plastic:
+            continue
+        hist = r.residual_history
+        if len(hist) < 3:
+            continue
+        # interior indices 1..len-2 (exclude hist[0]=predictor, hist[-1]=tol-clamped)
+        for k in range(1, len(hist) - 1):
+            r_prev = max(hist[k - 1], FLOOR)
+            r_curr = max(hist[k], FLOOR)
+            ratios.append(r_curr / r_prev ** 2)
+
+    if not ratios:
+        pytest.skip("No plastic steps with len(residual_history) >= 3")
+
+    max_ratio = max(ratios)
+    assert max_ratio <= 5.0, (
+        f"Quadratic convergence ratio max={max_ratio:.3e} exceeds 5.0"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Suspect-2(a) gap marker
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skip(
+    reason=(
+        "UMAT write-back converged==1 guard (f90:1787) is only reachable via the "
+        "ABAQUS UMAT wrapper; FortranIntegrator calls the core subroutine directly "
+        "and hardcodes converged=True (fortran.py:320). "
+        "This path cannot be exercised within manforge and is an ABAQUS-side review item."
+    )
+)
+def test_umat_writeback_guard_requires_abaqus():
+    """Placeholder: UMAT write-back converged guard cannot be tested in manforge."""
+    pass

--- a/tests/benchmarks/yu_kinematic/test_fortran_vs_fd.py
+++ b/tests/benchmarks/yu_kinematic/test_fortran_vs_fd.py
@@ -37,7 +37,6 @@ from tests.fixtures.yu_fd import (
     fd_jacobian,
     fd_ddsdde,
     run_steps,
-    get_converged_state,
     pick_largest_dlambda,
     pick_min_gstag,
     uniaxial_plastic_step,

--- a/tests/benchmarks/yu_kinematic/test_fortran_vs_fd.py
+++ b/tests/benchmarks/yu_kinematic/test_fortran_vs_fd.py
@@ -1,0 +1,213 @@
+"""Fortran analytical solution vs Python finite-difference verification.
+
+This is the independent verification axis that catches "shared bugs" —
+bugs that exist identically in both Python and Fortran, which Python==Fortran
+tests (test_numerical_vs_fortran.py) cannot detect.
+
+TestFortranJacobianVsFd:
+  Fortran yu_calc_jacobian (analytical) vs FD of Fortran yu_calc_residual (truth).
+
+TestFortranDdsddeVsFd:
+  FortranIntegrator.stress_update.ddsdde (analytical) vs FD of Fortran stress_update (truth).
+"""
+import numpy as np
+import pytest
+
+pytest.importorskip(
+    "yu_kinematic_3d",
+    reason="yu_kinematic_3d module not compiled — run `make fortran-build-yu`",
+)
+
+pytestmark = pytest.mark.fortran
+
+from manforge.models import YUKinematic3D
+from manforge.simulation.integrator import (
+    FortranModule,
+    FortranIntegrator,
+    PythonAnalyticalIntegrator,
+    PythonNumericalIntegrator,
+)
+from tests.fixtures.yu_fd import (
+    PARAMS,
+    FD_RTOL_JAC,
+    FD_ATOL_JAC,
+    FD_RTOL,
+    FD_ATOL,
+    FD_RTOL_BAND,
+    fd_jacobian,
+    fd_ddsdde,
+    run_steps,
+    get_converged_state,
+    pick_largest_dlambda,
+    pick_min_gstag,
+    uniaxial_plastic_step,
+    pure_shear_step,
+    load_reversal_step,
+    stagnation_active_step,
+    stagnation_transition_band_history,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def fortran_mod():
+    return FortranModule("yu_kinematic_3d")
+
+
+@pytest.fixture(scope="module")
+def yu_model():
+    return YUKinematic3D(**PARAMS)
+
+
+def _make_fc_int(fortran_mod, model):
+    return FortranIntegrator.from_model(fortran_mod, "yu_kinematic_3d", model)
+
+
+def _props(model):
+    return (
+        model.E, model.nu, model.Y, model.B, model.C_1, model.C_2,
+        model.Rsat, model.k, model.b, model.h, model.Ea, model.xi,
+    )
+
+
+# ---------------------------------------------------------------------------
+# TestFortranJacobianVsFd
+# ---------------------------------------------------------------------------
+
+class TestFortranJacobianVsFd:
+    """Fortran calc_jacobian analytical vs FD of Fortran calc_residual."""
+
+    def _run_scenario(self, model, fortran_mod, strain_history):
+        """Return (state_new, state_n, dlambda, stress_trial) for the max-dlambda plastic step."""
+        integrator = PythonNumericalIntegrator(model)
+        step_data = run_steps(model, integrator, strain_history)
+        picked = pick_largest_dlambda(model, step_data)
+        if picked is None:
+            return None
+        result, stress_n, state_n, strain_inc = picked
+        if not result.is_plastic:
+            return None
+        state_new = result.state
+        dlambda = float(result.dlambda)
+        C0 = model.elastic_stiffness(state_n)
+        stress_trial = stress_n + C0 @ strain_inc
+        return state_new, state_n, dlambda, stress_trial
+
+    def _compare(self, model, fortran_mod, strain_history, label):
+        out = self._run_scenario(model, fortran_mod, strain_history)
+        if out is None:
+            pytest.skip(f"Scenario '{label}' produced no plastic step")
+        state_new, state_n, dlambda, stress_trial = out
+
+        props = _props(model)
+
+        # Analytical Jacobian from Fortran
+        J_fortran = np.asarray(fortran_mod.call(
+            "yu_calc_jacobian",
+            *props,
+            state_new["stress"], state_new["theta"], state_new["beta"],
+            float(state_new["R"]), float(state_new["eps_eq"]),
+            float(state_n["theta_max"]), float(state_n["R"]),
+            state_n["q"], float(state_n["r"]), dlambda,
+        ), dtype=float)
+
+        # FD Jacobian — differencing Fortran yu_calc_residual
+        def fortran_residual_fn(sn, dl):
+            return np.asarray(fortran_mod.call(
+                "yu_calc_residual",
+                *props,
+                sn["stress"], sn["theta"], sn["beta"],
+                float(sn["R"]), float(sn["eps_eq"]),
+                state_n["theta"], state_n["beta"], float(state_n["theta_max"]),
+                stress_trial, dl,
+            ), dtype=float)
+
+        J_fd = fd_jacobian(model, state_new, state_n, dlambda, fortran_residual_fn)
+
+        np.testing.assert_allclose(
+            J_fortran, J_fd,
+            rtol=FD_RTOL_JAC, atol=FD_ATOL_JAC,
+            err_msg=f"Fortran Jacobian vs FD mismatch for scenario '{label}'"
+        )
+
+    def test_uniaxial(self, yu_model, fortran_mod):
+        self._compare(yu_model, fortran_mod, uniaxial_plastic_step(), "uniaxial")
+
+    def test_pure_shear(self, yu_model, fortran_mod):
+        self._compare(yu_model, fortran_mod, pure_shear_step(), "pure_shear")
+
+    def test_load_reversal(self, yu_model, fortran_mod):
+        self._compare(yu_model, fortran_mod, load_reversal_step(), "load_reversal")
+
+    def test_stagnation_active(self, yu_model, fortran_mod):
+        self._compare(yu_model, fortran_mod, stagnation_active_step(), "stagnation_active")
+
+
+# ---------------------------------------------------------------------------
+# TestFortranDdsddeVsFd
+# ---------------------------------------------------------------------------
+
+class TestFortranDdsddeVsFd:
+    """FortranIntegrator.stress_update.ddsdde (analytical) vs FD of Fortran stress_update.
+
+    FortranIntegrator does not expose is_plastic/dlambda (UMAT convention).
+    We use PythonAnalyticalIntegrator to identify the plastic step, then
+    re-run the same (stress_n, state_n, strain_inc) through FortranIntegrator
+    to obtain the Fortran DDSDDE and compare against FD of Fortran stress_update.
+    """
+
+    def _get_plastic_step(self, model, scenario):
+        """Return (stress_n, state_n, strain_inc) for max-dlambda plastic step via Python."""
+        py_int = PythonAnalyticalIntegrator(model)
+        step_data = run_steps(model, py_int, scenario())
+        picked = pick_largest_dlambda(model, step_data)
+        return picked  # (result, stress_n, state_n, strain_inc) or None
+
+    def _get_min_gstag_step(self, model, scenario):
+        """Return ((result, stress_n, state_n, strain_inc), gstag) for min-gstag step."""
+        py_int = PythonAnalyticalIntegrator(model)
+        step_data = run_steps(model, py_int, scenario())
+        return pick_min_gstag(model, step_data)
+
+    @pytest.mark.parametrize("scenario,label", [
+        (uniaxial_plastic_step,   "uniaxial"),
+        (pure_shear_step,         "pure_shear"),
+        (load_reversal_step,      "load_reversal"),
+        (stagnation_active_step,  "stagnation_active"),
+    ])
+    def test_ddsdde_matches_fd(self, yu_model, fortran_mod, scenario, label):
+        """Fortran DDSDDE must match central-FD dσ/dε within tolerance."""
+        picked = self._get_plastic_step(yu_model, scenario)
+        if picked is None:
+            pytest.skip(f"Scenario '{label}' produced no plastic step")
+
+        _result, stress_n, state_n, strain_inc = picked
+        fc_int = _make_fc_int(fortran_mod, yu_model)
+
+        D_an = np.array(fc_int.stress_update(strain_inc, stress_n, state_n).ddsdde, dtype=float)
+        D_fd = fd_ddsdde(fc_int, strain_inc, stress_n, state_n)
+
+        np.testing.assert_allclose(
+            D_an, D_fd, rtol=FD_RTOL, atol=FD_ATOL,
+            err_msg=f"Fortran DDSDDE vs FD mismatch for scenario '{label}'"
+        )
+
+    def test_ddsdde_stagnation_transition_band(self, yu_model, fortran_mod):
+        """Fortran DDSDDE at the stagnation boundary must match FD (A1+A2 fix regression guard)."""
+        picked, gstag = self._get_min_gstag_step(yu_model, stagnation_transition_band_history)
+        if picked is None:
+            pytest.skip("No plastic step found in stagnation transition band scenario")
+
+        _result, stress_n, state_n, strain_inc = picked
+        fc_int = _make_fc_int(fortran_mod, yu_model)
+
+        D_an = np.array(fc_int.stress_update(strain_inc, stress_n, state_n).ddsdde, dtype=float)
+        D_fd = fd_ddsdde(fc_int, strain_inc, stress_n, state_n)
+
+        np.testing.assert_allclose(
+            D_an, D_fd, rtol=FD_RTOL_BAND, atol=FD_ATOL,
+            err_msg=f"Fortran DDSDDE vs FD mismatch in transition band (|g_stag|={gstag:.4f})"
+        )

--- a/tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py
+++ b/tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py
@@ -454,3 +454,78 @@ class TestCrosscheckTrajectory:
         )
         assert result.max_stress_rel_err < 1e-6
 
+
+# ---------------------------------------------------------------------------
+# TestSuspect2MuNewton: Stage-4 container for suspect-2(b) mu NR triage
+#
+# Background (Stage 4, suspect-2):
+#   fe6f449 → HEAD changed yu_inner_mu_newton's convergence criterion from
+#   one-sided absolute (F_mu < 1e-16) to two-sided relative
+#   (abs(F_mu) < 1e-12 * max(1, |3*Gn|)), plus added numerical guards.
+#   Python _solve_mu already uses the two-sided relative criterion.
+#   These tests confirm:
+#     (b) Python and Fortran mu-newton agree exactly (no inconsistency introduced).
+#     The HEAD criterion is a scale-aware improvement, not a divergence.
+#   Suspect-2(a) (umat write-back converged guard) is untestable in manforge;
+#   see test_convergence_stress.py::test_umat_writeback_guard_requires_abaqus.
+# ---------------------------------------------------------------------------
+
+class TestSuspect2MuNewton:
+    """Suspect-2(b): mu newton convergence criterion parity between Python and Fortran.
+
+    Python _solve_mu uses self.h (material parameter) internally.
+    Fortran yu_inner_mu_newton receives h as an explicit argument.
+    Both must be called with the same h = model.h for comparison.
+    """
+
+    @pytest.mark.parametrize("r_n,Gn,Fn", [
+        (2.0,   0.5,   0.0),    # normal, Fn=0 (h-independent)
+        (2.0,   0.5,   0.5),    # normal with drift (h matters — uses model.h)
+        (100.0, 5.0,   0.0),
+        (1e-3,  1e-4,  0.0),
+        (50.0, -3.0,   0.0),    # negative Gn analogue
+        (1e-18, 1e-18, 0.0),    # degenerate near-zero
+    ])
+    def test_mu_newton_python_matches_fortran(self, fortran_mod, model, r_n, Gn, Fn):
+        """Python _solve_mu and Fortran yu_inner_mu_newton return identical mu and conv flag.
+
+        Fortran receives h=model.h to match the implicit self.h used in Python.
+        """
+        h = model.h
+        mu_p, conv_p = model._solve_mu(r_n, Gn, Fn)
+
+        result = fortran_mod.call("yu_inner_mu_newton", h, r_n, Gn, Fn)
+        mu_f = float(result[0])
+        info_f = int(result[1])
+
+        assert mu_f == pytest.approx(mu_p, rel=1e-10, abs=1e-30), (
+            f"mu mismatch: Python={mu_p}, Fortran={mu_f}"
+        )
+        assert bool(info_f == 0) == conv_p, (
+            f"Convergence flag mismatch: Python conv={conv_p}, Fortran info={info_f}"
+        )
+
+    def test_mu_newton_criterion_is_two_sided_relative(self, fortran_mod, model):
+        """Both Python and Fortran use scale-aware two-sided relative criterion.
+
+        Uses moderate Gn=100 (F0=300, relative tol=3e-10) where convergence is
+        achievable and both ports agree, proving both use the same scale-aware criterion.
+        The old one-sided absolute criterion (F_mu < 1e-16) would not distinguish
+        positive-overshoot cases; the two-sided relative criterion is strictly more correct.
+        """
+        h = model.h
+        r_n = 1.0
+        Gn = 100.0   # F0 = 300, relative tol = 3e-10
+        Fn = 0.0
+
+        mu_p, conv_p = model._solve_mu(r_n, Gn, Fn)
+        result = fortran_mod.call("yu_inner_mu_newton", h, r_n, Gn, Fn)
+        mu_f = float(result[0])
+        info_f = int(result[1])
+
+        assert conv_p, "Python _solve_mu did not converge"
+        assert info_f == 0, "Fortran yu_inner_mu_newton did not converge"
+        assert mu_f == pytest.approx(mu_p, rel=1e-10, abs=1e-30), (
+            f"mu mismatch at scale test: Python={mu_p}, Fortran={mu_f}"
+        )
+

--- a/tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py
+++ b/tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py
@@ -414,7 +414,7 @@ class TestReturnMapping:
             )
 
     def test_single_plastic_step_ddsdde(self, plastic_state, fortran_mod):
-        """DDSDDE at a single plastic step matches (relaxed tolerance: 1e-4)."""
+        """DDSDDE at a single plastic step matches (rtol=1e-7, atol=1e-8)."""
         m, _, _, _ = plastic_state
         py_int = PythonAnalyticalIntegrator(m)
         stress_n_arr = np.zeros(6)
@@ -426,7 +426,7 @@ class TestReturnMapping:
         np.testing.assert_allclose(
             np.asarray(py_result.ddsdde),
             np.asarray(fc_result.ddsdde),
-            rtol=1e-5, atol=1e-5,
+            rtol=1e-7, atol=1e-8,
         )
 
 
@@ -438,13 +438,13 @@ class TestCrosscheckTrajectory:
     """PythonAnalyticalIntegrator vs FortranIntegrator over full strain trajectories."""
 
     def test_analytical_vs_fortran(self, yu_3d_scenario, fortran_mod):
-        """Strict crosscheck: analytical Python == Fortran (stress<1e-6, state<1e-6, tangent<1e-5)."""
+        """Strict crosscheck: analytical Python == Fortran (stress<1e-6, state<1e-6, tangent<1e-7)."""
         model, strain_history = yu_3d_scenario
         fc_int = _make_fc_int(fortran_mod, model)
         py_int = PythonAnalyticalIntegrator(model)
         load = FieldHistory(FieldType.STRAIN, "eps", strain_history)
 
-        cc = CrosscheckStrainDriver(py_int, fc_int, stress_tol=1e-6, tangent_tol=1e-5, state_tol=1e-6)
+        cc = CrosscheckStrainDriver(py_int, fc_int, stress_tol=1e-6, tangent_tol=1e-7, state_tol=1e-6)
         result = cc.run(load)
 
         assert result.passed, (

--- a/tests/fixtures/yu_fd.py
+++ b/tests/fixtures/yu_fd.py
@@ -27,11 +27,11 @@ PARAMS = dict(
 
 FD_EPS        = 1e-5   # step for Jacobian FD (residual-based)
 FD_H          = 1e-5   # step for DDSDDE FD (stress_update-based)
-FD_RTOL       = 2e-2   # relative tolerance (large-increment scenarios; Stage 5 will tighten)
+FD_RTOL       = 2e-2   # FD-truth-limited at ~1.2e-2 (stag_active); analytical Jacobian approx floor
 FD_ATOL       = 1e-1   # absolute tolerance (scaled to stiffness ~1e5)
 FD_RTOL_JAC   = 1e-4   # relative tolerance for Jacobian tests
 FD_ATOL_JAC   = 1e-3   # absolute tolerance for Jacobian tests
-FD_RTOL_BAND  = 5e-3   # tighter tolerance for stagnation transition band
+FD_RTOL_BAND  = 2e-3   # stagnation transition band; measured floor ~5.8e-4
 
 # ---------------------------------------------------------------------------
 # Scenario builders (cumulative total-strain histories, shape (N, 6))

--- a/tests/fixtures/yu_fd.py
+++ b/tests/fixtures/yu_fd.py
@@ -1,0 +1,238 @@
+"""Shared FD (finite-difference) helpers for YUKinematic3D tests.
+
+Used by:
+  tests/integration/models/test_yu_jacobian_fd.py
+  tests/integration/models/test_yu_ddsdde_fd.py
+  tests/benchmarks/yu_kinematic/test_fortran_vs_fd.py
+"""
+import numpy as np
+
+from manforge.models import YUKinematic3D
+from manforge.simulation.driver import StrainDriver
+from manforge.simulation.integrator import PythonIntegrator
+from manforge.simulation.types import FieldHistory, FieldType
+
+# ---------------------------------------------------------------------------
+# Standard YUKinematic3D parameters
+# ---------------------------------------------------------------------------
+
+PARAMS = dict(
+    E=206_000, nu=0.3, Y=360.0, C_1=2000.0, C_2=200.0,
+    B=435.0, Rsat=255.0, k=26.0, b=66.0, h=0.4, Ea=159_000, xi=61.0,
+)
+
+# ---------------------------------------------------------------------------
+# FD constants
+# ---------------------------------------------------------------------------
+
+FD_EPS        = 1e-5   # step for Jacobian FD (residual-based)
+FD_H          = 1e-5   # step for DDSDDE FD (stress_update-based)
+FD_RTOL       = 2e-2   # relative tolerance (large-increment scenarios; Stage 5 will tighten)
+FD_ATOL       = 1e-1   # absolute tolerance (scaled to stiffness ~1e5)
+FD_RTOL_JAC   = 1e-4   # relative tolerance for Jacobian tests
+FD_ATOL_JAC   = 1e-3   # absolute tolerance for Jacobian tests
+FD_RTOL_BAND  = 5e-3   # tighter tolerance for stagnation transition band
+
+# ---------------------------------------------------------------------------
+# Scenario builders (cumulative total-strain histories, shape (N, 6))
+# ---------------------------------------------------------------------------
+
+def uniaxial_plastic_step():
+    data = np.zeros((10, 6))
+    data[:, 0] = np.linspace(0.0, 4e-3, 10)
+    return data
+
+
+def pure_shear_step():
+    data = np.zeros((10, 6))
+    data[:, 3] = np.linspace(0.0, 4e-3, 10)
+    return data
+
+
+def load_reversal_step():
+    data = np.zeros((20, 6))
+    data[:10, 0] = np.linspace(0.0, 5e-3, 10)
+    data[10:, 0] = np.linspace(5e-3, -2e-3, 10)
+    return data
+
+
+def stagnation_active_step():
+    """Large cycle then small reversal to make stagnation surface active."""
+    large = np.zeros((20, 6))
+    large[:, 0] = np.linspace(0.0, 0.03, 20)
+    small = np.zeros((10, 6))
+    small[:, 0] = np.linspace(0.03, 0.02, 10)
+    return np.vstack([large, small])
+
+
+def stagnation_transition_band_history():
+    """Pure-shear ramp that crosses the stagnation boundary (g_stag changes sign).
+
+    At ~step 45 (gamma≈0.036) g_stag passes through 0, exercising the
+    smooth-heaviside derivative term in the chain-rule correction block.
+    """
+    data = np.zeros((100, 6))
+    data[:, 3] = np.linspace(0.0, 0.08, 100)
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Step-running helpers
+# ---------------------------------------------------------------------------
+
+def run_steps(model, integrator, strain_data):
+    """Run driver; return list of (result, stress_n, state_n, strain_inc) for each step."""
+    history = FieldHistory(type=FieldType.STRAIN, name="strain", data=strain_data)
+    driver = StrainDriver(integrator)
+    steps = list(driver.iter_run(history))
+    initial = model.initial_state()
+
+    out = []
+    for i, step in enumerate(steps):
+        prev = steps[i - 1] if i > 0 else None
+        state_n = prev.result.state if prev is not None else initial
+        stress_n = np.asarray(prev.result.stress, dtype=float) if prev is not None else np.zeros(6)
+        prev_strain = np.asarray(prev.strain, dtype=float) if prev is not None else np.zeros(6)
+        strain_inc = np.asarray(step.strain, dtype=float) - prev_strain
+        out.append((step.result, stress_n, state_n, strain_inc))
+    return out
+
+
+def get_converged_state(strain_history, integrator_cls=PythonIntegrator):
+    """Run driver; return (model, result, state_n) for plastic step with max dlambda."""
+    model = YUKinematic3D(**PARAMS)
+    integrator = integrator_cls(model)
+    history = FieldHistory(type=FieldType.STRAIN, name="strain", data=strain_history)
+    driver = StrainDriver(integrator)
+    steps = list(driver.iter_run(history))
+    assert steps, "No steps produced"
+
+    best_step = None
+    best_prev = None
+    best_dlambda = -1.0
+    initial = model.initial_state()
+    for i, step in enumerate(steps):
+        if step.result.is_plastic:
+            dl = float(step.result.dlambda)
+            if dl > best_dlambda:
+                best_dlambda = dl
+                best_step = step
+                best_prev = steps[i - 1] if i > 0 else None
+
+    if best_step is None:
+        return model, None, None
+
+    state_n = best_prev.result.state if best_prev is not None else initial
+    return model, best_step.result, state_n
+
+
+def pick_largest_dlambda(model, step_data, gstag_min=0.05):
+    """Select plastic step with max dlambda, preferring steps outside the transition band."""
+    def gstag(result, state_n):
+        beta = np.asarray(result.state["beta"])
+        q = np.asarray(state_n["q"])
+        return abs(float(model.vonmises_norm(beta - q)) - float(state_n["r"]))
+
+    best, best_dl = None, -1.0
+    for result, stress_n, state_n, strain_inc in step_data:
+        if result.is_plastic and gstag(result, state_n) > gstag_min:
+            dl = float(result.dlambda)
+            if dl > best_dl:
+                best_dl = dl
+                best = (result, stress_n, state_n, strain_inc)
+    if best is None:
+        for result, stress_n, state_n, strain_inc in step_data:
+            if result.is_plastic and float(result.dlambda) > best_dl:
+                best_dl = float(result.dlambda)
+                best = (result, stress_n, state_n, strain_inc)
+    return best
+
+
+def pick_min_gstag(model, step_data):
+    """Select plastic step with minimum |g_stag| — targets the stagnation transition band."""
+    best, best_abs = None, np.inf
+    for result, stress_n, state_n, strain_inc in step_data:
+        if not result.is_plastic:
+            continue
+        beta = np.asarray(result.state["beta"])
+        q = np.asarray(state_n["q"])
+        gstag = abs(float(model.vonmises_norm(beta - q)) - float(state_n["r"]))
+        if gstag < best_abs:
+            best_abs = gstag
+            best = (result, stress_n, state_n, strain_inc)
+    return best, best_abs
+
+
+# ---------------------------------------------------------------------------
+# FD kernels
+# ---------------------------------------------------------------------------
+
+def fd_ddsdde(integrator, strain_inc, stress_n, state_n, h=FD_H):
+    """Central finite-difference of dσ/dε via independent stress_update calls.
+
+    Works with any integrator (Python or Fortran) that implements stress_update.
+    """
+    ntens = len(strain_inc)
+    J = np.zeros((ntens, ntens))
+    for j in range(ntens):
+        e_j = np.zeros(ntens)
+        e_j[j] = 1.0
+        sp = np.asarray(integrator.stress_update(strain_inc + h * e_j, stress_n, state_n).stress, dtype=float)
+        sm = np.asarray(integrator.stress_update(strain_inc - h * e_j, stress_n, state_n).stress, dtype=float)
+        J[:, j] = (sp - sm) / (2.0 * h)
+    return J
+
+
+def fd_jacobian(model, state_new, state_n, dlambda, residual_fn, eps=FD_EPS):
+    """Central finite-difference of the NR Jacobian.
+
+    Parameters
+    ----------
+    model       : YUKinematic3D instance (used only for vonmises_norm / scalar params k, Rsat)
+    state_new   : converged state at step n+1
+    state_n     : state at step n (start of step)
+    dlambda     : converged plastic multiplier
+    residual_fn : callable (state_dict, dlambda_val) -> array(19)
+                  Use Python:  lambda sn, dl: np.array(model.calc_residual(sn, state_n, stress_trial, dl))
+                  Use Fortran: see test_fortran_vs_fd.py
+    eps         : central-difference step size
+
+    The dlambda column updates eps_eq and R consistently with the NR loop:
+      eps_eq = eps_eq_n + dlambda_perturbed
+      R      = R_n + g_flag * delta_R(dlambda_perturbed)
+    All other columns hold eps_eq/R at their converged values.
+    """
+    from manforge.utils.smooth import smooth_heaviside
+
+    x0 = np.hstack([
+        state_new["stress"],
+        [dlambda],
+        state_new["theta"],
+        state_new["beta"],
+    ])
+    n = len(x0)
+    J_fd = np.zeros((n, n))
+
+    g_xi_0   = np.array(state_new["beta"]) - np.array(state_n["q"])
+    g_flag_0 = float(smooth_heaviside(float(model.vonmises_norm(g_xi_0)) - float(state_n["r"])))
+    R_n_val  = float(state_n["R"])
+    eps_eq_n = float(state_n["eps_eq"])
+
+    def _residual(x):
+        sn           = dict(state_new)
+        sn["stress"] = x[0:6].copy()
+        sn["theta"]  = x[7:13].copy()
+        sn["beta"]   = x[13:19].copy()
+        dl_val       = float(x[6])
+        sn["eps_eq"] = eps_eq_n + dl_val
+        s            = 1.0 / (1.0 + model.k * dl_val)
+        delta_R      = s * (R_n_val + model.k * model.Rsat * dl_val) - R_n_val
+        sn["R"]      = R_n_val + g_flag_0 * delta_R
+        return np.array(residual_fn(sn, dl_val), dtype=float)
+
+    for j in range(n):
+        xp = x0.copy(); xp[j] += eps
+        xm = x0.copy(); xm[j] -= eps
+        J_fd[:, j] = (_residual(xp) - _residual(xm)) / (2.0 * eps)
+
+    return J_fd

--- a/tests/integration/models/test_yu_ddsdde_fd.py
+++ b/tests/integration/models/test_yu_ddsdde_fd.py
@@ -11,36 +11,22 @@ import numpy as np
 import pytest
 
 from manforge.models import YUKinematic3D
-from manforge.simulation.driver import StrainDriver
 from manforge.simulation.integrator import PythonAnalyticalIntegrator
-from manforge.simulation.types import FieldHistory, FieldType
-
-PARAMS = dict(
-    E=206_000, nu=0.3, Y=360.0, C_1=2000.0, C_2=200.0,
-    B=435.0, Rsat=255.0, k=26.0, b=66.0, h=0.4, Ea=159_000, xi=61.0,
+from tests.fixtures.yu_fd import (
+    PARAMS,
+    FD_RTOL,
+    FD_ATOL,
+    FD_RTOL_BAND,
+    fd_ddsdde,
+    run_steps,
+    pick_largest_dlambda,
+    pick_min_gstag,
+    uniaxial_plastic_step,
+    pure_shear_step,
+    load_reversal_step,
+    stagnation_active_step,
+    stagnation_transition_band_history,
 )
-
-FD_H         = 1e-5   # central-difference step size
-FD_RTOL      = 2e-2   # relative tolerance for large-increment scenarios (Stage 5 will tighten)
-FD_ATOL      = 1e-1   # absolute tolerance (scaled to stiffness magnitudes ~1e5)
-FD_RTOL_BAND = 5e-3   # tighter tolerance for stagnation transition band test
-
-
-def _fd_ddsdde(integrator, strain_inc, stress_n, state_n, h=FD_H):
-    """Central finite-difference of dσ/dε via independent stress_update calls.
-
-    Each perturbed call is independent (same stress_n, state_n base point),
-    so this gives the consistent tangent FD truth at the given step start.
-    """
-    ntens = len(strain_inc)
-    J = np.zeros((ntens, ntens))
-    for j in range(ntens):
-        e_j = np.zeros(ntens)
-        e_j[j] = 1.0
-        sp = np.asarray(integrator.stress_update(strain_inc + h * e_j, stress_n, state_n).stress, dtype=float)
-        sm = np.asarray(integrator.stress_update(strain_inc - h * e_j, stress_n, state_n).stress, dtype=float)
-        J[:, j] = (sp - sm) / (2.0 * h)
-    return J
 
 
 def _make_integrator():
@@ -48,130 +34,23 @@ def _make_integrator():
     return model, PythonAnalyticalIntegrator(model)
 
 
-def _run_steps(model, integrator, strain_data):
-    """Run driver; return list of (result, stress_n, state_n, strain_inc) for every step."""
-    history = FieldHistory(type=FieldType.STRAIN, name="strain", data=strain_data)
-    driver = StrainDriver(integrator)
-    steps = list(driver.iter_run(history))
-    initial = model.initial_state()
-
-    out = []
-    for i, step in enumerate(steps):
-        prev = steps[i - 1] if i > 0 else None
-        state_n = prev.result.state if prev is not None else initial
-        stress_n = np.asarray(prev.result.stress, dtype=float) if prev is not None else np.zeros(6)
-        prev_strain = np.asarray(prev.strain, dtype=float) if prev is not None else np.zeros(6)
-        strain_inc = np.asarray(step.strain, dtype=float) - prev_strain
-        out.append((step.result, stress_n, state_n, strain_inc))
-    return out
-
-
-def _pick_largest_dlambda(model, step_data, gstag_min=0.05):
-    """Select plastic step with maximum dlambda, outside the stagnation transition band.
-
-    Prefers steps where |g_stag| > gstag_min so that the smooth-heaviside
-    derivative term in the chain-rule correction is negligible (g_flag fully
-    saturated at 0 or 1).  Falls back to all plastic steps if none qualify.
-    """
-    def gstag(result, state_n):
-        beta = np.asarray(result.state["beta"])
-        q = np.asarray(state_n["q"])
-        return abs(float(model.vonmises_norm(beta - q)) - float(state_n["r"]))
-
-    best, best_dl = None, -1.0
-    for result, stress_n, state_n, strain_inc in step_data:
-        if result.is_plastic and gstag(result, state_n) > gstag_min:
-            dl = float(result.dlambda)
-            if dl > best_dl:
-                best_dl = dl
-                best = (result, stress_n, state_n, strain_inc)
-    if best is None:
-        # Fall back: any plastic step
-        for result, stress_n, state_n, strain_inc in step_data:
-            if result.is_plastic and float(result.dlambda) > best_dl:
-                best_dl = float(result.dlambda)
-                best = (result, stress_n, state_n, strain_inc)
-    return best
-
-
-def _pick_min_gstag(model, step_data):
-    """Select plastic step with minimum |g_stag| — targets the stagnation transition band."""
-    best, best_abs = None, np.inf
-    for result, stress_n, state_n, strain_inc in step_data:
-        if not result.is_plastic:
-            continue
-        beta = np.asarray(result.state["beta"])
-        q = np.asarray(state_n["q"])
-        gstag = abs(float(model.vonmises_norm(beta - q)) - float(state_n["r"]))
-        if gstag < best_abs:
-            best_abs = gstag
-            best = (result, stress_n, state_n, strain_inc)
-    return best, best_abs
-
-
-# ---------------------------------------------------------------------------
-# Scenario builders (cumulative total-strain histories)
-# ---------------------------------------------------------------------------
-
-def _uniaxial_plastic_step():
-    data = np.zeros((10, 6))
-    data[:, 0] = np.linspace(0.0, 4e-3, 10)
-    return data
-
-
-def _pure_shear_step():
-    data = np.zeros((10, 6))
-    data[:, 3] = np.linspace(0.0, 4e-3, 10)
-    return data
-
-
-def _load_reversal_step():
-    data = np.zeros((20, 6))
-    data[:10, 0] = np.linspace(0.0, 5e-3, 10)
-    data[10:, 0] = np.linspace(5e-3, -2e-3, 10)
-    return data
-
-
-def _stagnation_active_step():
-    large = np.zeros((20, 6))
-    large[:, 0] = np.linspace(0.0, 0.03, 20)
-    small = np.zeros((10, 6))
-    small[:, 0] = np.linspace(0.03, 0.02, 10)
-    return np.vstack([large, small])
-
-
-def _stagnation_transition_band_history():
-    """Pure-shear ramp that crosses the stagnation boundary (g_stag changes sign).
-
-    At ~step 45 (gamma≈0.036) g_stag passes through 0, exercising the
-    smooth-heaviside derivative term in the chain-rule correction block.
-    """
-    data = np.zeros((100, 6))
-    data[:, 3] = np.linspace(0.0, 0.08, 100)
-    return data
-
-
-# ---------------------------------------------------------------------------
-# Tests
-# ---------------------------------------------------------------------------
-
 @pytest.mark.parametrize("scenario,label", [
-    (_uniaxial_plastic_step,   "uniaxial"),
-    (_pure_shear_step,         "pure_shear"),
-    (_load_reversal_step,      "load_reversal"),
-    (_stagnation_active_step,  "stagnation_active"),
+    (uniaxial_plastic_step,   "uniaxial"),
+    (pure_shear_step,         "pure_shear"),
+    (load_reversal_step,      "load_reversal"),
+    (stagnation_active_step,  "stagnation_active"),
 ])
 def test_ddsdde_matches_fd(scenario, label):
     """result.ddsdde must match central-FD dσ/dε within tolerance."""
     model, integrator = _make_integrator()
-    step_data = _run_steps(model, integrator, scenario())
-    picked = _pick_largest_dlambda(model, step_data)
+    step_data = run_steps(model, integrator, scenario())
+    picked = pick_largest_dlambda(model, step_data)
     if picked is None:
         pytest.skip(f"Scenario '{label}' produced no plastic step")
 
     result, stress_n, state_n, strain_inc = picked
     D_an = np.array(result.ddsdde, dtype=float)
-    D_fd = _fd_ddsdde(integrator, strain_inc, stress_n, state_n)
+    D_fd = fd_ddsdde(integrator, strain_inc, stress_n, state_n)
 
     np.testing.assert_allclose(
         D_an, D_fd, rtol=FD_RTOL, atol=FD_ATOL,
@@ -187,14 +66,14 @@ def test_ddsdde_stagnation_transition_band():
     chain-rule correction term in calc_ddsdde is most significant.
     """
     model, integrator = _make_integrator()
-    step_data = _run_steps(model, integrator, _stagnation_transition_band_history())
-    picked, gstag = _pick_min_gstag(model, step_data)
+    step_data = run_steps(model, integrator, stagnation_transition_band_history())
+    picked, gstag = pick_min_gstag(model, step_data)
     if picked is None:
         pytest.skip("No plastic step found in stagnation transition band scenario")
 
     result, stress_n, state_n, strain_inc = picked
     D_an = np.array(result.ddsdde, dtype=float)
-    D_fd = _fd_ddsdde(integrator, strain_inc, stress_n, state_n)
+    D_fd = fd_ddsdde(integrator, strain_inc, stress_n, state_n)
 
     np.testing.assert_allclose(
         D_an, D_fd, rtol=FD_RTOL_BAND, atol=FD_ATOL,

--- a/tests/integration/models/test_yu_ddsdde_fd.py
+++ b/tests/integration/models/test_yu_ddsdde_fd.py
@@ -1,0 +1,202 @@
+"""Finite-difference check of the YUKinematic3D consistent tangent (DDSDDE).
+
+Compares result.ddsdde (from PythonAnalyticalIntegrator / calc_ddsdde) against
+a central finite-difference approximation of dσ/dε for several stress paths.
+
+The stagnation_transition_band test is the critical regression guard for the
+A1+A2 chain-rule coefficient fix in calc_ddsdde (Stage 2 of the convergence
+improvement plan).
+"""
+import numpy as np
+import pytest
+
+from manforge.models import YUKinematic3D
+from manforge.simulation.driver import StrainDriver
+from manforge.simulation.integrator import PythonAnalyticalIntegrator
+from manforge.simulation.types import FieldHistory, FieldType
+
+PARAMS = dict(
+    E=206_000, nu=0.3, Y=360.0, C_1=2000.0, C_2=200.0,
+    B=435.0, Rsat=255.0, k=26.0, b=66.0, h=0.4, Ea=159_000, xi=61.0,
+)
+
+FD_H         = 1e-5   # central-difference step size
+FD_RTOL      = 2e-2   # relative tolerance for large-increment scenarios (Stage 5 will tighten)
+FD_ATOL      = 1e-1   # absolute tolerance (scaled to stiffness magnitudes ~1e5)
+FD_RTOL_BAND = 5e-3   # tighter tolerance for stagnation transition band test
+
+
+def _fd_ddsdde(integrator, strain_inc, stress_n, state_n, h=FD_H):
+    """Central finite-difference of dσ/dε via independent stress_update calls.
+
+    Each perturbed call is independent (same stress_n, state_n base point),
+    so this gives the consistent tangent FD truth at the given step start.
+    """
+    ntens = len(strain_inc)
+    J = np.zeros((ntens, ntens))
+    for j in range(ntens):
+        e_j = np.zeros(ntens)
+        e_j[j] = 1.0
+        sp = np.asarray(integrator.stress_update(strain_inc + h * e_j, stress_n, state_n).stress, dtype=float)
+        sm = np.asarray(integrator.stress_update(strain_inc - h * e_j, stress_n, state_n).stress, dtype=float)
+        J[:, j] = (sp - sm) / (2.0 * h)
+    return J
+
+
+def _make_integrator():
+    model = YUKinematic3D(**PARAMS)
+    return model, PythonAnalyticalIntegrator(model)
+
+
+def _run_steps(model, integrator, strain_data):
+    """Run driver; return list of (result, stress_n, state_n, strain_inc) for every step."""
+    history = FieldHistory(type=FieldType.STRAIN, name="strain", data=strain_data)
+    driver = StrainDriver(integrator)
+    steps = list(driver.iter_run(history))
+    initial = model.initial_state()
+
+    out = []
+    for i, step in enumerate(steps):
+        prev = steps[i - 1] if i > 0 else None
+        state_n = prev.result.state if prev is not None else initial
+        stress_n = np.asarray(prev.result.stress, dtype=float) if prev is not None else np.zeros(6)
+        prev_strain = np.asarray(prev.strain, dtype=float) if prev is not None else np.zeros(6)
+        strain_inc = np.asarray(step.strain, dtype=float) - prev_strain
+        out.append((step.result, stress_n, state_n, strain_inc))
+    return out
+
+
+def _pick_largest_dlambda(model, step_data, gstag_min=0.05):
+    """Select plastic step with maximum dlambda, outside the stagnation transition band.
+
+    Prefers steps where |g_stag| > gstag_min so that the smooth-heaviside
+    derivative term in the chain-rule correction is negligible (g_flag fully
+    saturated at 0 or 1).  Falls back to all plastic steps if none qualify.
+    """
+    def gstag(result, state_n):
+        beta = np.asarray(result.state["beta"])
+        q = np.asarray(state_n["q"])
+        return abs(float(model.vonmises_norm(beta - q)) - float(state_n["r"]))
+
+    best, best_dl = None, -1.0
+    for result, stress_n, state_n, strain_inc in step_data:
+        if result.is_plastic and gstag(result, state_n) > gstag_min:
+            dl = float(result.dlambda)
+            if dl > best_dl:
+                best_dl = dl
+                best = (result, stress_n, state_n, strain_inc)
+    if best is None:
+        # Fall back: any plastic step
+        for result, stress_n, state_n, strain_inc in step_data:
+            if result.is_plastic and float(result.dlambda) > best_dl:
+                best_dl = float(result.dlambda)
+                best = (result, stress_n, state_n, strain_inc)
+    return best
+
+
+def _pick_min_gstag(model, step_data):
+    """Select plastic step with minimum |g_stag| — targets the stagnation transition band."""
+    best, best_abs = None, np.inf
+    for result, stress_n, state_n, strain_inc in step_data:
+        if not result.is_plastic:
+            continue
+        beta = np.asarray(result.state["beta"])
+        q = np.asarray(state_n["q"])
+        gstag = abs(float(model.vonmises_norm(beta - q)) - float(state_n["r"]))
+        if gstag < best_abs:
+            best_abs = gstag
+            best = (result, stress_n, state_n, strain_inc)
+    return best, best_abs
+
+
+# ---------------------------------------------------------------------------
+# Scenario builders (cumulative total-strain histories)
+# ---------------------------------------------------------------------------
+
+def _uniaxial_plastic_step():
+    data = np.zeros((10, 6))
+    data[:, 0] = np.linspace(0.0, 4e-3, 10)
+    return data
+
+
+def _pure_shear_step():
+    data = np.zeros((10, 6))
+    data[:, 3] = np.linspace(0.0, 4e-3, 10)
+    return data
+
+
+def _load_reversal_step():
+    data = np.zeros((20, 6))
+    data[:10, 0] = np.linspace(0.0, 5e-3, 10)
+    data[10:, 0] = np.linspace(5e-3, -2e-3, 10)
+    return data
+
+
+def _stagnation_active_step():
+    large = np.zeros((20, 6))
+    large[:, 0] = np.linspace(0.0, 0.03, 20)
+    small = np.zeros((10, 6))
+    small[:, 0] = np.linspace(0.03, 0.02, 10)
+    return np.vstack([large, small])
+
+
+def _stagnation_transition_band_history():
+    """Pure-shear ramp that crosses the stagnation boundary (g_stag changes sign).
+
+    At ~step 45 (gamma≈0.036) g_stag passes through 0, exercising the
+    smooth-heaviside derivative term in the chain-rule correction block.
+    """
+    data = np.zeros((100, 6))
+    data[:, 3] = np.linspace(0.0, 0.08, 100)
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("scenario,label", [
+    (_uniaxial_plastic_step,   "uniaxial"),
+    (_pure_shear_step,         "pure_shear"),
+    (_load_reversal_step,      "load_reversal"),
+    (_stagnation_active_step,  "stagnation_active"),
+])
+def test_ddsdde_matches_fd(scenario, label):
+    """result.ddsdde must match central-FD dσ/dε within tolerance."""
+    model, integrator = _make_integrator()
+    step_data = _run_steps(model, integrator, scenario())
+    picked = _pick_largest_dlambda(model, step_data)
+    if picked is None:
+        pytest.skip(f"Scenario '{label}' produced no plastic step")
+
+    result, stress_n, state_n, strain_inc = picked
+    D_an = np.array(result.ddsdde, dtype=float)
+    D_fd = _fd_ddsdde(integrator, strain_inc, stress_n, state_n)
+
+    np.testing.assert_allclose(
+        D_an, D_fd, rtol=FD_RTOL, atol=FD_ATOL,
+        err_msg=f"DDSDDE mismatch for scenario '{label}' (rtol={FD_RTOL}, atol={FD_ATOL})"
+    )
+
+
+def test_ddsdde_stagnation_transition_band():
+    """Chain-rule correction block (A1+A2 fixed) is verified at the stagnation boundary.
+
+    This test specifically targets the step where |g_stag| is minimal — the
+    transition band where smooth_heaviside has its largest derivative and the
+    chain-rule correction term in calc_ddsdde is most significant.
+    """
+    model, integrator = _make_integrator()
+    step_data = _run_steps(model, integrator, _stagnation_transition_band_history())
+    picked, gstag = _pick_min_gstag(model, step_data)
+    if picked is None:
+        pytest.skip("No plastic step found in stagnation transition band scenario")
+
+    result, stress_n, state_n, strain_inc = picked
+    D_an = np.array(result.ddsdde, dtype=float)
+    D_fd = _fd_ddsdde(integrator, strain_inc, stress_n, state_n)
+
+    np.testing.assert_allclose(
+        D_an, D_fd, rtol=FD_RTOL_BAND, atol=FD_ATOL,
+        err_msg=f"DDSDDE mismatch in transition band (|g_stag|={gstag:.4f})"
+    )

--- a/tests/integration/models/test_yu_jacobian_fd.py
+++ b/tests/integration/models/test_yu_jacobian_fd.py
@@ -11,9 +11,7 @@ obtain a converged state, then evaluate the Jacobian at that state.
 import numpy as np
 import pytest
 
-from manforge.models import YUKinematic3D
 from tests.fixtures.yu_fd import (
-    PARAMS,
     FD_RTOL_JAC as FD_RTOL,
     FD_ATOL_JAC as FD_ATOL,
     fd_jacobian,

--- a/tests/integration/models/test_yu_jacobian_fd.py
+++ b/tests/integration/models/test_yu_jacobian_fd.py
@@ -12,152 +12,42 @@ import numpy as np
 import pytest
 
 from manforge.models import YUKinematic3D
-from manforge.simulation.driver import StrainDriver
-from manforge.simulation.integrator import PythonIntegrator
-from manforge.simulation.types import FieldHistory, FieldType
-
-PARAMS = dict(
-    E=206_000, nu=0.3, Y=360.0, C_1=2000.0, C_2=200.0,
-    B=435.0, Rsat=255.0, k=26.0, b=66.0, h=0.4, Ea=159_000, xi=61.0,
+from tests.fixtures.yu_fd import (
+    PARAMS,
+    FD_RTOL_JAC as FD_RTOL,
+    FD_ATOL_JAC as FD_ATOL,
+    fd_jacobian,
+    get_converged_state,
+    uniaxial_plastic_step,
+    pure_shear_step,
+    load_reversal_step,
+    stagnation_active_step,
 )
-
-FD_EPS   = 1e-5   # central-difference step
-FD_RTOL  = 1e-4   # relative tolerance for analytical vs fd comparison
-FD_ATOL  = 1e-3   # absolute tolerance (some blocks may be near-zero)
-
-
-def _fd_jacobian(model, state_new, state_n, stress_trial, dlambda):
-    """Central finite-difference of the **total** derivative used in the NR loop.
-
-    When dlambda is perturbed, eps_eq and R are updated consistently with the
-    NR iteration (eps_eq = eps_eq_n + dlambda, R = R_n + g_flag*delta_R(dlambda)).
-    This gives the total derivative that calc_jacobian must match for 2nd-order
-    NR convergence.  For all other columns (sigma, theta, beta), R/eps_eq are
-    held at their converged iterate values.
-    """
-    from manforge.utils.smooth import smooth_heaviside
-
-    x0 = np.hstack([
-        state_new["stress"],
-        [dlambda],
-        state_new["theta"],
-        state_new["beta"],
-    ])
-    n = len(x0)
-    J_fd = np.zeros((n, n))
-
-    # g_flag evaluated at converged beta (dlambda perturbation holds beta fixed)
-    g_xi_0     = np.array(state_new["beta"]) - np.array(state_n["q"])
-    g_flag_0   = float(smooth_heaviside(float(model.vonmises_norm(g_xi_0)) - float(state_n["r"])))
-    R_n_val    = float(state_n["R"])
-    eps_eq_n   = float(state_n["eps_eq"])
-
-    def residual(x):
-        sn           = dict(state_new)
-        sn["stress"] = x[0:6].copy()
-        sn["theta"]  = x[7:13].copy()
-        sn["beta"]   = x[13:19].copy()
-        dl_val       = float(x[6])
-        # Update eps_eq and R consistently with the NR-loop update
-        sn["eps_eq"] = eps_eq_n + dl_val
-        s            = 1.0 / (1.0 + model.k * dl_val)
-        delta_R      = s * (R_n_val + model.k * model.Rsat * dl_val) - R_n_val
-        sn["R"]      = R_n_val + g_flag_0 * delta_R
-        return np.array(model.calc_residual(sn, state_n, stress_trial, dl_val), dtype=float)
-
-    for j in range(n):
-        xp = x0.copy(); xp[j] += FD_EPS
-        xm = x0.copy(); xm[j] -= FD_EPS
-        J_fd[:, j] = (residual(xp) - residual(xm)) / (2.0 * FD_EPS)
-
-    return J_fd
-
-
-def _get_converged_state(strain_history):
-    """Run the driver; return (model, result, state_n) for the plastic step with max dlambda."""
-    model      = YUKinematic3D(**PARAMS)
-    integrator = PythonIntegrator(model)
-    history    = FieldHistory(type=FieldType.STRAIN, name="strain", data=strain_history)
-    driver     = StrainDriver(integrator)
-    steps      = list(driver.iter_run(history))
-    assert steps, "No steps produced"
-
-    best_step    = None
-    best_prev    = None
-    best_dlambda = -1.0
-    initial      = model.initial_state()
-    for i, step in enumerate(steps):
-        if step.result.is_plastic:
-            dl = float(step.result.dlambda)
-            if dl > best_dlambda:
-                best_dlambda = dl
-                best_step    = step
-                best_prev    = steps[i - 1] if i > 0 else None
-
-    if best_step is None:
-        return model, None, None
-
-    state_n = best_prev.result.state if best_prev is not None else initial
-    return model, best_step.result, state_n
-
-
-# ---------------------------------------------------------------------------
-# Scenario builders
-# ---------------------------------------------------------------------------
-
-def _uniaxial_plastic_step():
-    n = 10
-    data = np.zeros((n, 6))
-    data[:, 0] = np.linspace(0.0, 4e-3, n)
-    return data
-
-
-def _pure_shear_step():
-    n = 10
-    data = np.zeros((n, 6))
-    data[:, 3] = np.linspace(0.0, 4e-3, n)  # gamma12 only
-    return data
-
-
-def _load_reversal_step():
-    n = 20
-    data = np.zeros((n, 6))
-    data[:10, 0] = np.linspace(0.0, 5e-3, 10)
-    data[10:, 0] = np.linspace(5e-3, -2e-3, 10)
-    return data
-
-
-def _stagnation_active_step():
-    """Large cycle then small reversal to make stagnation surface active."""
-    large = np.zeros((20, 6))
-    large[:, 0] = np.linspace(0.0, 0.03, 20)
-    small = np.zeros((10, 6))
-    small[:, 0] = np.linspace(0.03, 0.02, 10)
-    return np.vstack([large, small])
 
 
 @pytest.mark.parametrize("scenario,label", [
-    (_uniaxial_plastic_step,   "uniaxial"),
-    (_pure_shear_step,         "pure_shear"),
-    (_load_reversal_step,      "load_reversal"),
-    (_stagnation_active_step,  "stagnation_active"),
+    (uniaxial_plastic_step,   "uniaxial"),
+    (pure_shear_step,         "pure_shear"),
+    (load_reversal_step,      "load_reversal"),
+    (stagnation_active_step,  "stagnation_active"),
 ])
 def test_analytical_jacobian_matches_fd(scenario, label):
     """Analytical calc_jacobian must match central-FD approximation within tolerance."""
-    history = scenario()
-    model, result, state_n = _get_converged_state(history)
+    model, result, state_n = get_converged_state(scenario())
 
     if result is None or not result.is_plastic:
         pytest.skip(f"Scenario '{label}' did not yield a plastic step")
 
     rm           = result.return_mapping
-    stress_new   = rm.stress
     state_new    = rm.state
     dlambda      = float(rm.dlambda)
     stress_trial = result.stress_trial
 
+    def python_residual_fn(sn, dl):
+        return model.calc_residual(sn, state_n, stress_trial, dl)
+
     J_analytical = model.calc_jacobian(state_new, state_n, stress_trial, dlambda)
-    J_fd         = _fd_jacobian(model, state_new, state_n, stress_trial, dlambda)
+    J_fd         = fd_jacobian(model, state_new, state_n, dlambda, python_residual_fn)
 
     np.testing.assert_allclose(
         J_analytical, J_fd,


### PR DESCRIPTION
## Summary

YUKinematic3D を ABAQUS 大規模FEモデルで使用した際の収束悪化を 5 ステージで修正・検証。

- **fix**: `calc_ddsdde` の chain-rule 補正ブロックに 2 つの係数バグ (A1+A2) を修正
  - A1: `smooth_heaviside` 微分の係数 `25.0 → 12.5` (Python + Fortran)
  - A2: `da_dbeta` に欠落していた `1.5*` ファクタを追加 (Python + Fortran)
  - 修正効果: pure_shear 遷移帯での FD 乖離 `0.041 → 0.0025` (16×改善)
- **test**: FD ground-truth による consistent tangent 検証テスト群を新設
- **test**: Fortran 解析解 vs Python FD の直接検証 (共有バグ取り逃がし防止)
- **test**: 大変形・多サイクル収束ストレステスト + 容疑2 (mu NR / umat write-back) 切り分け
- **test**: tolerance を実測値ベースで厳格化 (Stage 5)

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `src/manforge/models/yu_kinematic.py` | A1+A2 係数修正 |
| `fortran/yu_kinematic_3d.f90` | 同上 (Fortran側) |
| `tests/fixtures/yu_fd.py` | FD ヘルパ共有モジュール (新規) |
| `tests/integration/models/test_yu_ddsdde_fd.py` | ddsdde vs FD 検証テスト (新規) |
| `tests/integration/models/test_yu_jacobian_fd.py` | fixtures モジュールへ移行 (簡略化) |
| `tests/benchmarks/yu_kinematic/test_fortran_vs_fd.py` | Fortran 解析 vs FD 検証 (新規) |
| `tests/benchmarks/yu_kinematic/test_convergence_stress.py` | 収束ストレステスト (新規) |
| `tests/benchmarks/yu_kinematic/test_numerical_vs_fortran.py` | tolerance 厳格化 + 容疑2テスト追加 |
| `tests/benchmarks/yu_kinematic/test_analytical_vs_numerical.py` | tolerance 厳格化 |
| `tests/benchmarks/yu_kinematic/_diagnose_ddsdde_fd.py` | A/B 切り分け診断 (非収集) |
| `tests/benchmarks/yu_kinematic/_diagnose_ddsdde_fortran.py` | 同上 Fortran版 |

## Test plan

- [x] `make test-all` — 820 passed, 2 skipped
- [x] `make test-benchmarks-fortran` — Fortran 比較テスト全 PASS
- [x] `uv run pytest tests/integration/models/test_yu_ddsdde_fd.py -v` — 5件 PASS
- [x] `uv run pytest tests/benchmarks/yu_kinematic/test_convergence_stress.py -m slow -v` — 4件 PASS
- [x] 容疑2(b) 無罪確定 (Python==Fortran mu newton 7件 PASS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)